### PR TITLE
Add rule for missing label on `exit`/`cycle`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -93,7 +93,8 @@ impl<'a> Iterator for DepthFirstIteratorExcept<'a> {
     }
 }
 
-/// Iterate over all nodes beneath the current node in a depth-first manner.
+/// Iterate over all nodes beneath the current node in a depth-first manner, never going deeper
+/// than any node types in the exceptions list.
 pub fn descendants_except<'a, I>(node: &'a Node, exceptions: I) -> impl Iterator<Item = Node<'a>>
 where
     I: IntoIterator<Item = &'a str>,
@@ -109,7 +110,8 @@ where
     }
 }
 
-/// Iterate over all named nodes beneath the current node in a depth-first manner.
+/// Iterate over all nodes beneath the current node in a depth-first manner, never going deeper
+/// than any node types in the exceptions list.
 pub fn named_descendants_except<'a, I>(
     node: &'a Node,
     exceptions: I,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 /// Contains methods to parse Fortran code into a tree-sitter Tree and utilites to simplify the
 /// navigation of a Tree.
 use std::sync::Mutex;
-use tree_sitter::{Node, Parser, Tree, TreeCursor};
+use tree_sitter::{Language, Node, Parser, Tree, TreeCursor};
 
 lazy_static! {
     static ref PARSER: Mutex<Parser> = {
@@ -24,6 +24,11 @@ pub fn parse<S: AsRef<str>>(source: S) -> anyhow::Result<Tree> {
         .unwrap()
         .parse(source.as_ref(), None)
         .context("Failed to parse")
+}
+
+/// Access the language of the parser.
+pub fn language() -> Language {
+    PARSER.lock().unwrap().language().unwrap()
 }
 
 pub struct DepthFirstIterator<'a> {
@@ -59,6 +64,60 @@ pub fn descendants<'a>(node: &'a Node) -> impl Iterator<Item = Node<'a>> {
 /// Iterate over all named nodes beneath the current node in a depth-first manner.
 pub fn named_descendants<'a>(node: &'a Node) -> impl Iterator<Item = Node<'a>> {
     descendants(node).filter(|&x| x.is_named())
+}
+
+pub struct DepthFirstIteratorExcept<'a> {
+    cursor: TreeCursor<'a>,
+    exceptions: Vec<u16>,
+}
+
+impl<'a> Iterator for DepthFirstIteratorExcept<'a> {
+    type Item = Node<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // ignore exception list if we're at a depth of 0
+        if (self.cursor.depth() == 0 || !self.exceptions.contains(&self.cursor.node().kind_id()))
+            && self.cursor.goto_first_child()
+        {
+            return Some(self.cursor.node());
+        }
+        if self.cursor.goto_next_sibling() {
+            return Some(self.cursor.node());
+        }
+        while self.cursor.goto_parent() {
+            if self.cursor.goto_next_sibling() {
+                return Some(self.cursor.node());
+            }
+        }
+        None
+    }
+}
+
+/// Iterate over all nodes beneath the current node in a depth-first manner.
+pub fn descendants_except<'a, I>(node: &'a Node, exceptions: I) -> impl Iterator<Item = Node<'a>>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let lang = language();
+    let exception_ids: Vec<_> = exceptions
+        .into_iter()
+        .map(|x| lang.id_for_node_kind(x, true))
+        .collect();
+    DepthFirstIteratorExcept {
+        cursor: node.walk(),
+        exceptions: exception_ids,
+    }
+}
+
+/// Iterate over all named nodes beneath the current node in a depth-first manner.
+pub fn named_descendants_except<'a, I>(
+    node: &'a Node,
+    exceptions: I,
+) -> impl Iterator<Item = Node<'a>>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    descendants_except(node, exceptions).filter(|&x| x.is_named())
 }
 
 pub struct AncestorsIterator<'a> {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -13,6 +13,7 @@ register_rules! {
     (Category::Error, "E001", AST, error::syntax_error::SyntaxError, SyntaxError),
     (Category::Filesystem, "F001", PATH, filesystem::extensions::NonStandardFileExtension, NonStandardFileExtension),
     (Category::Style, "S001", TEXT, style::line_length::LineTooLong, LineTooLong),
+    (Category::Style, "S021", AST, style::exit_labels::MissingExitOrCycleLabel, MissingExitOrCycleLabel),
     (Category::Style, "S041", AST, style::old_style_array_literal::OldStyleArrayLiteral, OldStyleArrayLiteral),
     (Category::Style, "S101", TEXT, style::whitespace::TrailingWhitespace, TrailingWhitespace),
     (Category::Typing, "T001", AST, typing::implicit_typing::ImplicitTyping, ImplicitTyping),

--- a/src/rules/style/exit_labels.rs
+++ b/src/rules/style/exit_labels.rs
@@ -1,0 +1,130 @@
+use crate::ast::{child_with_name, named_descendants, to_text};
+use crate::settings::Settings;
+use crate::{ASTRule, Rule, Violation};
+use tree_sitter::Node;
+
+pub struct MissingExitOrCycleLabel {}
+
+impl Rule for MissingExitOrCycleLabel {
+    fn new(_settings: &Settings) -> Self {
+        Self {}
+    }
+
+    fn explain(&self) -> &'static str {
+        "
+        When using `exit` or `cycle` in a named `do` loop, the `exit`/`cycle` statement
+        should use the loop name
+
+        ```
+        name: do
+          exit name
+        end do name
+        ```
+
+        Using named loops is particularly useful for nested or complicated loops, as it
+        helps the reader keep track of the flow of logic. It's also the only way to `exit`
+        or `cycle` outer loops from within inner ones.
+        "
+    }
+}
+
+impl ASTRule for MissingExitOrCycleLabel {
+    fn check<'a>(&self, node: &'a Node, src: &'a str) -> Option<Vec<Violation>> {
+        // Skip unlabelled loops
+        child_with_name(node, "block_label_start_expression")?;
+
+        let violations: Vec<Violation> = named_descendants(node)
+            .filter(|node| node.kind() == "keyword_statement")
+            .map(|stmt| (stmt, to_text(&stmt, src).unwrap_or_default().to_lowercase()))
+            .filter(|(_, name)| name == "exit" || name == "cycle")
+            .map(|(stmt, name)| {
+                let msg = format!("'{name}' statement in named 'do' loop missing label");
+                Violation::from_node(msg, &stmt)
+            })
+            .collect();
+
+        Some(violations)
+    }
+
+    fn entrypoints(&self) -> Vec<&'static str> {
+        vec!["do_loop_statement"]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::default_settings;
+    use crate::violation;
+    use pretty_assertions::assert_eq;
+    use textwrap::dedent;
+
+    #[test]
+    fn test_missing_exit_label() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            program test
+              label1: do
+                if (.true.) then
+                  EXIT
+                end if
+              end do label1
+
+              label2: do
+                if (.true.) exit
+              end do label2
+
+              label3: do
+                exit label3
+              end do label3
+
+              label4: do
+                if (.true.) exit label4
+              end do label4
+
+              label5: do i = 1, 2
+                do j = 1, 2  ! unnamed inner loop
+                  cycle
+                end do
+              end do label5
+
+              label6: do i = 1, 2
+                inner: do j = 1, 2
+                  if (.true.) CYCLE ! named inner loop: currently get two warnings
+                end do inner
+              end do label6
+
+              label7: do
+                cycle label7
+              end do label7
+
+              label8: do
+                if (.true.) cycle label8
+              end do label8
+
+              do
+                ! Don't warn on unnamed loops
+                exit
+              end do
+            end program test
+            ",
+        );
+        let expected: Vec<Violation> = [
+            (5, 7, "exit"),
+            (10, 17, "exit"),
+            (23, 7, "cycle"),
+            (29, 19, "cycle"),
+            (29, 19, "cycle"), // Ideally don't get this one
+        ]
+        .iter()
+        .map(|(line, col, stmt_kind)| {
+            let msg = format!("'{stmt_kind}' statement in named 'do' loop missing label");
+            violation!(msg, *line, *col)
+        })
+        .collect();
+        let rule = MissingExitOrCycleLabel::new(&default_settings());
+        let actual = rule.apply(source.as_str())?;
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+}

--- a/src/rules/style/mod.rs
+++ b/src/rules/style/mod.rs
@@ -1,3 +1,4 @@
+pub mod exit_labels;
 pub mod line_length;
 pub mod old_style_array_literal;
 pub mod whitespace;


### PR DESCRIPTION
Mostly following the equivalent rule in `stylist` except:

- also capture `cycle` as well as `exit`
- only applies to `do` loops with a name
- unfortunately, warns twice for unlabelled `exit/`cycle` in nested loops

Last point could probably be fixed with some more sophisticated logic: walking the tree, and only descending into non-`do` nodes. Then I think we'd be able to confidently suggest the correct label for a fix.

Second point could be turned into another rule: `exit`/`cycle` in nested loops should be labelled.

Also, I've just put this into the "style" category, but I'm not sure that's completely appropriate. Maybe we need some community input into the categorisation of rules.