### PR TITLE
Update tree-sitter-fortran to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,8 +353,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-fortran"
-version = "0.0.1"
-source = "git+https://github.com/ZedThree/tree-sitter-fortran?branch=kind-and-sizes#fba22c0c71b73e77f4b67abf5c99a0ce4990a48f"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d655214a848bfb63dfdc2e7eeef5c3c323807a220b3117a1aef46b2bb95a12"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,23 +341,30 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.22.6"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
+checksum = "20f4cd3642c47a85052a887d86704f4eac272969f61b686bdd3f772122aabaff"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-fortran"
 version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e656a324e086c1cbe979d8d29df16d5413ebef2073681c80a97a1ecd83d9131"
+source = "git+https://github.com/ZedThree/tree-sitter-fortran?branch=kind-and-sizes#fba22c0c71b73e77f4b67abf5c99a0ce4990a48f"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ lazy-regex = "3.3.0"
 lazy_static = "1.5.0"
 textwrap = "0.16.0"
 tree-sitter = "~0.23.0"
-tree-sitter-fortran = { git = "https://github.com/ZedThree/tree-sitter-fortran", branch = "kind-and-sizes" }
+tree-sitter-fortran = "0.1.0"
 walkdir = "2.4.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ itertools = "0.12.0"
 lazy-regex = "3.3.0"
 lazy_static = "1.5.0"
 textwrap = "0.16.0"
-tree-sitter = "~0.22.6"
-tree-sitter-fortran = "0.0.1"
+tree-sitter = "~0.23.0"
+tree-sitter-fortran = { git = "https://github.com/ZedThree/tree-sitter-fortran", branch = "kind-and-sizes" }
 walkdir = "2.4.0"
 
 [dev-dependencies]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -11,7 +11,7 @@ lazy_static! {
         parser
             .lock()
             .unwrap()
-            .set_language(&tree_sitter_fortran::language())
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
             .expect("Error loading Fortran grammar");
         parser
     };

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -1,7 +1,6 @@
 use crate::ast::{child_with_name, dtype_is_plain_number, parse_intrinsic_type, to_text};
 use crate::settings::Settings;
 use crate::{ASTRule, Rule, Violation};
-use lazy_regex::regex_is_match;
 use tree_sitter::Node;
 /// Defines rules that discourage the use of raw number literals as kinds, as this can result in
 /// non-portable code.
@@ -74,29 +73,55 @@ impl Rule for LiteralKind {
 impl ASTRule for LiteralKind {
     fn check(&self, node: &Node, src: &str) -> Option<Violation> {
         let dtype = parse_intrinsic_type(node)?;
-        if dtype_is_plain_number(dtype.as_str()) {
-            if let Some(child) = child_with_name(node, "size") {
-                let txt = to_text(&child, src)?;
-                // Match for numbers that aren't preceeded by:
-                // - Letters: don't want to catch things like real64
-                // - Other numbers: again, shouldn't catch real64
-                // - Underscores: could be part of parameter name
-                // - "*": 'star kinds' are caught by a different rule
-                if regex_is_match!(r"[^A-z0-9_\*]\d", txt) {
-                    let msg = format!(
-                        "{} kind set with number literal, use 'iso_fortran_env' parameter",
-                        dtype,
-                    );
-                    return Some(Violation::from_node(&msg, node));
-                }
-            }
+        // TODO: Deal with characters
+        if !dtype_is_plain_number(dtype.as_str()) {
+            return None;
         }
-        None
+
+        let type_node = node.child_by_field_name("type")?;
+        let kind_node = type_node.child_by_field_name("kind")?;
+        let literal_value = integer_literal_kind(&kind_node, &src)?;
+        // TODO: Can we recommend the "correct" size? Although
+        // non-standard, `real*8` _usually_ means `real(real64)`
+        let msg = format!(
+            "{} kind set with number literal '{}', use 'iso_fortran_env' parameter",
+            dtype,
+            to_text(&literal_value, src)?
+        );
+        Some(Violation::from_node(&msg, &literal_value))
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {
         vec!["variable_declaration", "function_statement"]
     }
+}
+
+/// Return any kind spec that is a number literal
+fn integer_literal_kind<'a>(node: &'a Node, src: &str) -> Option<Node<'a>> {
+    if let Some(literal) = child_with_name(&node, "number_literal") {
+        return Some(literal);
+    }
+
+    for child in node.named_children(&mut node.walk()) {
+        if child.kind() == "number_literal" {
+            return Some(child);
+        }
+
+        if child.kind() != "keyword_argument" {
+            continue;
+        }
+
+        // find instances of `kind=8` etc
+        let name = child.child_by_field_name("name")?;
+        if to_text(&name, src)?.to_lowercase() != "kind" {
+            continue;
+        }
+        let value = child.child_by_field_name("value")?;
+        if value.kind() == "number_literal" {
+            return Some(value);
+        }
+    }
+    None
 }
 
 pub struct LiteralKindSuffix {}
@@ -135,15 +160,16 @@ impl Rule for LiteralKindSuffix {
 
 impl ASTRule for LiteralKindSuffix {
     fn check(&self, node: &Node, src: &str) -> Option<Violation> {
-        let txt = to_text(node, src)?;
-        if regex_is_match!(r"_\d+$", txt) {
-            let msg = format!(
-                "{} has literal suffix, use 'iso_fortran_env' parameter",
-                txt,
-            );
-            return Some(Violation::from_node(&msg, node));
+        let kind = node.child_by_field_name("kind")?;
+        if kind.kind() != "number_literal" {
+            return None;
         }
-        None
+        let msg = format!(
+            "'{}' has literal suffix '{}', use 'iso_fortran_env' parameter",
+            to_text(node, src)?,
+            to_text(&kind, src)?,
+        );
+        Some(Violation::from_node(&msg, &kind))
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {
@@ -191,18 +217,18 @@ mod tests {
             ",
         );
         let expected: Vec<Violation> = [
-            (2, 1, "integer"),
-            (4, 3, "integer"),
-            (6, 3, "logical"),
-            (16, 3, "real"),
-            (17, 3, "complex"),
-            (24, 3, "complex"),
+            (2, 9, "integer", 8),
+            (4, 16, "integer", 2),
+            (6, 16, "logical", 4),
+            (16, 8, "real", 8),
+            (17, 11, "complex", 4),
+            (24, 16, "complex", 4),
         ]
         .iter()
-        .map(|(line, col, kind)| {
+        .map(|(line, col, kind, literal)| {
             let msg = format!(
-                "{} kind set with number literal, use 'iso_fortran_env' parameter",
-                kind,
+                "{} kind set with number literal '{}', use 'iso_fortran_env' parameter",
+                kind, literal
             );
             violation!(&msg, *line, *col)
         })
@@ -226,12 +252,12 @@ mod tests {
             real(sp), parameter :: x5 = 2.468_sp
             ",
         );
-        let expected: Vec<Violation> = [(4, 29, "1.234567_4"), (7, 29, "9.876_8")]
+        let expected: Vec<Violation> = [(4, 38, "1.234567_4", "4"), (7, 35, "9.876_8", "8")]
             .iter()
-            .map(|(line, col, num)| {
+            .map(|(line, col, num, kind)| {
                 let msg = format!(
-                    "{} has literal suffix, use 'iso_fortran_env' parameter",
-                    num,
+                    "'{}' has literal suffix '{}', use 'iso_fortran_env' parameter",
+                    num, kind
                 );
                 violation!(&msg, *line, *col)
             })

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -84,8 +84,7 @@ impl ASTRule for LiteralKind {
         // TODO: Can we recommend the "correct" size? Although
         // non-standard, `real*8` _usually_ means `real(real64)`
         let msg = format!(
-            "{} kind set with number literal '{}', use 'iso_fortran_env' parameter",
-            dtype,
+            "{dtype} kind set with number literal '{}', use 'iso_fortran_env' parameter",
             to_text(&literal_value, src)?
         );
         Some(Violation::from_node(&msg, &literal_value))
@@ -227,8 +226,7 @@ mod tests {
         .iter()
         .map(|(line, col, kind, literal)| {
             let msg = format!(
-                "{} kind set with number literal '{}', use 'iso_fortran_env' parameter",
-                kind, literal
+                "{kind} kind set with number literal '{literal}', use 'iso_fortran_env' parameter",
             );
             violation!(&msg, *line, *col)
         })
@@ -256,8 +254,7 @@ mod tests {
             .iter()
             .map(|(line, col, num, kind)| {
                 let msg = format!(
-                    "'{}' has literal suffix '{}', use 'iso_fortran_env' parameter",
-                    num, kind
+                    "'{num}' has literal suffix '{kind}', use 'iso_fortran_env' parameter",
                 );
                 violation!(&msg, *line, *col)
             })

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -3,7 +3,6 @@ use crate::ast::{
 };
 use crate::settings::Settings;
 use crate::{ASTRule, Rule, Violation};
-use lazy_regex::regex_captures;
 use tree_sitter::Node;
 /// Defines rules that discourage the use of the non-standard kind specifiers such as
 /// `int*4` or `real*8`. Also prefers the use of `character(len=*)` to
@@ -31,25 +30,25 @@ impl Rule for StarKind {
 impl ASTRule for StarKind {
     fn check(&self, node: &Node, src: &str) -> Option<Violation> {
         let dtype = parse_intrinsic_type(node)?;
-        if dtype_is_plain_number(dtype.as_str()) {
-            if let Some(child) = child_with_name(node, "size") {
-                let size = strip_line_breaks(to_text(&child, src)?);
-                // Match anything beginning with a '*' followed by any amount of
-                // whitespace and some digits. Parameters like real64 aren't
-                // allowed in this syntax, so we don't need to worry about them.
-                if let Some((_, kind)) = regex_captures!(r"^\*\s*(\d+)", size.as_str()) {
-                    let msg = format!(
-                        "{}{} is non-standard, use {}({})",
-                        dtype,
-                        size.replace(" ", "").replace("\t", ""),
-                        dtype,
-                        kind,
-                    );
-                    return Some(Violation::from_node(&msg, node));
-                }
-            }
+        // TODO: Handle characters
+        if !dtype_is_plain_number(dtype.as_str()) {
+            return None;
         }
-        None
+        let type_node = node.child_by_field_name("type")?;
+        let kind_node = type_node.child_by_field_name("kind")?;
+        let size = to_text(&kind_node, src)?;
+        if !size.starts_with('*') {
+            return None;
+        }
+
+        // Tidy up the kind spec so it's just e.g. '*8'
+        let size = strip_line_breaks(size).replace(" ", "").replace("\t", "");
+
+        let literal = child_with_name(&kind_node, "number_literal")?;
+        let kind = to_text(&literal, &src)?;
+        // TODO: Better suggestion, rather than use integer literal
+        let msg = format!("{}{} is non-standard, use {}({})", dtype, size, dtype, kind);
+        return Some(Violation::from_node(&msg, &kind_node));
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {
@@ -76,28 +75,29 @@ mod tests {
               real    * &
                8 :: t
 
-              if (x) then
+              if (x == 2) then
                 add_if = x + y
               else
                 add_if = x
               end if
             end function
 
-            subroutine complex_mul(x, y)
+            subroutine complex_mul(x, real)
               real * 4, intent(in) :: x
-              complex  *  8, intent(inout) :: y
-              y = y * x
+              complex  *  8, intent(inout) :: real
+              ! This would be a false positive with purely regexp based linting
+              real = real * 8
             end subroutine
             ",
         );
 
         let expected: Vec<Violation> = [
-            (2, 1, "integer*8", "integer(8)"),
-            (4, 3, "integer*4", "integer(4)"),
-            (5, 3, "logical*4", "logical(4)"),
-            (6, 3, "real*8", "real(8)"),
-            (17, 3, "real*4", "real(4)"),
-            (18, 3, "complex*8", "complex(8)"),
+            (2, 8, "integer*8", "integer(8)"),
+            (4, 11, "integer*4", "integer(4)"),
+            (5, 10, "logical*4", "logical(4)"),
+            (6, 11, "real*8", "real(8)"),
+            (17, 8, "real*4", "real(4)"),
+            (18, 12, "complex*8", "complex(8)"),
         ]
         .iter()
         .map(|(line, col, from, to)| {

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -47,7 +47,7 @@ impl ASTRule for StarKind {
         let literal = child_with_name(&kind_node, "number_literal")?;
         let kind = to_text(&literal, &src)?;
         // TODO: Better suggestion, rather than use integer literal
-        let msg = format!("{}{} is non-standard, use {}({})", dtype, size, dtype, kind);
+        let msg = format!("{dtype}{size} is non-standard, use {dtype}({kind})");
         return Some(Violation::from_node(&msg, &kind_node));
     }
 
@@ -101,7 +101,7 @@ mod tests {
         ]
         .iter()
         .map(|(line, col, from, to)| {
-            let msg = format!("{} is non-standard, use {}", from, to);
+            let msg = format!("{from} is non-standard, use {to}");
             violation!(&msg, *line, *col)
         })
         .collect();


### PR DESCRIPTION
Mostly fine, except some breaking changes for the literal kind detection.

Starting to get my head around the rust ts bindings. Worked out that we can write:


```rust
if let Some(foo) = <something> {
  ...
}
```

as just:

```rust
let foo = <something>?;
```

More straight-line code, less indentation! That's the power of monads! or something