### PR TITLE
Optimise tree sitter usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,12 @@ pub trait Rule {
     /// Return text explaining what the rule tests for, why this is important, and how
     /// the user might fix it.
     fn explain(&self) -> &str;
+
+    /// Return list of tree-sitter node types on which a rule should trigger.
+    /// Only relevant for tree-sitter based rules, should not be implemented otherwise.
+    fn entrypoints(&self) -> Vec<&str> {
+        vec![]
+    }
 }
 
 // Violation diagnostics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub enum Method {
     /// Methods that work on just the path name of the file.
     Path(fn(&Path) -> Option<Violation>),
     /// Methods that analyse the syntax tree.
-    Tree(fn(&tree_sitter::Node, &str) -> Vec<Violation>),
+    Tree(fn(&tree_sitter::Node, &str) -> Option<Violation>),
     /// Methods that analyse lines of code directly, using regex or otherwise.
     Text(fn(&str, &Settings) -> Vec<Violation>),
 }
@@ -178,10 +178,9 @@ pub trait Rule {
     fn explain(&self) -> &str;
 
     /// Return list of tree-sitter node types on which a rule should trigger.
-    /// Only relevant for tree-sitter based rules, should not be implemented otherwise.
-    fn entrypoints(&self) -> Vec<&str> {
-        vec![]
-    }
+    /// Path-based rules should return a vector containing only "PATH" while
+    /// text-based rules should return a vector containing only "TEXT".
+    fn entrypoints(&self) -> Vec<&str>;
 }
 
 // Violation diagnostics

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -3,16 +3,8 @@ use tree_sitter::Node;
 
 /// Rules that check for syntax errors.
 
-fn syntax_error(node: &Node, _src: &str) -> Vec<Violation> {
-    let mut violations = Vec::new();
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        if child.is_error() {
-            violations.push(Violation::from_node("syntax error", &child));
-        }
-        violations.extend(syntax_error(&child, _src));
-    }
-    violations
+fn syntax_error(node: &Node, _src: &str) -> Option<Violation> {
+    Some(Violation::from_node("syntax_error", node))
 }
 
 pub struct SyntaxError {}

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -33,4 +33,8 @@ impl Rule for SyntaxError {
         bug in our code or in our parser!
         "
     }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["ERROR"]
+    }
 }

--- a/src/rules/filesystem/extensions.rs
+++ b/src/rules/filesystem/extensions.rs
@@ -32,6 +32,10 @@ impl Rule for NonStandardFileExtension {
         by some compilers and build tools.
         "
     }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["PATH"]
+    }
 }
 
 #[cfg(test)]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -10,6 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 pub type RuleBox = Box<dyn Rule>;
 pub type RuleSet = BTreeSet<String>;
 pub type RuleMap = BTreeMap<String, RuleBox>;
+pub type EntryPointMap = BTreeMap<String, Vec<(String, RuleBox)>>;
 
 /// Create a new `Rule` given a rule code, expressed as a string.
 pub fn build_rule(code_str: &str) -> anyhow::Result<RuleBox> {
@@ -106,4 +107,27 @@ pub fn rulemap(set: &RuleSet) -> anyhow::Result<RuleMap> {
         rules.insert(code.to_string(), rule);
     }
     Ok(rules)
+}
+
+/// Map tree-sitter node types to the rules that operate over them
+pub fn entrypoint_map(set: &RuleSet) -> anyhow::Result<EntryPointMap> {
+    let mut map = EntryPointMap::new();
+    for code in set {
+        let rule = build_rule(code)?;
+        let entrypoints = rule.entrypoints();
+        for entrypoint in entrypoints {
+            match map.get_mut(entrypoint) {
+                Some(rule_vec) => {
+                    rule_vec.push((code.to_string(), build_rule(code)?));
+                }
+                None => {
+                    map.insert(
+                        entrypoint.to_string(),
+                        vec![(code.to_string(), build_rule(code)?)],
+                    );
+                }
+            }
+        }
+    }
+    Ok(map)
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -4,12 +4,12 @@ mod modules;
 mod style;
 mod typing;
 use crate::{Category, Code, Rule};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 /// A collection of all rules, and utilities to select a subset at runtime.
 
 pub type RuleBox = Box<dyn Rule>;
-pub type RuleSet = HashSet<String>;
-pub type RuleMap = HashMap<String, RuleBox>;
+pub type RuleSet = BTreeSet<String>;
+pub type RuleMap = BTreeMap<String, RuleBox>;
 
 /// Create a new `Rule` given a rule code, expressed as a string.
 pub fn build_rule(code_str: &str) -> anyhow::Result<RuleBox> {

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -44,6 +44,10 @@ impl Rule for ExternalFunction {
         defined outside of these scopes, and this is a common source of bugs.
         "
     }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["function", "subroutine"]
+    }
 }
 
 #[cfg(test)]

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -6,26 +6,12 @@ use tree_sitter::Node;
 
 // TODO Check that 'used' entity is actually used somewhere
 
-fn use_missing_only_clause(node: &Node) -> Option<Violation> {
+fn use_all(node: &Node, _src: &str) -> Option<Violation> {
     if child_with_name(node, "included_items").is_none() {
         let msg = "'use' statement missing 'only' clause";
         return Some(Violation::from_node(msg, node));
     }
     None
-}
-
-fn use_all(node: &Node, _src: &str) -> Vec<Violation> {
-    let mut violations = Vec::new();
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        if child.kind() == "use_statement" {
-            if let Some(x) = use_missing_only_clause(&child) {
-                violations.push(x);
-            }
-        }
-        violations.extend(use_all(&child, _src));
-    }
-    violations
 }
 
 pub struct UseAll {}
@@ -67,7 +53,7 @@ mod tests {
     use textwrap::dedent;
 
     #[test]
-    fn test_use_all() {
+    fn test_use_all() -> Result<(), String> {
         let source = dedent(
             "
             module my_module
@@ -77,6 +63,7 @@ mod tests {
             ",
         );
         let violation = violation!("'use' statement missing 'only' clause", 4, 5);
-        test_tree_method(use_all, source, Some(vec![violation]));
+        test_tree_method(&UseAll {}, source, Some(vec![violation]))?;
+        Ok(())
     }
 }

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -53,6 +53,10 @@ impl Rule for UseAll {
         local scope.
         "
     }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["use_statement"]
+    }
 }
 
 #[cfg(test)]

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -50,4 +50,8 @@ impl Rule for LineTooLong {
         is recommended to stay beneath this limit.
         "
     }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["TEXT"]
+    }
 }

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -27,4 +27,8 @@ impl Rule for TrailingWhitespace {
         shared projects.
         "
     }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["TEXT"]
+    }
 }

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -55,6 +55,10 @@ impl Rule for ImplicitTyping {
         reduces the readability of code and increases the chances of typing errors.
         "
     }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["module", "submodule", "program"]
+    }
 }
 
 fn interface_implicit_none_not_found(node: &Node) -> Option<Violation> {
@@ -94,6 +98,10 @@ impl Rule for InterfaceImplicitTyping {
         Interface functions and subroutines require 'implicit none', even if they are
         inside a module that uses 'implicit none'.
         "
+    }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["function", "subroutine"]
     }
 }
 
@@ -150,6 +158,10 @@ impl Rule for SuperfluousImplicitNone {
         If a module has 'implicit none' set, it is not necessary to set it in contained
         functions and subroutines (except when using interfaces).
         "
+    }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["implicit_statement"]
     }
 }
 

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -31,12 +31,8 @@ fn implicit_typing(node: &Node, _src: &str) -> Vec<Violation> {
     for child in node.named_children(&mut cursor) {
         match child.kind() {
             "module" | "submodule" | "program" => {
-                // For some reason a second 'module' node is found at the end
-                // of each module, but it has nothing in it.
-                if child.child_count() != 0 {
-                    if let Some(x) = implicit_none_not_found(&child) {
-                        violations.push(x)
-                    }
+                if let Some(x) = implicit_none_not_found(&child) {
+                    violations.push(x)
                 }
             }
             _ => (),

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -7,7 +7,7 @@ use tree_sitter::Node;
 
 // TODO rules for intrinsic kinds in real(x, [KIND]) and similar type casting functions
 
-fn variable_has_literal_kind(node: &Node, src: &str) -> Option<Violation> {
+fn literal_kind(node: &Node, src: &str) -> Option<Violation> {
     let dtype = intrinsic_type(node)?;
     if dtype_is_number(dtype.as_str()) {
         if let Some(child) = child_with_name(node, "size") {
@@ -27,21 +27,6 @@ fn variable_has_literal_kind(node: &Node, src: &str) -> Option<Violation> {
         }
     }
     None
-}
-
-fn literal_kind(node: &Node, src: &str) -> Vec<Violation> {
-    let mut violations = Vec::new();
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        let kind = child.kind();
-        if kind == "variable_declaration" || kind == "function_statement" {
-            if let Some(x) = variable_has_literal_kind(&child, src) {
-                violations.push(x)
-            }
-        }
-        violations.extend(literal_kind(&child, src));
-    }
-    violations
 }
 
 pub struct LiteralKind {}
@@ -111,7 +96,7 @@ impl Rule for LiteralKind {
     }
 }
 
-fn literal_has_literal_suffix(node: &Node, src: &str) -> Option<Violation> {
+fn literal_kind_suffix(node: &Node, src: &str) -> Option<Violation> {
     let txt = to_text(node, src)?;
     if regex_is_match!(r"_\d+$", txt) {
         let msg = format!(
@@ -121,20 +106,6 @@ fn literal_has_literal_suffix(node: &Node, src: &str) -> Option<Violation> {
         return Some(Violation::from_node(&msg, node));
     }
     None
-}
-
-fn literal_kind_suffix(node: &Node, src: &str) -> Vec<Violation> {
-    let mut violations = Vec::new();
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        if child.kind() == "number_literal" {
-            if let Some(x) = literal_has_literal_suffix(&child, src) {
-                violations.push(x)
-            }
-        }
-        violations.extend(literal_kind_suffix(&child, src));
-    }
-    violations
 }
 
 pub struct LiteralKindSuffix {}
@@ -183,7 +154,7 @@ mod tests {
     use textwrap::dedent;
 
     #[test]
-    fn test_literal_kind() {
+    fn test_literal_kind() -> Result<(), String> {
         let source = dedent(
             "
             integer(8) function add_if(x, y, z)
@@ -230,11 +201,12 @@ mod tests {
             violation!(&msg, *line, *col)
         })
         .collect();
-        test_tree_method(literal_kind, source, Some(expected_violations));
+        test_tree_method(&LiteralKind {}, source, Some(expected_violations))?;
+        Ok(())
     }
 
     #[test]
-    fn test_literal_kind_suffix() {
+    fn test_literal_kind_suffix() -> Result<(), String> {
         let source = dedent(
             "
             use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
@@ -256,6 +228,7 @@ mod tests {
                 violation!(&msg, *line, *col)
             })
             .collect();
-        test_tree_method(literal_kind_suffix, source, Some(expected_violations));
+        test_tree_method(&LiteralKindSuffix {}, source, Some(expected_violations))?;
+        Ok(())
     }
 }

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -105,6 +105,10 @@ impl Rule for LiteralKind {
         ```
         "
     }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["variable_declaration", "function_statement"]
+    }
 }
 
 fn literal_has_literal_suffix(node: &Node, src: &str) -> Option<Violation> {
@@ -164,6 +168,10 @@ impl Rule for LiteralKindSuffix {
         real(dp), parameter :: pi = 3.14159265358979_dp
         ```
         "
+    }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["number_literal"]
     }
 }
 

--- a/src/rules/typing/real_precision.rs
+++ b/src/rules/typing/real_precision.rs
@@ -63,6 +63,10 @@ impl Rule for DoublePrecision {
         `real(c_double)`, which may be found in the intrinsic module `iso_c_binding`.
         "
     }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["intrinsic_type"]
+    }
 }
 
 fn real_has_no_suffix(node: &Node, src: &str) -> Option<Violation> {
@@ -136,6 +140,10 @@ impl Rule for NoRealSuffix {
         implementation it instead requires all real literals to have an explicit
         kind suffix.
         "
+    }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["number_literal"]
     }
 }
 

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -63,6 +63,10 @@ impl Rule for StarKind {
         built-in functions 'selected_real_kind' and 'selected_int_kind'.
         "
     }
+
+    fn entrypoints(&self) -> Vec<&str> {
+        vec!["variable_declaration", "function_statement"]
+    }
 }
 
 #[cfg(test)]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,14 +1,31 @@
 #[cfg(test)]
 pub mod test_utils {
-    use crate::Violation;
+    use crate::{Method, Rule, Violation};
     use tree_sitter::Node;
 
-    pub fn test_tree_method<F, S: AsRef<str>>(
-        f: F,
+    fn scan_tree<F>(f: &F, entrypoints: &Vec<&str>, node: &Node, source: &str) -> Vec<Violation>
+    where
+        F: Fn(&Node, &str) -> Option<Violation>,
+    {
+        let mut violations = Vec::new();
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if entrypoints.contains(&child.kind()) {
+                if let Some(violation) = f(&child, source) {
+                    violations.push(violation);
+                }
+            }
+            violations.extend(scan_tree(f, entrypoints, &child, source));
+        }
+        violations
+    }
+
+    pub fn test_tree_method<S: AsRef<str>>(
+        rule: &dyn Rule,
         source: S,
         expected_violations: Option<Vec<Violation>>,
-    ) where
-        F: Fn(&Node, &str) -> Vec<Violation>,
+    ) -> Result<(), String>
+    where
         S: AsRef<str>,
     {
         let src = source.as_ref();
@@ -18,17 +35,24 @@ pub mod test_utils {
             .expect("Error loading Fortran grammar");
         let tree = parser.parse(src, None).unwrap();
         let root = tree.root_node();
-        let violations = f(&root, src);
-        match expected_violations {
-            Some(x) => {
-                assert_eq!(violations.len(), x.len());
-                for (actual, expected) in violations.iter().zip(&x) {
-                    assert_eq!(actual, expected);
-                }
+        let mut violations = Vec::new();
+        let entrypoints = rule.entrypoints();
+
+        match rule.method() {
+            Method::Tree(f) => {
+                violations.extend(scan_tree(&f, &entrypoints, &root, src));
             }
-            None => {
-                // Do nothing!
+            _ => {
+                return Err("Broken entrypoints".to_string());
             }
         }
+
+        if let Some(x) = expected_violations {
+            assert_eq!(violations.len(), x.len());
+            for (actual, expected) in violations.iter().zip(&x) {
+                assert_eq!(actual, expected);
+            }
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
Resolves https://github.com/PlasmaFAIR/fortitude/issues/26

Results in a massive speed up. Running on the [GS2](https://bitbucket.org/gyrokinetics/gs2/src/master/) `src` directory, it used to take about 5.5 seconds on my laptop, but now takes under 0.5s.

The method to achieve this isn't great, as now every rule needs to declare 'entrypoints' that must match its method type. The process of generating a map from entrypoints to `(rule_code, rule)` is a little messy too. It would be better to use some fancy macros, enums and match statements instead, but the current methods work well enough.