### PR TITLE
Simplify method types

### DIFF
--- a/src/best_practices/extensions.rs
+++ b/src/best_practices/extensions.rs
@@ -22,7 +22,7 @@ pub struct UseStandardFileExtensions {}
 
 impl Rule for UseStandardFileExtensions {
     fn method(&self) -> Method {
-        Method::Path(Box::new(use_standard_file_extensions))
+        Method::Path(use_standard_file_extensions)
     }
 
     fn explain(&self) -> &str {

--- a/src/best_practices/implicit_none.rs
+++ b/src/best_practices/implicit_none.rs
@@ -41,7 +41,7 @@ pub struct UseImplicitNoneModulesAndPrograms {}
 
 impl Rule for UseImplicitNoneModulesAndPrograms {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(use_implicit_none_modules_and_programs))
+        Method::Tree(use_implicit_none_modules_and_programs)
     }
 
     fn explain(&self) -> &str {
@@ -86,7 +86,7 @@ pub struct UseImplicitNoneInterfaces {}
 
 impl Rule for UseImplicitNoneInterfaces {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(use_implicit_none_interfaces))
+        Method::Tree(use_implicit_none_interfaces)
     }
 
     fn explain(&self) -> &str {
@@ -132,7 +132,7 @@ pub struct AvoidSuperfluousImplicitNone {}
 
 impl Rule for AvoidSuperfluousImplicitNone {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(avoid_superfluous_implicit_none))
+        Method::Tree(avoid_superfluous_implicit_none)
     }
 
     fn explain(&self) -> &str {

--- a/src/best_practices/kinds.rs
+++ b/src/best_practices/kinds.rs
@@ -83,7 +83,7 @@ pub struct AvoidNumberLiteralKinds {}
 
 impl Rule for AvoidNumberLiteralKinds {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(avoid_number_literal_kinds))
+        Method::Tree(avoid_number_literal_kinds)
     }
 
     fn explain(&self) -> &str {
@@ -183,7 +183,7 @@ pub struct AvoidNonStandardByteSpecifier {}
 
 impl Rule for AvoidNonStandardByteSpecifier {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(avoid_non_standard_byte_specifier))
+        Method::Tree(avoid_non_standard_byte_specifier)
     }
 
     fn explain(&self) -> &str {
@@ -250,7 +250,7 @@ pub struct AvoidDoublePrecision {}
 
 impl Rule for AvoidDoublePrecision {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(avoid_double_precision))
+        Method::Tree(avoid_double_precision)
     }
 
     fn explain(&self) -> &str {
@@ -310,7 +310,7 @@ fn use_floating_point_suffixes(root: &Node, src: &str) -> Vec<Violation> {
 
 impl Rule for UseFloatingPointSuffixes {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(use_floating_point_suffixes))
+        Method::Tree(use_floating_point_suffixes)
     }
 
     fn explain(&self) -> &str {
@@ -369,7 +369,7 @@ pub struct AvoidNumberedKindSuffixes {}
 
 impl Rule for AvoidNumberedKindSuffixes {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(avoid_numbered_kind_suffixes))
+        Method::Tree(avoid_numbered_kind_suffixes)
     }
 
     fn explain(&self) -> &str {

--- a/src/best_practices/modules_and_programs.rs
+++ b/src/best_practices/modules_and_programs.rs
@@ -29,7 +29,7 @@ pub struct UseModulesAndPrograms {}
 
 impl Rule for UseModulesAndPrograms {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(use_modules_and_programs))
+        Method::Tree(use_modules_and_programs)
     }
 
     fn explain(&self) -> &str {
@@ -71,7 +71,7 @@ pub struct UseOnlyClause {}
 
 impl Rule for UseOnlyClause {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(use_only_clause))
+        Method::Tree(use_only_clause)
     }
 
     fn explain(&self) -> &str {

--- a/src/code_errors/syntax_errors.rs
+++ b/src/code_errors/syntax_errors.rs
@@ -3,7 +3,7 @@ use tree_sitter::Node;
 
 /// Rules that check for syntax errors.
 
-fn find_syntax_errors(node: &Node) -> Vec<Violation> {
+fn find_syntax_errors(node: &Node, _src: &str) -> Vec<Violation> {
     // TODO There should be a way to achieve this just using iterators, without
     //      returning intermediates.
     let mut violations = Vec::new();
@@ -13,7 +13,7 @@ fn find_syntax_errors(node: &Node) -> Vec<Violation> {
         if child.is_error() {
             violations.push(Violation::from_node("syntax error", &child));
         }
-        violations.extend(find_syntax_errors(&child));
+        violations.extend(find_syntax_errors(&child, _src));
     }
     violations
 }
@@ -22,7 +22,7 @@ pub struct SyntaxErrors {}
 
 impl Rule for SyntaxErrors {
     fn method(&self) -> Method {
-        Method::Tree(Box::new(|node, _| find_syntax_errors(node)))
+        Method::Tree(find_syntax_errors)
     }
 
     fn explain(&self) -> &str {

--- a/src/code_style/whitespace.rs
+++ b/src/code_style/whitespace.rs
@@ -1,31 +1,23 @@
 use crate::core::{Method, Rule, Violation};
+use crate::settings::Settings;
 use crate::violation;
-use regex::Regex;
 /// Defines rules that enforce widely accepted whitespace rules.
 
-pub struct AvoidTrailingWhitespace {
-    re: Regex,
-}
+pub struct AvoidTrailingWhitespace {}
 
-impl AvoidTrailingWhitespace {
-    pub fn new() -> anyhow::Result<Self> {
-        Ok(Self {
-            re: Regex::new(r"[ \t]+$")?,
-        })
-    }
-
-    fn rule(&self, number: usize, line: &str) -> Option<Violation> {
-        if self.re.is_match(line) {
-            Some(violation!("trailing whitespace", number))
-        } else {
-            None
+fn avoid_trailing_whitespace(source: &str, _: &Settings) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    for (idx, line) in source.split('\n').enumerate() {
+        if line.ends_with(&[' ', '\t']) {
+            violations.push(violation!("trailing whitespace", idx + 1));
         }
     }
+    violations
 }
 
 impl Rule for AvoidTrailingWhitespace {
     fn method(&self) -> Method {
-        Method::Line(Box::new(move |num, line| self.rule(num, line)))
+        Method::Text(avoid_trailing_whitespace)
     }
 
     fn explain(&self) -> &str {

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,3 +1,4 @@
+use crate::settings::Settings;
 use anyhow::Context;
 use colored::Colorize;
 use regex::Regex;
@@ -149,15 +150,13 @@ macro_rules! violation {
 /// some by reading a full file, and others by analysing the concrete syntax tree. All
 /// rules must be associated with a `Method` via the `Rule` trait.
 #[allow(dead_code, clippy::type_complexity)]
-pub enum Method<'a> {
+pub enum Method {
     /// Methods that work on just the path name of the file.
-    Path(Box<dyn Fn(&Path) -> Option<Violation> + 'a>),
+    Path(fn(&Path) -> Option<Violation>),
     /// Methods that analyse the syntax tree.
-    Tree(Box<dyn Fn(&tree_sitter::Node, &str) -> Vec<Violation> + 'a>),
-    /// Methods that analyse individual lines of code, using regex or otherwise.
-    Line(Box<dyn Fn(usize, &str) -> Option<Violation> + 'a>),
-    /// Methods that analyse multiple lines of code.
-    MultiLine(Box<dyn Fn(&str) -> Vec<Violation> + 'a>),
+    Tree(fn(&tree_sitter::Node, &str) -> Vec<Violation>),
+    /// Methods that analyse lines of code directly, using regex or otherwise.
+    Text(fn(&str, &Settings) -> Vec<Violation>),
 }
 
 // Rule trait

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1,6 +1,5 @@
 use crate::cli::ExplainArgs;
 use crate::rules::{full_ruleset, rulemap, RuleSet};
-use crate::settings::Settings;
 use colored::Colorize;
 use textwrap::dedent;
 
@@ -17,9 +16,8 @@ fn get_ruleset(args: &ExplainArgs) -> RuleSet {
 
 /// Check all files, report issues found, and return error code.
 pub fn explain(args: ExplainArgs) -> i32 {
-    let settings = Settings { line_length: 100 };
     let ruleset = get_ruleset(&args);
-    match rulemap(&ruleset, &settings) {
+    match rulemap(&ruleset) {
         Ok(rules) => {
             let mut outputs = Vec::new();
             for (code, rule) in &rules {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -2,7 +2,6 @@ use crate::best_practices;
 use crate::code_errors;
 use crate::code_style;
 use crate::core::{Category, Code, Rule};
-use crate::settings::Settings;
 use std::collections::{HashMap, HashSet};
 /// A collection of all rules, and utilities to select a subset at runtime.
 
@@ -11,7 +10,7 @@ pub type RuleSet = HashSet<String>;
 pub type RuleMap = HashMap<String, RuleBox>;
 
 /// Create a new `Rule` given a rule code, expressed as a string.
-pub fn build_rule(code_str: &str, settings: &Settings) -> anyhow::Result<RuleBox> {
+pub fn build_rule(code_str: &str) -> anyhow::Result<RuleBox> {
     let code = Code::from(code_str)?;
     match code {
         Code {
@@ -67,11 +66,11 @@ pub fn build_rule(code_str: &str, settings: &Settings) -> anyhow::Result<RuleBox
         Code {
             category: Category::CodeStyle,
             number: 1,
-        } => Ok(Box::new(code_style::AvoidTrailingWhitespace::new()?)),
+        } => Ok(Box::new(code_style::AvoidTrailingWhitespace {})),
         Code {
             category: Category::CodeStyle,
             number: 10,
-        } => Ok(Box::new(code_style::EnforceMaxLineLength::new(settings)?)),
+        } => Ok(Box::new(code_style::EnforceMaxLineLength {})),
         _ => {
             anyhow::bail!("Unknown rule code {}", code_str)
         }
@@ -94,10 +93,10 @@ pub fn default_ruleset() -> RuleSet {
     full_ruleset()
 }
 
-pub fn rulemap(set: &RuleSet, settings: &Settings) -> anyhow::Result<RuleMap> {
+pub fn rulemap(set: &RuleSet) -> anyhow::Result<RuleMap> {
     let mut rules = RuleMap::new();
     for code in set {
-        let rule = build_rule(code, settings)?;
+        let rule = build_rule(code)?;
         rules.insert(code.to_string(), rule);
     }
     Ok(rules)


### PR DESCRIPTION
Method structs no longer contain data.
Combined 'Line' and 'Multiline' types into the single 'Text'.