### PR TITLE
Add rule for deprecated relational operators

### DIFF
--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -15,7 +15,7 @@ register_rules! {
     (Category::Style, "S001", TEXT, style::line_length::LineTooLong, LineTooLong),
     (Category::Style, "S021", AST, style::exit_labels::MissingExitOrCycleLabel, MissingExitOrCycleLabel),
     (Category::Style, "S041", AST, style::old_style_array_literal::OldStyleArrayLiteral, OldStyleArrayLiteral),
-    (Category::Style, "S051", AST, style::relational_symbols::RelationalSymbol, RelationalSymbol),
+    (Category::Style, "S051", AST, style::relational_operators::DeprecatedRelationalOperator, DeprecatedRelationalOperator),
     (Category::Style, "S101", TEXT, style::whitespace::TrailingWhitespace, TrailingWhitespace),
     (Category::Typing, "T001", AST, typing::implicit_typing::ImplicitTyping, ImplicitTyping),
     (Category::Typing, "T002", AST, typing::implicit_typing::InterfaceImplicitTyping, InterfaceImplicitTyping),

--- a/src/rules/style/mod.rs
+++ b/src/rules/style/mod.rs
@@ -1,5 +1,5 @@
 pub mod exit_labels;
 pub mod line_length;
 pub mod old_style_array_literal;
-pub mod relational_symbols;
+pub mod relational_operators;
 pub mod whitespace;


### PR DESCRIPTION
Closes #63 

One more easy rule for 0.3.0! Explanation could do with a little work though