### PR TITLE
Add rule for initialisation in declarations

### DIFF
--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -24,6 +24,7 @@ register_rules! {
     (Category::Typing, "T021", AST, typing::star_kinds::StarKind, StarKind),
     (Category::Typing, "T031", AST, typing::intent::MissingIntent, MissingIntent),
     (Category::Typing, "T041", AST, typing::assumed_size::AssumedSize, AssumedSize),
+    (Category::Typing, "T051", AST, typing::init_decls::InitialisationInDeclaration, InitialisationInDeclaration),
     (Category::Precision, "P001", AST, precision::kind_suffixes::NoRealSuffix, NoRealSuffix),
     (Category::Precision, "P011", AST, precision::double_precision::DoublePrecision, DoublePrecision),
     (Category::Modules, "M001", AST, modules::external_functions::ExternalFunction, ExternalFunction),

--- a/src/rules/typing/init_decls.rs
+++ b/src/rules/typing/init_decls.rs
@@ -1,0 +1,157 @@
+use crate::ast::FortitudeNode;
+use crate::settings::Settings;
+use crate::{ASTRule, Rule, Violation};
+use tree_sitter::Node;
+
+/// Rules for catching assumed size variables
+
+pub struct InitialisationInDeclaration {}
+
+impl Rule for InitialisationInDeclaration {
+    fn new(_settings: &Settings) -> Self {
+        InitialisationInDeclaration {}
+    }
+
+    fn explain(&self) -> &'static str {
+        "
+        Initialising procedure local variables in their declaration gives them an
+        implicit `save` attribute: the initialisation is only done on the first call
+        to the procedure, and the variable retains its value on exit.
+
+        For example, this subroutine:
+
+        ```
+        subroutine example()
+          integer :: var = 1
+          print*, var
+          var = var + 1
+        end subroutine example
+        ```
+
+        when called twice:
+
+        ```
+        call example()
+        call example()
+        ```
+
+        prints `1 2`, when it might be expected to print `1 1`.
+
+        Adding the `save` attribute makes it clear that this is the intention:
+
+        ```
+        subroutine example()
+          integer, save :: var = 1
+          print*, var
+          var = var + 1
+        end subroutine example
+        ```
+
+        Unfortunately, in Fortran there is no way to disable this behaviour, and so if it
+        is not intended, it's necessary to have a separate assignment statement:
+
+        ```
+        subroutine example()
+          integer :: var
+          var = 1
+          print*, var
+          var = var + 1
+        end subroutine example
+        ```
+
+        If the variable's value is intended to be constant, then use the `parameter`
+        attribute instead:
+
+        ```
+        subroutine example()
+          integer, parameter :: var = 1
+          print*, var
+        end subroutine example
+        ```
+        "
+    }
+}
+
+impl ASTRule for InitialisationInDeclaration {
+    fn check(&self, node: &Node, src: &str) -> Option<Vec<Violation>> {
+        // Only check in procedures
+        node.ancestors().find(|parent| {
+            ["function", "subroutine", "module_procedure"].contains(&parent.kind())
+        })?;
+
+        let declaration = node
+            .ancestors()
+            .find(|parent| parent.kind() == "variable_declaration")?;
+
+        // Init in declaration ok for save and parameter
+        if declaration
+            .children_by_field_name("attribute", &mut declaration.walk())
+            .filter_map(|attr| attr.to_text(src))
+            .any(|attr_name| ["save", "parameter"].contains(&attr_name.to_lowercase().as_str()))
+        {
+            return None;
+        }
+
+        let name = node.child_by_field_name("left")?.to_text(src)?;
+        let msg = format!("'{name}' is initialised in its declaration and has no explicit `save` or `parameter` attribute");
+        some_vec![Violation::from_node(msg, node)]
+    }
+
+    fn entrypoints(&self) -> Vec<&'static str> {
+        vec!["init_declarator"]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::default_settings;
+    use crate::violation;
+    use pretty_assertions::assert_eq;
+    use textwrap::dedent;
+
+    #[test]
+    fn test_init_decl() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            module test
+              integer :: global = 0  ! Ok at module level
+
+              type :: my_type
+                integer :: component = 1  ! Ok in types
+              end type
+            contains
+
+            subroutine init_decl1()
+              integer :: foo = 1
+            end subroutine init_decl1
+
+            subroutine init_decl2()
+              integer, save :: foo = 1  ! Ok with explicit save
+              integer, parameter :: bar = 2  ! Ok as parameter
+            end subroutine init_decl2
+
+            subroutine init_decl3()
+              integer :: foo, bar = 1, quazz, zapp = 2
+            end subroutine no_init_decl3
+
+            end module test
+            ",
+        );
+        let expected: Vec<Violation> = [
+            (11, 14, "foo"),
+            (20, 19, "bar"),
+            (20, 35, "zapp"),
+        ]
+        .iter()
+        .map(|(line, col, variable)| {
+            let msg = format!("'{variable}' is initialised in its declaration and has no explicit `save` or `parameter` attribute");
+            violation!(&msg, *line, *col)
+        })
+        .collect();
+        let rule = InitialisationInDeclaration::new(&default_settings());
+        let actual = rule.apply(source.as_str())?;
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+}

--- a/src/rules/typing/mod.rs
+++ b/src/rules/typing/mod.rs
@@ -1,5 +1,6 @@
 pub mod assumed_size;
 pub mod implicit_typing;
+pub mod init_decls;
 pub mod intent;
 pub mod literal_kinds;
 pub mod star_kinds;


### PR DESCRIPTION
Closes #60

The explanation is longer than the check!

Might be useful to pull out the "attributes as text" bit into a method on the `FortitudeNode` trait, as it's used in a couple of rules now. Maybe also the "find a specific parent" too