### PR TITLE
Bugfix: newline printed for files without rule violations

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -154,8 +154,10 @@ pub fn check(args: CheckArgs) -> i32 {
                             .into_iter()
                             .map(|(c, v)| Diagnostic::new(&file, c, &v))
                             .collect();
-                        diagnostics.sort_unstable();
-                        println!("{}", join(&diagnostics, "\n"));
+                        if !diagnostics.is_empty() {
+                            diagnostics.sort_unstable();
+                            println!("{}", join(&diagnostics, "\n"));
+                        }
                         total_errors += diagnostics.len();
                     }
                     Err(msg) => {


### PR DESCRIPTION
If no errors are found when checking a file, fortitude would print a pointless newline to the terminal. This fixes that error.