### PR TITLE
Fix clippy warning, update pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,7 +16,7 @@ if [ $? != "0" ]; then
 fi
 
 echo "Linting Rust..."
-cargo clippy
+cargo clippy --all-targets --all-features -- -Dwarnings
 if [ $? != "0" ]; then
   echo "Found Rust linter errors, fix all reported by 'cargo clippy' and try again"
   echo $caveat

--- a/src/rules/typing/intent.rs
+++ b/src/rules/typing/intent.rs
@@ -143,7 +143,7 @@ mod tests {
         })
         .collect();
         let rule = MissingIntent::new(&default_settings());
-        let actual = rule.apply(&source.as_str())?;
+        let actual = rule.apply(source.as_str())?;
         assert_eq!(actual, expected);
         Ok(())
     }


### PR DESCRIPTION
Fixes a single missed Clippy warning from https://github.com/PlasmaFAIR/fortitude/pull/50 and https://github.com/PlasmaFAIR/fortitude/pull/51.

Updates pre-commit hook to catch warnings in tests and upgrade warnings to errors.