### PR TITLE
Overhaul core

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -155,7 +155,7 @@ pub fn check(args: CheckArgs) -> i32 {
             }
         }
         Err(msg) => {
-            println!("{}{}", "ERROR".bright_red(), msg);
+            eprintln!("{}: {}", "ERROR".bright_red(), msg);
             1
         }
     }

--- a/src/check.rs
+++ b/src/check.rs
@@ -3,7 +3,7 @@ use crate::cli::CheckArgs;
 use crate::rules::{default_ruleset, entrypoint_map, EntryPointMap, RuleSet};
 use crate::settings::Settings;
 use crate::violation;
-use crate::{Category, Code, Diagnostic, Method, Violation};
+use crate::{Diagnostic, Method, Violation};
 use colored::Colorize;
 use itertools::{chain, join};
 use std::fs::read_to_string;
@@ -161,10 +161,9 @@ pub fn check(args: CheckArgs) -> i32 {
                         total_errors += diagnostics.len();
                     }
                     Err(msg) => {
-                        let err_code = Code::new(Category::Error, 0).to_string();
                         let err_msg = format!("Failed to process: {}", msg);
                         let violation = violation!(&err_msg);
-                        let diagnostic = Diagnostic::new(&file, &err_code, &violation);
+                        let diagnostic = Diagnostic::new(&file, "E000", &violation);
                         println!("{}", diagnostic);
                         total_errors += 1;
                     }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -40,7 +40,7 @@ pub fn explain(args: ExplainArgs) -> i32 {
             0
         }
         Err(msg) => {
-            eprintln!("{}: {}", "ERROR:".bright_red(), msg);
+            eprintln!("{}: {}", "ERROR".bright_red(), msg);
             1
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,8 @@ pub mod cli;
 pub mod explain;
 mod rules;
 mod settings;
-use anyhow::Context;
 use ast::{named_descendants, parse};
 use colored::Colorize;
-use lazy_regex::regex_captures;
 use settings::Settings;
 use std::cmp::Ordering;
 use std::fmt;
@@ -36,6 +34,7 @@ pub enum Category {
     FileSystem,
 }
 
+#[allow(dead_code)]
 impl Category {
     fn from(s: &str) -> anyhow::Result<Self> {
         match s {
@@ -49,47 +48,6 @@ impl Category {
                 anyhow::bail!("{} is not a rule category.", s)
             }
         }
-    }
-}
-
-impl fmt::Display for Category {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = match self {
-            Self::Error => "E",
-            Self::Style => "S",
-            Self::Typing => "T",
-            Self::Modules => "M",
-            Self::Precision => "P",
-            Self::FileSystem => "F",
-        };
-        write!(f, "{}", s)
-    }
-}
-
-/// The combination of a rule category and a unique identifying number.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct Code {
-    pub category: Category,
-    pub number: usize,
-}
-
-impl Code {
-    pub const fn new(category: Category, number: usize) -> Self {
-        Self { category, number }
-    }
-
-    pub fn from(code_str: &str) -> anyhow::Result<Self> {
-        let (_, category_str, number_str) = regex_captures!(r"^([A-Z]+)([0-9]{3})$", code_str)
-            .context(format!("{} is not a valid error code.", code_str))?;
-        let category = Category::from(category_str)?;
-        let number = number_str.parse::<usize>()?;
-        Ok(Code::new(category, number))
-    }
-}
-
-impl fmt::Display for Code {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}{:03}", self.category, self.number)
     }
 }
 
@@ -276,19 +234,4 @@ impl fmt::Display for Diagnostic {
             }
         }
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_rule_code() {
-        let f001 = Code::new(Category::FileSystem, 1);
-        assert_eq!(f001.to_string(), "F001");
-        let c120 = Code::new(Category::Style, 120);
-        assert_eq!(c120.to_string(), "S120");
-    }
-
-    // TODO Test diagnostics
 }

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -1,20 +1,17 @@
-use crate::{Method, Rule, Violation};
+use crate::settings::Settings;
+use crate::{ASTRule, Rule, Violation};
 use tree_sitter::Node;
 
 /// Rules that check for syntax errors.
 
-fn syntax_error(node: &Node, _src: &str) -> Option<Violation> {
-    Some(Violation::from_node("syntax_error", node))
-}
-
 pub struct SyntaxError {}
 
 impl Rule for SyntaxError {
-    fn method(&self) -> Method {
-        Method::Tree(syntax_error)
+    fn new(_settings: &Settings) -> Self {
+        SyntaxError {}
     }
 
-    fn explain(&self) -> &str {
+    fn explain(&self) -> &'static str {
         "
         This rule reports any syntax errors reported by Fortitude's Fortran parser.
         This may indicate an error with your code, an aspect of Fortran not recognised
@@ -25,8 +22,14 @@ impl Rule for SyntaxError {
         bug in our code or in our parser!
         "
     }
+}
 
-    fn entrypoints(&self) -> Vec<&str> {
+impl ASTRule for SyntaxError {
+    fn check(&self, node: &Node, _src: &str) -> Option<Violation> {
+        Some(Violation::from_node("syntax_error", node))
+    }
+
+    fn entrypoints(&self) -> Vec<&'static str> {
         vec!["ERROR"]
     }
 }

--- a/src/rules/filesystem/extensions.rs
+++ b/src/rules/filesystem/extensions.rs
@@ -1,17 +1,17 @@
 use crate::settings::Settings;
 use crate::violation;
-use crate::{BaseRule, PathRule, Violation};
+use crate::{PathRule, Rule, Violation};
 use std::path::Path;
 /// Defines rule that enforces use of standard file extensions.
 
 pub struct NonStandardFileExtension {}
 
-impl BaseRule for NonStandardFileExtension {
+impl Rule for NonStandardFileExtension {
     fn new(_settings: &Settings) -> Self {
         NonStandardFileExtension {}
     }
 
-    fn explain(&self) -> &str {
+    fn explain(&self) -> &'static str {
         "
         The standard file extensions for modern (free-form) Fortran are '.f90' or  '.F90'.
         Forms that reference later Fortran standards such as '.f08' or '.F95' may be rejected

--- a/src/rules/macros.rs
+++ b/src/rules/macros.rs
@@ -1,19 +1,46 @@
-macro_rules! num_rules {
-    ($rule: ident) => {
-        1
+macro_rules! num_ast {
+    (AST) => {1};
+    ($type: tt) => {0};
+    (AST, $($types: tt), +) => {
+        1 + num_ast!($($types), +)
     };
-    ($rule: path, $($rules: ident), +) => {
-        1 + num_rules!($($rules), +)
+    ($type: tt, $($types: tt), +) => {
+        num_ast!($($types), +)
+    }
+}
+
+macro_rules! option_ast {
+    (AST, $value: tt) => {
+        Some($value)
+    };
+    ($type: tt, $value: tt) => {
+        None
     };
 }
 
 #[macro_export]
 macro_rules! register_rules {
-    ($(($categories: ty, $codes: literal, $paths: path, $rules: ident)), +) => {
+    ($(($categories: ty, $codes: literal, $types: tt, $paths: path, $rules: ident)), +) => {
 
-        const N_RULES: usize = num_rules!($($rules),+);
+        const CODES: &[&str; [$($codes), *].len()] = &[$($codes), +];
 
-        const CODES: &[&str; N_RULES] = &[$($codes,) +];
+        const fn drop_none<'a, const N1: usize, const N2: usize>(xs: &'a [Option<&'a str>; N1]) -> [&'a str; N2] {
+            let mut result: [&str; N2] = [""; N2];
+            let mut i = 0;
+            let mut j = 0;
+            while i < N1 {
+                if let Some(y) = xs[i] {
+                    result[j] = y;
+                    j += 1;
+                }
+                i += 1;
+            }
+            result
+        }
+
+        const N_AST: usize = num_ast!($($types), +);
+        const AST_OPTIONS: &[Option<&str>; CODES.len()] = &[$(option_ast!($types, $codes)), +];
+        const AST_CODES: &[&str; N_AST] = &drop_none(AST_OPTIONS);
 
         $(type $rules = $paths;)+
 

--- a/src/rules/macros.rs
+++ b/src/rules/macros.rs
@@ -1,0 +1,30 @@
+macro_rules! num_rules {
+    ($rule: ident) => {
+        1
+    };
+    ($rule: path, $($rules: ident), +) => {
+        1 + num_rules!($($rules), +)
+    };
+}
+
+#[macro_export]
+macro_rules! register_rules {
+    ($(($categories: ty, $codes: literal, $paths: path, $rules: ident)), +) => {
+
+        const N_RULES: usize = num_rules!($($rules),+);
+
+        const CODES: &[&str; N_RULES] = &[$($codes,) +];
+
+        $(type $rules = $paths;)+
+
+        /// Create a new `Rule` given a rule code, expressed as a string.
+        pub fn build_rule(code: &str) -> anyhow::Result<Box<dyn Rule>> {
+            match code {
+                $($codes => Ok(Box::new($rules {})),)+
+                _ => {
+                    anyhow::bail!("Unknown rule code {}", code)
+                }
+            }
+        }
+    };
+}

--- a/src/rules/macros.rs
+++ b/src/rules/macros.rs
@@ -32,14 +32,26 @@ macro_rules! some_type {
     };
 }
 
+macro_rules! build_set {
+    ($name: ident, $array: ident) => {
+        lazy_static! {
+            static ref $name: BTreeSet<&'static str> = { BTreeSet::from(*$array) };
+        }
+    };
+}
+
 #[macro_export]
 macro_rules! register_rules {
     ($(($categories: ty, $codes: literal, $types: tt, $paths: path, $rules: ident)), +) => {
 
-        const CODES: &[&str; [$($codes), *].len()] = &[$($codes), +];
+        use lazy_static::lazy_static;
+        use std::collections::BTreeSet;
 
-        const fn drop_none<'a, const N1: usize, const N2: usize>(xs: &'a [Option<&'a str>; N1]) -> [&'a str; N2] {
-            let mut result: [&str; N2] = [""; N2];
+        const _CODES: &[&'static str; [$($codes), *].len()] = &[$($codes), +];
+        build_set!(CODES, _CODES);
+
+        const fn drop_none<const N1: usize, const N2: usize>(xs: &[Option<&'static str>; N1]) -> [&'static str; N2] {
+            let mut result: [&'static str; N2] = [""; N2];
             let mut i = 0;
             let mut j = 0;
             while i < N1 {
@@ -52,17 +64,20 @@ macro_rules! register_rules {
             result
         }
 
-        const N_PATH: usize = num_types!(PATH, $($types), +);
-        const PATH_OPTIONS: &[Option<&str>; CODES.len()] = &[$(some_type!(PATH, $types, $codes)), +];
-        const PATH_CODES: &[&str; N_PATH] = &drop_none(PATH_OPTIONS);
+        const _N_PATH: usize = num_types!(PATH, $($types), +);
+        const _PATH_OPTIONS: &[Option<&str>; _CODES.len()] = &[$(some_type!(PATH, $types, $codes)), +];
+        const _PATH_CODES: &[&str; _N_PATH] = &drop_none(_PATH_OPTIONS);
+        build_set!(PATH_CODES, _PATH_CODES);
 
-        const N_TEXT: usize = num_types!(TEXT, $($types), +);
-        const TEXT_OPTIONS: &[Option<&str>; CODES.len()] = &[$(some_type!(TEXT, $types, $codes)), +];
-        const TEXT_CODES: &[&str; N_TEXT] = &drop_none(TEXT_OPTIONS);
+        const _N_TEXT: usize = num_types!(TEXT, $($types), +);
+        const _TEXT_OPTIONS: &[Option<&str>; _CODES.len()] = &[$(some_type!(TEXT, $types, $codes)), +];
+        const _TEXT_CODES: &[&str; _N_TEXT] = &drop_none(_TEXT_OPTIONS);
+        build_set!(TEXT_CODES, _TEXT_CODES);
 
-        const N_AST: usize = num_types!(AST, $($types), +);
-        const AST_OPTIONS: &[Option<&str>; CODES.len()] = &[$(some_type!(AST, $types, $codes)), +];
-        const AST_CODES: &[&str; N_AST] = &drop_none(AST_OPTIONS);
+        const _N_AST: usize = num_types!(AST, $($types), +);
+        const _AST_OPTIONS: &[Option<&str>; _CODES.len()] = &[$(some_type!(AST, $types, $codes)), +];
+        const _AST_CODES: &[&str; _N_AST] = &drop_none(_AST_OPTIONS);
+        build_set!(AST_CODES, _AST_CODES);
 
         $(type $rules = $paths;)+
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -8,7 +8,7 @@ mod precision;
 mod style;
 mod typing;
 use crate::register_rules;
-use crate::{PathRule, Rule};
+use crate::{PathRule, Rule, TextRule};
 use std::collections::BTreeMap;
 
 register_rules! {
@@ -59,6 +59,9 @@ pub fn entrypoint_map(set: &RuleSet) -> anyhow::Result<EntryPointMap> {
     let mut map = EntryPointMap::new();
     for code in set {
         if PATH_CODES.contains(code.as_str()) {
+            continue;
+        }
+        if TEXT_CODES.contains(code.as_str()) {
             continue;
         }
         let rule = build_rule(code)?;

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -12,20 +12,20 @@ use crate::Rule;
 use std::collections::{BTreeMap, BTreeSet};
 
 register_rules! {
-    (Category::Error, "E001", error::syntax_error::SyntaxError, SyntaxError),
-    (Category::Filesystem, "F001", filesystem::extensions::NonStandardFileExtension, NonStandardFileExtension),
-    (Category::Style, "S001", style::line_length::LineTooLong, LineTooLong),
-    (Category::Style, "S101", style::whitespace::TrailingWhitespace, TrailingWhitespace),
-    (Category::Typing, "T001", typing::implicit_typing::ImplicitTyping, ImplicitTyping),
-    (Category::Typing, "T002", typing::implicit_typing::InterfaceImplicitTyping, InterfaceImplicitTyping),
-    (Category::Typing, "T003", typing::implicit_typing::SuperfluousImplicitNone, SuperfluousImplicitNone),
-    (Category::Typing, "T011", typing::literal_kinds::LiteralKind, LiteralKind),
-    (Category::Typing, "T012", typing::literal_kinds::LiteralKindSuffix, LiteralKindSuffix),
-    (Category::Typing, "T021", typing::star_kinds::StarKind, StarKind),
-    (Category::Precision, "P001", precision::kind_suffixes::NoRealSuffix, NoRealSuffix),
-    (Category::Precision, "P011", precision::double_precision::DoublePrecision, DoublePrecision),
-    (Category::Modules, "M001", modules::external_functions::ExternalFunction, ExternalFunction),
-    (Category::Modules, "M011", modules::use_statements::UseAll, UseAll)
+    (Category::Error, "E001", AST, error::syntax_error::SyntaxError, SyntaxError),
+    (Category::Filesystem, "F001", PATH, filesystem::extensions::NonStandardFileExtension, NonStandardFileExtension),
+    (Category::Style, "S001", TEXT, style::line_length::LineTooLong, LineTooLong),
+    (Category::Style, "S101", TEXT, style::whitespace::TrailingWhitespace, TrailingWhitespace),
+    (Category::Typing, "T001", AST, typing::implicit_typing::ImplicitTyping, ImplicitTyping),
+    (Category::Typing, "T002", AST, typing::implicit_typing::InterfaceImplicitTyping, InterfaceImplicitTyping),
+    (Category::Typing, "T003", AST, typing::implicit_typing::SuperfluousImplicitNone, SuperfluousImplicitNone),
+    (Category::Typing, "T011", AST, typing::literal_kinds::LiteralKind, LiteralKind),
+    (Category::Typing, "T012", AST, typing::literal_kinds::LiteralKindSuffix, LiteralKindSuffix),
+    (Category::Typing, "T021", AST, typing::star_kinds::StarKind, StarKind),
+    (Category::Precision, "P001", AST, precision::kind_suffixes::NoRealSuffix, NoRealSuffix),
+    (Category::Precision, "P011", AST, precision::double_precision::DoublePrecision, DoublePrecision),
+    (Category::Modules, "M001", AST, modules::external_functions::ExternalFunction, ExternalFunction),
+    (Category::Modules, "M011", AST, modules::use_statements::UseAll, UseAll)
 }
 
 pub type RuleBox = Box<dyn Rule>;

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -8,7 +8,7 @@ mod precision;
 mod style;
 mod typing;
 use crate::register_rules;
-use crate::Rule;
+use crate::{PathRule, Rule};
 use std::collections::BTreeMap;
 
 register_rules! {
@@ -58,6 +58,9 @@ pub fn rulemap(set: &RuleSet) -> anyhow::Result<RuleMap> {
 pub fn entrypoint_map(set: &RuleSet) -> anyhow::Result<EntryPointMap> {
     let mut map = EntryPointMap::new();
     for code in set {
+        if PATH_CODES.contains(code.as_str()) {
+            continue;
+        }
         let rule = build_rule(code)?;
         let entrypoints = rule.entrypoints();
         for entrypoint in entrypoints {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -9,7 +9,7 @@ mod style;
 mod typing;
 use crate::register_rules;
 use crate::Rule;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 register_rules! {
     (Category::Error, "E001", AST, error::syntax_error::SyntaxError, SyntaxError),
@@ -35,7 +35,7 @@ pub type EntryPointMap = BTreeMap<String, Vec<(String, RuleBox)>>;
 
 // Returns the full set of all rules.
 pub fn full_ruleset() -> RuleSet {
-    RuleSet::from_iter(CODES.iter().map(|x| x.to_string()))
+    CODES.iter().map(|x| x.to_string()).collect()
 }
 
 /// Returns the set of rules that are activated by default, expressed as strings.

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,54 +1,41 @@
+/// A collection of all rules, and utilities to select a subset at runtime.
 mod error;
 mod filesystem;
+#[macro_use]
+mod macros;
 mod modules;
 mod precision;
 mod style;
 mod typing;
+use crate::register_rules;
 use crate::Rule;
 use std::collections::{BTreeMap, BTreeSet};
-/// A collection of all rules, and utilities to select a subset at runtime.
+
+register_rules! {
+    (Category::Error, "E001", error::syntax_error::SyntaxError, SyntaxError),
+    (Category::Filesystem, "F001", filesystem::extensions::NonStandardFileExtension, NonStandardFileExtension),
+    (Category::Style, "S001", style::line_length::LineTooLong, LineTooLong),
+    (Category::Style, "S101", style::whitespace::TrailingWhitespace, TrailingWhitespace),
+    (Category::Typing, "T001", typing::implicit_typing::ImplicitTyping, ImplicitTyping),
+    (Category::Typing, "T002", typing::implicit_typing::InterfaceImplicitTyping, InterfaceImplicitTyping),
+    (Category::Typing, "T003", typing::implicit_typing::SuperfluousImplicitNone, SuperfluousImplicitNone),
+    (Category::Typing, "T011", typing::literal_kinds::LiteralKind, LiteralKind),
+    (Category::Typing, "T012", typing::literal_kinds::LiteralKindSuffix, LiteralKindSuffix),
+    (Category::Typing, "T021", typing::star_kinds::StarKind, StarKind),
+    (Category::Precision, "P001", precision::kind_suffixes::NoRealSuffix, NoRealSuffix),
+    (Category::Precision, "P011", precision::double_precision::DoublePrecision, DoublePrecision),
+    (Category::Modules, "M001", modules::external_functions::ExternalFunction, ExternalFunction),
+    (Category::Modules, "M011", modules::use_statements::UseAll, UseAll)
+}
 
 pub type RuleBox = Box<dyn Rule>;
 pub type RuleSet = BTreeSet<String>;
 pub type RuleMap = BTreeMap<String, RuleBox>;
 pub type EntryPointMap = BTreeMap<String, Vec<(String, RuleBox)>>;
 
-/// Create a new `Rule` given a rule code, expressed as a string.
-pub fn build_rule(code: &str) -> anyhow::Result<RuleBox> {
-    match code {
-        "E001" => Ok(Box::new(error::syntax_error::SyntaxError {})),
-        "F001" => Ok(Box::new(
-            filesystem::extensions::NonStandardFileExtension {},
-        )),
-        "S001" => Ok(Box::new(style::line_length::LineTooLong {})),
-        "S101" => Ok(Box::new(style::whitespace::TrailingWhitespace {})),
-        "T001" => Ok(Box::new(typing::implicit_typing::ImplicitTyping {})),
-        "T002" => Ok(Box::new(
-            typing::implicit_typing::InterfaceImplicitTyping {},
-        )),
-        "T003" => Ok(Box::new(
-            typing::implicit_typing::SuperfluousImplicitNone {},
-        )),
-        "T011" => Ok(Box::new(typing::literal_kinds::LiteralKind {})),
-        "T012" => Ok(Box::new(typing::literal_kinds::LiteralKindSuffix {})),
-        "T021" => Ok(Box::new(typing::star_kinds::StarKind {})),
-        "P001" => Ok(Box::new(precision::kind_suffixes::NoRealSuffix {})),
-        "P011" => Ok(Box::new(precision::double_precision::DoublePrecision {})),
-        "M001" => Ok(Box::new(modules::external_functions::ExternalFunction {})),
-        "M011" => Ok(Box::new(modules::use_statements::UseAll {})),
-        _ => {
-            anyhow::bail!("Unknown rule code {}", code)
-        }
-    }
-}
-
 // Returns the full set of all rules.
 pub fn full_ruleset() -> RuleSet {
-    let all_rules = &[
-        "E001", "F001", "S001", "S101", "T001", "T002", "T003", "T011", "T012", "T021", "P001",
-        "P011", "M001", "M011",
-    ];
-    RuleSet::from_iter(all_rules.iter().map(|x| x.to_string()))
+    RuleSet::from_iter(CODES.iter().map(|x| x.to_string()))
 }
 
 /// Returns the set of rules that are activated by default, expressed as strings.

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -4,7 +4,7 @@ mod modules;
 mod precision;
 mod style;
 mod typing;
-use crate::{Category, Code, Rule};
+use crate::Rule;
 use std::collections::{BTreeMap, BTreeSet};
 /// A collection of all rules, and utilities to select a subset at runtime.
 
@@ -14,73 +14,30 @@ pub type RuleMap = BTreeMap<String, RuleBox>;
 pub type EntryPointMap = BTreeMap<String, Vec<(String, RuleBox)>>;
 
 /// Create a new `Rule` given a rule code, expressed as a string.
-pub fn build_rule(code_str: &str) -> anyhow::Result<RuleBox> {
-    let code = Code::from(code_str)?;
+pub fn build_rule(code: &str) -> anyhow::Result<RuleBox> {
     match code {
-        Code {
-            category: Category::Error,
-            number: 1,
-        } => Ok(Box::new(error::syntax_error::SyntaxError {})),
-        Code {
-            category: Category::FileSystem,
-            number: 1,
-        } => Ok(Box::new(
+        "E001" => Ok(Box::new(error::syntax_error::SyntaxError {})),
+        "F001" => Ok(Box::new(
             filesystem::extensions::NonStandardFileExtension {},
         )),
-        Code {
-            category: Category::Style,
-            number: 1,
-        } => Ok(Box::new(style::line_length::LineTooLong {})),
-        Code {
-            category: Category::Style,
-            number: 101,
-        } => Ok(Box::new(style::whitespace::TrailingWhitespace {})),
-        Code {
-            category: Category::Typing,
-            number: 1,
-        } => Ok(Box::new(typing::implicit_typing::ImplicitTyping {})),
-        Code {
-            category: Category::Typing,
-            number: 2,
-        } => Ok(Box::new(
+        "S001" => Ok(Box::new(style::line_length::LineTooLong {})),
+        "S101" => Ok(Box::new(style::whitespace::TrailingWhitespace {})),
+        "T001" => Ok(Box::new(typing::implicit_typing::ImplicitTyping {})),
+        "T002" => Ok(Box::new(
             typing::implicit_typing::InterfaceImplicitTyping {},
         )),
-        Code {
-            category: Category::Typing,
-            number: 3,
-        } => Ok(Box::new(
+        "T003" => Ok(Box::new(
             typing::implicit_typing::SuperfluousImplicitNone {},
         )),
-        Code {
-            category: Category::Typing,
-            number: 11,
-        } => Ok(Box::new(typing::literal_kinds::LiteralKind {})),
-        Code {
-            category: Category::Typing,
-            number: 12,
-        } => Ok(Box::new(typing::literal_kinds::LiteralKindSuffix {})),
-        Code {
-            category: Category::Typing,
-            number: 21,
-        } => Ok(Box::new(typing::star_kinds::StarKind {})),
-        Code {
-            category: Category::Precision,
-            number: 1,
-        } => Ok(Box::new(precision::kind_suffixes::NoRealSuffix {})),
-        Code {
-            category: Category::Precision,
-            number: 11,
-        } => Ok(Box::new(precision::double_precision::DoublePrecision {})),
-        Code {
-            category: Category::Modules,
-            number: 1,
-        } => Ok(Box::new(modules::external_functions::ExternalFunction {})),
-        Code {
-            category: Category::Modules,
-            number: 11,
-        } => Ok(Box::new(modules::use_statements::UseAll {})),
+        "T011" => Ok(Box::new(typing::literal_kinds::LiteralKind {})),
+        "T012" => Ok(Box::new(typing::literal_kinds::LiteralKindSuffix {})),
+        "T021" => Ok(Box::new(typing::star_kinds::StarKind {})),
+        "P001" => Ok(Box::new(precision::kind_suffixes::NoRealSuffix {})),
+        "P011" => Ok(Box::new(precision::double_precision::DoublePrecision {})),
+        "M001" => Ok(Box::new(modules::external_functions::ExternalFunction {})),
+        "M011" => Ok(Box::new(modules::use_statements::UseAll {})),
         _ => {
-            anyhow::bail!("Unknown rule code {}", code_str)
+            anyhow::bail!("Unknown rule code {}", code)
         }
     }
 }

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -1,6 +1,6 @@
 use crate::settings::Settings;
 use crate::violation;
-use crate::{BaseRule, TextRule, Violation};
+use crate::{Rule, TextRule, Violation};
 use lazy_regex::regex_is_match;
 /// Defines rules that govern line length.
 
@@ -8,14 +8,14 @@ pub struct LineTooLong {
     line_length: usize,
 }
 
-impl BaseRule for LineTooLong {
+impl Rule for LineTooLong {
     fn new(settings: &Settings) -> Self {
         LineTooLong {
             line_length: settings.line_length,
         }
     }
 
-    fn explain(&self) -> &str {
+    fn explain(&self) -> &'static str {
         "
         Long lines are more difficult to read, and may not fit on some developers'
         terminals. The line continuation character '&' may be used to split a long line

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -1,23 +1,13 @@
 use crate::settings::Settings;
 use crate::violation;
-use crate::{Method, Rule, Violation};
+use crate::{BaseRule, TextRule, Violation};
 /// Defines rules that enforce widely accepted whitespace rules.
 
 pub struct TrailingWhitespace {}
 
-fn trailing_whitespace(source: &str, _: &Settings) -> Vec<Violation> {
-    let mut violations = Vec::new();
-    for (idx, line) in source.split('\n').enumerate() {
-        if line.ends_with(&[' ', '\t']) {
-            violations.push(violation!("trailing whitespace", idx + 1));
-        }
-    }
-    violations
-}
-
-impl Rule for TrailingWhitespace {
-    fn method(&self) -> Method {
-        Method::Text(trailing_whitespace)
+impl BaseRule for TrailingWhitespace {
+    fn new(_settings: &Settings) -> Self {
+        TrailingWhitespace {}
     }
 
     fn explain(&self) -> &str {
@@ -27,8 +17,16 @@ impl Rule for TrailingWhitespace {
         shared projects.
         "
     }
+}
 
-    fn entrypoints(&self) -> Vec<&str> {
-        vec!["TEXT"]
+impl TextRule for TrailingWhitespace {
+    fn check(&self, source: &str) -> Vec<Violation> {
+        let mut violations = Vec::new();
+        for (idx, line) in source.split('\n').enumerate() {
+            if line.ends_with(&[' ', '\t']) {
+                violations.push(violation!("trailing whitespace", idx + 1));
+            }
+        }
+        violations
     }
 }

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -1,16 +1,16 @@
 use crate::settings::Settings;
 use crate::violation;
-use crate::{BaseRule, TextRule, Violation};
+use crate::{Rule, TextRule, Violation};
 /// Defines rules that enforce widely accepted whitespace rules.
 
 pub struct TrailingWhitespace {}
 
-impl BaseRule for TrailingWhitespace {
+impl Rule for TrailingWhitespace {
     fn new(_settings: &Settings) -> Self {
         TrailingWhitespace {}
     }
 
-    fn explain(&self) -> &str {
+    fn explain(&self) -> &'static str {
         "
         Trailing whitespace is difficult to spot, and as some editors will remove it
         automatically while others leave it, it can cause unwanted 'diff noise' in


### PR DESCRIPTION

Rewrites a lot of fundamental components of the project. Changes include:

- Remove `Code` struct, just use string literals instead.
- Remove `Method` enum, replace with new traits for each rule type:
  - `PathRule`
  - `TextRule`
  - `ASTRule`
- Define rule functions on the object, instead of the object returning a function
- Remove `entrypoints()` function on non-AST rules
- Define rules only once in `src/rules/mod.rs`, generate all necessary data structures with macros
- Clean up `check.rs`
