### PR TITLE
Use lazy-regex crate instead of plain regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
  "clap",
  "colored",
  "itertools",
- "regex",
+ "lazy-regex",
  "textwrap",
  "tree-sitter",
  "tree-sitter-fortran",
@@ -174,6 +174,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e1d8b05d672c53cb9c7b920bbba8783845ae4f0b076e02a3db1d02c81b4163"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +207,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.79"
 clap = { version = "4.4.16", features = ["derive"] }
 colored = "2.1.0"
 itertools = "0.12.0"
-regex = "1.10.2"
+lazy-regex = "3.3.0"
 textwrap = "0.16.0"
 tree-sitter = "~0.22.6"
 tree-sitter-fortran = "0.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod settings;
 mod test_utils;
 use anyhow::Context;
 use colored::Colorize;
-use regex::Regex;
+use lazy_regex::regex_captures;
 use settings::Settings;
 use std::cmp::Ordering;
 use std::fmt;
@@ -74,12 +74,8 @@ impl Code {
     }
 
     pub fn from(code_str: &str) -> anyhow::Result<Self> {
-        let re = Regex::new(r"^([A-Z]+)(\d{3})$")?;
-        let captures = re
-            .captures(code_str)
+        let (_, category_str, number_str) = regex_captures!(r"^([A-Z]+)([0-9]{3})$", code_str)
             .context(format!("{} is not a valid error code.", code_str))?;
-        let category_str = captures.get(1).map_or("", |x| x.as_str());
-        let number_str = captures.get(2).map_or("", |x| x.as_str());
         let category = Category::from(category_str)?;
         let number = number_str.parse::<usize>()?;
         Ok(Code::new(category, number))

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -1,23 +1,20 @@
 use crate::settings::Settings;
 use crate::violation;
 use crate::{Method, Rule, Violation};
-use regex::Regex;
+use lazy_regex::regex_is_match;
 /// Defines rules that govern line length.
 
 pub struct LineTooLong {}
 
 fn line_too_long(source: &str, settings: &Settings) -> Vec<Violation> {
     let mut violations = Vec::new();
-
-    // Are we ending on a string or comment? If so, we'll allow it through, as
-    // it may contain something like a long URL that cannot be reasonably split
-    // across multiple lines.
-    let re = Regex::new(r#"(["']\w*&?$)|(!.*$)|(^\w*&)"#).unwrap();
-
     for (idx, line) in source.split('\n').enumerate() {
         let len = line.len();
         if len > settings.line_length {
-            if re.is_match(line) {
+            // Are we ending on a string or comment? If so, we'll allow it through, as it may
+            // contain something like a long URL that cannot be reasonably split across multiple
+            // lines.
+            if regex_is_match!(r#"(["']\w*&?$)|(!.*$)|(^\w*&)"#, line) {
                 continue;
             }
             let msg = format!(

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -1,5 +1,5 @@
 use crate::{Method, Rule, Violation};
-use regex::Regex;
+use lazy_regex::regex_is_match;
 use tree_sitter::{Node, Query};
 /// Defines rules that discourage the use of raw number literals as kinds, as this can result in
 /// non-portable code.
@@ -139,7 +139,6 @@ fn literal_kind_suffix(root: &Node, src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     // Given a number literal, match anything suffixed with plain number.
     // TODO Match either int or real, change error message accordingly
-    let re = Regex::new(r"_\d+$").unwrap();
 
     let query_txt = "(number_literal) @num";
     let query = Query::new(&tree_sitter_fortran::language(), query_txt).unwrap();
@@ -149,7 +148,7 @@ fn literal_kind_suffix(root: &Node, src: &str) -> Vec<Violation> {
             let txt = capture.node.utf8_text(src.as_bytes());
             match txt {
                 Ok(x) => {
-                    if re.is_match(x) {
+                    if regex_is_match!(r"_\d+$", x) {
                         let msg = format!(
                             "Instead of number literal suffix in {}, use parameter suffix \
                             from 'iso_fortran_env'",


### PR DESCRIPTION
Currently, the tree-sitter based rules start at the root node of a file and scan the whole tree to find any matches. They then sometimes use regex to inspect what they find further. Any regular expressions used are therefore compiled once per file.

Inverting the order of operations as suggested by https://github.com/PlasmaFAIR/fortitude/issues/26 would mean having to compile a regular expression at each node, which would be terrible for performance.

This PR pre-emptively solves this problem by replacing all instances of the plain `Regex` crate with `lazy-regex`, which provides similar capabilities but compiles only once per run.