### PR TITLE
Remove tree-sitter queries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod check;
 pub mod cli;
 pub mod explain;
+mod parsing;
 mod rules;
 mod settings;
 mod test_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,10 +206,10 @@ impl Diagnostic {
 
     fn orderable(&self) -> (&Path, usize, usize, &str) {
         match self.violation.position() {
-            ViolationPosition::None => (&self.path.as_path(), 0, 0, &self.code.as_str()),
-            ViolationPosition::Line(line) => (&self.path.as_path(), line, 0, &self.code.as_str()),
+            ViolationPosition::None => (self.path.as_path(), 0, 0, self.code.as_str()),
+            ViolationPosition::Line(line) => (self.path.as_path(), line, 0, self.code.as_str()),
             ViolationPosition::LineCol((line, col)) => {
-                (&self.path.as_path(), line, col, &self.code.as_str())
+                (self.path.as_path(), line, col, self.code.as_str())
             }
         }
     }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,0 +1,32 @@
+use tree_sitter::Node;
+/// Utilities to simplify parsing tree-sitter structures.
+
+/// Convert a node to text, collapsing any raised errors to None.
+pub fn to_text<'a>(node: &'a Node<'a>, src: &'a str) -> Option<&'a str> {
+    let result = node.utf8_text(src.as_bytes()).ok()?;
+    Some(result)
+}
+
+/// Strip line breaks from a string of Fortran code.
+pub fn strip_line_breaks(src: &str) -> String {
+    src.replace("&", "").replace("\n", " ")
+}
+
+/// Given a variable declaration or function statement, return its type if it's an intrinsic type,
+/// or None otherwise.
+pub fn intrinsic_type(node: &Node) -> Option<String> {
+    // TODO This is copied from literal kinds, need to make a parsing utils file
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "intrinsic_type" {
+            let grandchild = child.child(0)?;
+            return Some(grandchild.kind().to_string());
+        }
+    }
+    None
+}
+
+/// Returns true if the type passed to it is number-like.
+pub fn dtype_is_number(dtype: &str) -> bool {
+    matches!(dtype, "integer" | "real" | "logical" | "complex")
+}

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,7 +1,14 @@
 use tree_sitter::Node;
 /// Utilities to simplify parsing tree-sitter structures.
 
-/// Convert a node to text, collapsing any raised errors to None.
+/// Get the first child with a given name. Returns None if not found.
+pub fn child_with_name<'a>(node: &'a Node, name: &'a str) -> Option<Node<'a>> {
+    let mut cursor = node.walk();
+    let result = node.named_children(&mut cursor).find(|x| x.kind() == name);
+    result
+}
+
+// Convert a node to text, collapsing any raised errors to None.
 pub fn to_text<'a>(node: &'a Node<'a>, src: &'a str) -> Option<&'a str> {
     let result = node.utf8_text(src.as_bytes()).ok()?;
     Some(result)
@@ -15,7 +22,6 @@ pub fn strip_line_breaks(src: &str) -> String {
 /// Given a variable declaration or function statement, return its type if it's an intrinsic type,
 /// or None otherwise.
 pub fn intrinsic_type(node: &Node) -> Option<String> {
-    // TODO This is copied from literal kinds, need to make a parsing utils file
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind() == "intrinsic_type" {

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -27,6 +27,10 @@ pub fn intrinsic_type(node: &Node) -> Option<String> {
 }
 
 /// Returns true if the type passed to it is number-like.
+/// Deliberately does not include 'double precision' or 'double complex'.
 pub fn dtype_is_number(dtype: &str) -> bool {
-    matches!(dtype, "integer" | "real" | "logical" | "complex")
+    matches!(
+        dtype.to_lowercase().as_str(),
+        "integer" | "real" | "logical" | "complex"
+    )
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -22,12 +22,9 @@ pub fn strip_line_breaks(src: &str) -> String {
 /// Given a variable declaration or function statement, return its type if it's an intrinsic type,
 /// or None otherwise.
 pub fn intrinsic_type(node: &Node) -> Option<String> {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "intrinsic_type" {
-            let grandchild = child.child(0)?;
-            return Some(grandchild.kind().to_string());
-        }
+    if let Some(child) = child_with_name(node, "intrinsic_type") {
+        let grandchild = child.child(0)?;
+        return Some(grandchild.kind().to_string());
     }
     None
 }

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -4,12 +4,9 @@ use tree_sitter::Node;
 /// Rules that check for syntax errors.
 
 fn syntax_error(node: &Node, _src: &str) -> Vec<Violation> {
-    // TODO There should be a way to achieve this just using iterators, without
-    //      returning intermediates.
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    let children = node.children(&mut cursor);
-    for child in children {
+    for child in node.children(&mut cursor) {
         if child.is_error() {
             violations.push(Violation::from_node("syntax error", &child));
         }

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -6,7 +6,7 @@ use tree_sitter::Node;
 fn syntax_error(node: &Node, _src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         if child.is_error() {
             violations.push(Violation::from_node("syntax error", &child));
         }

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -18,7 +18,7 @@ fn function_is_at_top_level(node: &Node, _src: &str) -> Option<Violation> {
 fn external_function(node: &Node, _src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         let kind = child.kind();
         if kind == "function" || kind == "subroutine" {
             if let Some(x) = function_is_at_top_level(&child, _src) {

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -1,23 +1,31 @@
 use crate::{Method, Rule, Violation};
-use tree_sitter::{Node, Query};
+use tree_sitter::Node;
 
 /// Defines rules that check whether functions and subroutines are defined within modules (or one
 /// of a few acceptable alternatives).
 
-fn external_fucntion(root: &Node, src: &str) -> Vec<Violation> {
+fn function_is_at_top_level(node: &Node, _src: &str) -> Option<Violation> {
+    if node.parent()?.kind() == "translation_unit" {
+        let msg = format!(
+            "{} not contained within (sub)module or program",
+            node.kind()
+        );
+        return Some(Violation::from_node(msg, node));
+    }
+    None
+}
+
+fn external_function(node: &Node, _src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
-    let query_txt = "(translation_unit [(function) @func (subroutine) @sub])";
-    let query = Query::new(&tree_sitter_fortran::language(), query_txt).unwrap();
-    let mut cursor = tree_sitter::QueryCursor::new();
-    for match_ in cursor.matches(&query, *root, src.as_bytes()) {
-        for capture in match_.captures {
-            let node = capture.node;
-            let msg = format!(
-                "{} not contained within (sub)module or program",
-                node.kind()
-            );
-            violations.push(Violation::from_node(&msg, &node));
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        if kind == "function" || kind == "subroutine" {
+            if let Some(x) = function_is_at_top_level(&child, _src) {
+                violations.push(x);
+            }
         }
+        violations.extend(external_function(&child, _src));
     }
     violations
 }
@@ -26,7 +34,7 @@ pub struct ExternalFunction {}
 
 impl Rule for ExternalFunction {
     fn method(&self) -> Method {
-        Method::Tree(external_fucntion)
+        Method::Tree(external_function)
     }
 
     fn explain(&self) -> &str {
@@ -67,7 +75,7 @@ mod tests {
                 violation!(&msg, *line, *col)
             })
             .collect();
-        test_tree_method(external_fucntion, source, Some(expected_violations));
+        test_tree_method(external_function, source, Some(expected_violations));
     }
 
     #[test]
@@ -87,6 +95,6 @@ mod tests {
                 end subroutine
             end module
             ";
-        test_tree_method(external_fucntion, source, None);
+        test_tree_method(external_function, source, None);
     }
 }

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -17,7 +17,7 @@ fn use_missing_only_clause(node: &Node) -> Option<Violation> {
 fn use_all(node: &Node, _src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         if child.kind() == "use_statement" {
             if let Some(x) = use_missing_only_clause(&child) {
                 violations.push(x);

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -1,3 +1,4 @@
+use crate::parsing::child_with_name;
 use crate::{Method, Rule, Violation};
 use tree_sitter::Node;
 
@@ -6,11 +7,7 @@ use tree_sitter::Node;
 // TODO Check that 'used' entity is actually used somewhere
 
 fn use_missing_only_clause(node: &Node) -> Option<Violation> {
-    let mut cursor = node.walk();
-    if !node
-        .children(&mut cursor)
-        .any(|x| x.kind() == "included_items")
-    {
+    if child_with_name(node, "included_items").is_none() {
         let msg = "'use' statement missing 'only' clause";
         return Some(Violation::from_node(msg, node));
     }

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -9,7 +9,7 @@ fn trailing_whitespace(source: &str, _: &Settings) -> Vec<Violation> {
     let mut violations = Vec::new();
     for (idx, line) in source.split('\n').enumerate() {
         if line.ends_with(&[' ', '\t']) {
-            violations.push(violation!("Trailing whitespace", idx + 1));
+            violations.push(violation!("trailing whitespace", idx + 1));
         }
     }
     violations

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -28,7 +28,7 @@ fn implicit_none_not_found(node: &Node) -> Option<Violation> {
 fn implicit_typing(node: &Node, _src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         match child.kind() {
             "module" | "submodule" | "program" => {
                 // For some reason a second 'module' node is found at the end
@@ -74,7 +74,7 @@ fn interface_implicit_none_not_found(node: &Node) -> Option<Violation> {
 fn interface_implicit_typing(node: &Node, _src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         let kind = child.kind();
         if kind == "function" || kind == "subroutine" {
             if let Some(x) = interface_implicit_none_not_found(&child) {
@@ -130,7 +130,7 @@ fn implicit_none_not_needed(node: &Node) -> Option<Violation> {
 fn superfluous_implicit_none(node: &Node, _src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         let kind = child.kind();
         if kind == "implicit_statement" {
             if let Some(x) = implicit_none_not_needed(&child) {

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -1,3 +1,4 @@
+use crate::parsing::child_with_name;
 use crate::{Method, Rule, Violation};
 use tree_sitter::Node;
 /// Defines rules that raise errors if implicit typing is in use.
@@ -10,11 +11,8 @@ fn implicit_statement_is_none(node: &Node) -> bool {
 }
 
 fn child_is_implicit_none(node: &Node) -> bool {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "implicit_statement" {
-            return implicit_statement_is_none(&child);
-        }
+    if let Some(child) = child_with_name(node, "implicit_statement") {
+        return implicit_statement_is_none(&child);
     }
     false
 }

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -32,7 +32,7 @@ fn variable_has_literal_kind(node: &Node, src: &str) -> Option<Violation> {
 fn literal_kind(node: &Node, src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         let kind = child.kind();
         if kind == "variable_declaration" || kind == "function_statement" {
             if let Some(x) = variable_has_literal_kind(&child, src) {
@@ -122,7 +122,7 @@ fn literal_has_literal_suffix(node: &Node, src: &str) -> Option<Violation> {
 fn literal_kind_suffix(node: &Node, src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         if child.kind() == "number_literal" {
             if let Some(x) = literal_has_literal_suffix(&child, src) {
                 violations.push(x)

--- a/src/rules/typing/real_precision.rs
+++ b/src/rules/typing/real_precision.rs
@@ -30,7 +30,7 @@ fn type_is_double_precision(node: &Node, src: &str) -> Option<Violation> {
 fn double_precision(node: &Node, src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         if child.kind() == "intrinsic_type" {
             if let Some(x) = type_is_double_precision(&child, src) {
                 violations.push(x)
@@ -81,7 +81,7 @@ fn real_has_no_suffix(node: &Node, src: &str) -> Option<Violation> {
 fn no_real_suffix(node: &Node, src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         if child.kind() == "number_literal" {
             if let Some(x) = real_has_no_suffix(&child, src) {
                 violations.push(x)

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -35,7 +35,7 @@ fn variable_has_star_kind(node: &Node, src: &str) -> Option<Violation> {
 fn star_kind(node: &Node, src: &str) -> Vec<Violation> {
     let mut violations = Vec::new();
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
+    for child in node.named_children(&mut cursor) {
         let kind = child.kind();
         if kind == "variable_declaration" || kind == "function_statement" {
             if let Some(x) = variable_has_star_kind(&child, src) {

--- a/test.f90
+++ b/test.f90
@@ -98,6 +98,7 @@ end subroutine
 
 ! Should trigger for missing implicit none
 module implicit_module
+  implicit integer(A)
   parameter(N = 1)
 end module
 

--- a/test.f90
+++ b/test.f90
@@ -29,6 +29,9 @@ module my_module
   real(dp), parameter :: pi_32 = 3.14159265358979
   real(dp), parameter :: pi_short = 3.1415
 
+  ! Should raise syntax error
+  real(dp), parameter :: mistake = 2e
+
   ! Should not raise error for maximum line length
   character(*), parameter :: long_string = "https://verylongurl.com/page/another_page/yet_another_page/wow"
 

--- a/test.f90
+++ b/test.f90
@@ -4,6 +4,11 @@ integer function double(x)
   double = 2 * x
 end function
 
+subroutine print_val(y)
+  real, intent(in) :: y
+  write (*,*) y
+end subroutine print_val
+
 module my_module
 
   ! Should not raise

--- a/test.f90
+++ b/test.f90
@@ -47,12 +47,18 @@ module my_module
   ! TODO should raise error for outdated 'character*(*)'
   character*(*), parameter :: hello = "hello world"
 
-  ! This function should raise an error for missing implicit none, one for using
-  ! a number literal kind in the signature, and one for a number literal kind in the
-  ! variable list.
   interface
+    ! This function should raise an error for missing implicit none, one for using
+    ! a number literal kind in the signature, and one for a number literal kind in the
+    ! variable list.
     integer(8) function interface_func(x)
       integer(kind=8), intent(in) :: x
+    end function
+
+    ! This function shouldn't raise anything
+    real function interface_func2(x)
+      implicit none
+      real, intent(in) :: x
     end function
   end interface
 


### PR DESCRIPTION
Replaces all uses of the tree-sitter query language with manual traversal of the tree. The code isn't noticeably faster when applied to a large code base, but this does make it easier to write and understand rules.

Resolves https://github.com/PlasmaFAIR/fortitude/issues/17
Resolves https://github.com/PlasmaFAIR/fortitude/issues/4 (by making the problem redundant)

Progress towards https://github.com/PlasmaFAIR/fortitude/issues/26, see comment in that thread.

