### PR TITLE
Print context of violations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e35ed54e5ea7997c14ed4c70ba043478db1112e98263b3b035907aa197d991"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +157,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 name = "fortitude"
 version = "0.2.0"
 dependencies = [
+ "annotate-snippets",
  "anyhow",
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-utilities", "development-tools"]
 exclude = [".*", "test.f90"]
 
 [dependencies]
+annotate-snippets = "0.11.4"
 anyhow = "1.0.79"
 clap = { version = "4.4.16", features = ["derive"] }
 colored = "2.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,7 +333,7 @@ fn format_violation_line_col(
     // put the annotation in the first column: it's either in column 2
     // or the end of the previous line. But does appear to be right
     // for other columns!
-    let label_offset = offset_up_to_line + col.saturating_sub(1).max(1);
+    let label_offset = offset_up_to_line + col.saturating_sub(1);
 
     // Some annoyance here: we *have* to have some level prefix to our
     // message. Might be fixed in future version of annotate-snippets
@@ -344,7 +344,11 @@ fn format_violation_line_col(
     let snippet = Level::Warning.title(&message_line).snippet(
         Snippet::source(&content_slice)
             .line_start(start_index)
-            .annotation(Level::Error.span(label_offset..label_offset).label(code)),
+            .annotation(
+                Level::Error
+                    .span(label_offset..label_offset.saturating_add(1))
+                    .label(code),
+            ),
     );
 
     let renderer = Renderer::styled();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,10 @@ pub mod cli;
 pub mod explain;
 mod rules;
 mod settings;
+use annotate_snippets::{Level, Renderer, Snippet};
 use anyhow::Context;
 use ast::{named_descendants, parse};
-use colored::Colorize;
+use colored::{ColoredString, Colorize};
 use lazy_regex::regex_captures;
 use settings::Settings;
 use std::cmp::Ordering;
@@ -269,13 +270,86 @@ impl fmt::Display for Diagnostic {
                 write!(f, "{}: {} {}", path, code, message)
             }
             ViolationPosition::Line(line) => {
-                write!(f, "{}:{}: {} {}", path, line, code, message)
+                format_violation_line_col(self, f, line, 0, message, &path, &code)
             }
             ViolationPosition::LineCol((line, col)) => {
-                write!(f, "{}:{}:{}: {} {}", path, line, col, code, message)
+                format_violation_line_col(self, f, line, col, message, &path, &code)
             }
         }
     }
+}
+
+/// Read filename into vec of strings
+fn read_lines(filename: &PathBuf) -> Vec<String> {
+    std::fs::read_to_string(filename)
+        .unwrap() // panic on possible file-reading errors
+        .lines() // split the string into an iterator of string slices
+        .map(String::from) // make each slice into a string
+        .collect() // gather them together into a vector
+}
+
+fn format_violation_line_col(
+    diagnostic: &Diagnostic,
+    f: &mut fmt::Formatter,
+    line: usize,
+    col: usize,
+    message: &str,
+    path: &ColoredString,
+    code: &ColoredString,
+) -> fmt::Result {
+    let lines = read_lines(&diagnostic.path);
+    let mut start_index = line.saturating_sub(2).max(1);
+
+    // Trim leading empty lines.
+    while start_index < line {
+        if !lines[start_index.saturating_sub(1)].trim().is_empty() {
+            break;
+        }
+        start_index = start_index.saturating_add(1);
+    }
+
+    let mut end_index = line.saturating_add(2).min(lines.len());
+
+    // Trim leading empty lines.
+    while end_index > line {
+        if !lines[end_index.saturating_sub(1)].trim().is_empty() {
+            break;
+        }
+        end_index = end_index.saturating_sub(1);
+    }
+
+    let content_slice = lines[start_index.saturating_sub(1)..end_index]
+        .iter()
+        .fold(String::default(), |acc, line| format!("{acc}{line}\n"));
+
+    // Annotations are done by offset, so we need to count line
+    // lengths... including the newline character, which doesn't
+    // appear in `lines`!
+    let offset_up_to_line = lines[start_index.saturating_sub(1)..line.saturating_sub(1)]
+        .iter()
+        .fold(0, |acc, line| acc + line.chars().count() + 1);
+
+    // Something really weird going on here, where I can't get it to
+    // put the annotation in the first column: it's either in column 2
+    // or the end of the previous line. But does appear to be right
+    // for other columns!
+    let label_offset = offset_up_to_line + col.saturating_sub(1).max(1);
+
+    // Some annoyance here: we *have* to have some level prefix to our
+    // message. Might be fixed in future version of annotate-snippets
+    // -- or we use an earlier version with more control.
+    // Also, we could use `.origin(path)` to get the filename and
+    // line:col automatically, but see above about off-by-one error
+    let message_line = format!("{}:{}:{}: {} {}", path, line, col, code, message);
+    let snippet = Level::Warning.title(&message_line).snippet(
+        Snippet::source(&content_slice)
+            .line_start(start_index)
+            .annotation(Level::Error.span(label_offset..label_offset).label(code)),
+    );
+
+    let renderer = Renderer::styled();
+    let source_block = renderer.render(snippet);
+    writeln!(f, "{}", source_block)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Example:

```text
warning: test.f90:90:3: P011 prefer 'real(real64)' to 'double precision' (see 'iso_fortran_env')
   |
89 |   ! Should trigger for use of 'double precision'
90 |   double precision function double_prec(x)
   |   ^ P011
91 |     double precision, intent(in) :: x
92 |     double_prec = 2 * x
   |

warning: test.f90:91:5: P011 prefer 'real(real64)' to 'double precision' (see 'iso_fortran_env')
   |
89 |   ! Should trigger for use of 'double precision'
90 |   double precision function double_prec(x)
91 |     double precision, intent(in) :: x
   |     ^ P011
92 |     double_prec = 2 * x
93 |   end function
   |

warning: test.f90:97:1: M001 subroutine not contained within (sub)module or program
   |
96 | ! This function should trigger for missing enclosing module
97 | subroutine triple(x)
   |  ^ M001
98 |   integer, intent(inout) :: x
99 |   x = x * 3
   |
```

A couple of annoying things:

- Something really weird going on here, where I can't get it to
  put the annotation in the first column: it's either in column 2
  or the end of the previous line. But does appear to be right
  for other columns!
- Some annoyance here: we *have* to have some level prefix to our
  message. Might be fixed in future version of annotate-snippets
  -- or we use an earlier version with more control.
- Also, we could use `.origin(path)` to get the filename and
  line:col automatically, but see above about off-by-one error
