### PR TITLE
Add ranges to `Violation`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,8 @@ dependencies = [
  "lazy-regex",
  "lazy_static",
  "pretty_assertions",
+ "ruff_source_file",
+ "ruff_text_size",
  "textwrap",
  "tree-sitter",
  "tree-sitter-fortran",
@@ -289,6 +291,21 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "ruff_source_file"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.6.8#ae39ce56c0cc1f8ac15f980c0b457b16b67c1f2a"
+dependencies = [
+ "memchr",
+ "once_cell",
+ "ruff_text_size",
+]
+
+[[package]]
+name = "ruff_text_size"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.6.8#ae39ce56c0cc1f8ac15f980c0b457b16b67c1f2a"
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ colored = "2.1.0"
 itertools = "0.12.0"
 lazy-regex = "3.3.0"
 lazy_static = "1.5.0"
+ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.6.8", version = "0.0.0" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.6.8", version = "0.0.0" }
 textwrap = "0.16.0"
 tree-sitter = "~0.23.0"
 tree-sitter-fortran = "0.1.0"

--- a/src/check.rs
+++ b/src/check.rs
@@ -104,7 +104,7 @@ fn check_file(
     for node in tree.root_node().named_descendants() {
         if let Some(rules) = ast_entrypoints.get(node.kind()) {
             for (code, rule) in rules {
-                if let Some(violation) = rule.check(&node, file.source_text()) {
+                if let Some(violation) = rule.check(&node, &file) {
                     for v in violation {
                         violations.push((code.to_string(), v));
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,12 @@ mod settings;
 use annotate_snippets::{Level, Renderer, Snippet};
 use ast::{parse, FortitudeNode};
 use colored::{ColoredString, Colorize};
-use ruff_source_file::SourceFile;
+use ruff_source_file::{OneIndexed, SourceFile, SourceLocation};
+use ruff_text_size::{TextRange, TextSize};
 use settings::Settings;
 use std::cmp::Ordering;
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 // Rule categories and identity codes
 // ----------------------------------
@@ -60,7 +61,7 @@ impl Category {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ViolationPosition {
     None,
-    LineCol((usize, usize)),
+    Range(TextRange),
 }
 
 // This type is created when a rule is broken. As not all broken rules come with a
@@ -71,22 +72,41 @@ pub struct Violation {
     /// Description of the error.
     message: String,
     /// The location at which the error was detected.
-    position: ViolationPosition,
+    range: ViolationPosition,
 }
 
 impl Violation {
-    pub fn new<T: AsRef<str>>(message: T, position: ViolationPosition) -> Self {
+    pub fn new<T: AsRef<str>>(message: T, range: ViolationPosition) -> Self {
         Self {
             message: String::from(message.as_ref()),
-            position,
+            range,
         }
     }
 
     pub fn from_node<T: AsRef<str>>(message: T, node: &tree_sitter::Node) -> Self {
-        let position = node.start_position();
         Violation::new(
             message,
-            ViolationPosition::LineCol((position.row + 1, position.column + 1)),
+            ViolationPosition::Range(TextRange::new(
+                TextSize::try_from(node.start_byte()).unwrap(),
+                TextSize::try_from(node.end_byte()).unwrap(),
+            )),
+        )
+    }
+
+    pub fn from_line_start_end_col<T: AsRef<str>>(
+        message: T,
+        source: &SourceFile,
+        line: usize,
+        start_col: usize,
+        end_col: usize,
+    ) -> Self {
+        let source_code = source.to_source_code();
+        let line_offset = source_code.line_start(OneIndexed::from_zero_indexed(line));
+        let start_offset = line_offset + TextSize::try_from(start_col).unwrap();
+        let end_offset = line_offset + TextSize::try_from(end_col).unwrap();
+        Violation::new(
+            message,
+            ViolationPosition::Range(TextRange::new(start_offset, end_offset)),
         )
     }
 
@@ -94,8 +114,8 @@ impl Violation {
         self.message.as_str()
     }
 
-    pub fn position(&self) -> ViolationPosition {
-        self.position
+    pub fn range(&self) -> ViolationPosition {
+        self.range
     }
 }
 
@@ -103,9 +123,6 @@ impl Violation {
 macro_rules! violation {
     ($msg:expr) => {
         $crate::Violation::new($msg, $crate::ViolationPosition::None)
-    };
-    ($msg:expr, $line:expr, $col:expr) => {
-        $crate::Violation::new($msg, $crate::ViolationPosition::LineCol(($line, $col)))
     };
 }
 
@@ -158,145 +175,144 @@ pub trait ASTRule: Rule {
 
 /// Reports of each violation. They are pretty-printable and sortable.
 #[derive(Eq)]
-pub struct Diagnostic {
+pub struct Diagnostic<'a> {
     /// The file where an error was reported.
-    path: PathBuf,
+    file: &'a SourceFile,
     /// The rule code that was violated, expressed as a string.
     code: String,
     /// The specific violation detected
     violation: Violation,
 }
 
-impl Diagnostic {
-    pub fn new<P, S>(path: P, code: S, violation: &Violation) -> Self
+impl<'a> Diagnostic<'a> {
+    pub fn new<S>(file: &'a SourceFile, code: S, violation: &Violation) -> Self
     where
-        P: AsRef<Path>,
         S: AsRef<str>,
     {
         Self {
-            path: path.as_ref().to_path_buf(),
+            file,
             code: code.as_ref().to_string(),
             violation: violation.clone(),
         }
     }
 
-    fn orderable(&self) -> (&Path, usize, usize, &str) {
-        match self.violation.position() {
-            ViolationPosition::None => (self.path.as_path(), 0, 0, self.code.as_str()),
-            ViolationPosition::LineCol((line, col)) => {
-                (self.path.as_path(), line, col, self.code.as_str())
-            }
+    fn orderable(&self) -> (&str, usize, usize, &str) {
+        match self.violation.range() {
+            ViolationPosition::None => (self.file.name(), 0, 0, self.code.as_str()),
+            ViolationPosition::Range(range) => (
+                self.file.name(),
+                range.start().into(),
+                range.end().into(),
+                self.code.as_str(),
+            ),
         }
     }
 }
 
-impl Ord for Diagnostic {
+impl<'a> Ord for Diagnostic<'a> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.orderable().cmp(&other.orderable())
     }
 }
 
-impl PartialOrd for Diagnostic {
+impl<'a> PartialOrd for Diagnostic<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl PartialEq for Diagnostic {
+impl<'a> PartialEq for Diagnostic<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.orderable() == other.orderable()
     }
 }
 
-impl fmt::Display for Diagnostic {
+impl<'a> fmt::Display for Diagnostic<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let path = self.path.to_string_lossy().bold();
+        let path = self.file.name().bold();
         let code = self.code.bold().bright_red();
         let message = self.violation.message();
-        match self.violation.position() {
+        match self.violation.range() {
             ViolationPosition::None => {
                 write!(f, "{}: {} {}", path, code, message)
             }
-            ViolationPosition::LineCol((line, col)) => {
-                format_violation_line_col(self, f, line, col, message, &path, &code)
+            ViolationPosition::Range(range) => {
+                format_violation_line_col(self, f, &range, message, &path, &code)
             }
         }
     }
-}
-
-/// Read filename into vec of strings
-fn read_lines(filename: &PathBuf) -> Vec<String> {
-    std::fs::read_to_string(filename)
-        .unwrap() // panic on possible file-reading errors
-        .lines() // split the string into an iterator of string slices
-        .map(String::from) // make each slice into a string
-        .collect() // gather them together into a vector
 }
 
 fn format_violation_line_col(
     diagnostic: &Diagnostic,
     f: &mut fmt::Formatter,
-    line: usize,
-    col: usize,
+    range: &TextRange,
     message: &str,
     path: &ColoredString,
     code: &ColoredString,
 ) -> fmt::Result {
-    let lines = read_lines(&diagnostic.path);
-    let mut start_index = line.saturating_sub(2).max(1);
+    let source_code = diagnostic.file.to_source_code();
+    let content_start_index = source_code.line_index(range.start());
+    let mut start_index = content_start_index.saturating_sub(2);
 
     // Trim leading empty lines.
-    while start_index < line {
-        if !lines[start_index.saturating_sub(1)].trim().is_empty() {
+    while start_index < content_start_index {
+        if !source_code.line_text(start_index).trim().is_empty() {
             break;
         }
         start_index = start_index.saturating_add(1);
     }
 
-    let mut end_index = line.saturating_add(2).min(lines.len());
+    let content_end_index = source_code.line_index(range.end());
+    let mut end_index = content_end_index
+        .saturating_add(2)
+        .min(OneIndexed::from_zero_indexed(source_code.line_count()));
 
     // Trim leading empty lines.
-    while end_index > line {
-        if !lines[end_index.saturating_sub(1)].trim().is_empty() {
+    while end_index > content_end_index {
+        if !source_code.line_text(end_index).trim().is_empty() {
             break;
         }
         end_index = end_index.saturating_sub(1);
     }
 
-    let content_slice = lines[start_index.saturating_sub(1)..end_index]
-        .iter()
-        .fold(String::default(), |acc, line| format!("{acc}{line}\n"));
+    let start_offset = source_code.line_start(start_index);
+    let end_offset = source_code.line_end(end_index);
 
-    // Annotations are done by offset, so we need to count line
-    // lengths... including the newline character, which doesn't
-    // appear in `lines`!
-    let offset_up_to_line = lines[start_index.saturating_sub(1)..line.saturating_sub(1)]
-        .iter()
-        .fold(0, |acc, line| acc + line.chars().count() + 1);
-
-    // Something really weird going on here, where I can't get it to
-    // put the annotation in the first column: it's either in column 2
-    // or the end of the previous line. But does appear to be right
-    // for other columns!
-    let label_offset = offset_up_to_line + col.saturating_sub(1);
+    let source = source_code.slice(TextRange::new(start_offset, end_offset));
+    let message_range = range - start_offset;
+    
+    let start_char = source[TextRange::up_to(message_range.start())].chars().count();
+    let end_char = source[TextRange::up_to(message_range.end())].chars().count();
 
     // Some annoyance here: we *have* to have some level prefix to our
     // message. Might be fixed in future version of annotate-snippets
     // -- or we use an earlier version with more control.
     // Also, we could use `.origin(path)` to get the filename and
     // line:col automatically, but see above about off-by-one error
-    let message_line = format!("{}:{}:{}: {} {}", path, line, col, code, message);
-    let snippet = Level::Warning.title(&message_line).snippet(
-        Snippet::source(&content_slice)
-            .line_start(start_index)
-            .annotation(
-                Level::Error
-                    .span(label_offset..label_offset.saturating_add(1))
-                    .label(code),
-            ),
+
+    // let message_line = format!("{path}:{st}:{}: {} {}", path, line, col, code, message);
+    let snippet = Level::Warning.title(message).snippet(
+        Snippet::source(source)
+            .origin(path)
+            .line_start(start_index.to_zero_indexed())
+            .annotation(Level::Error.span(start_char..end_char).label(code)),
     );
 
     let renderer = Renderer::styled();
     let source_block = renderer.render(snippet);
     writeln!(f, "{}", source_block)
+}
+
+pub trait SourceLocationToOffset {
+    fn line_location(&self, row: usize, column: u32) -> SourceLocation;
+}
+
+impl SourceLocationToOffset for SourceFile {
+    fn line_location(&self, row: usize, column: u32) -> SourceLocation {
+        let source_code = self.to_source_code();
+        let offset =
+            source_code.line_start(OneIndexed::from_zero_indexed(row)) + TextSize::new(column);
+        source_code.source_location(offset)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,3 +323,12 @@ impl SourceLocationToOffset for SourceFile {
         source_code.source_location(offset)
     }
 }
+
+/// Simplify making a `SourceFile` in tests
+#[cfg(test)]
+pub fn test_file(source: &str) -> SourceFile {
+    use ruff_source_file::SourceFileBuilder;
+    use textwrap::dedent;
+
+    SourceFileBuilder::new("test.f90", dedent(source)).finish()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod settings;
 use annotate_snippets::{Level, Renderer, Snippet};
 use ast::{parse, FortitudeNode};
 use colored::{ColoredString, Colorize};
+use ruff_source_file::SourceFile;
 use settings::Settings;
 use std::cmp::Ordering;
 use std::fmt;
@@ -129,7 +130,7 @@ pub trait PathRule: Rule {
 
 /// Implemented by rules that analyse lines of code directly, using regex or otherwise.
 pub trait TextRule: Rule {
-    fn check(&self, source: &str) -> Vec<Violation>;
+    fn check(&self, source: &SourceFile) -> Vec<Violation>;
 }
 
 /// Implemented by rules that analyse the abstract syntax tree.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,15 +135,15 @@ pub trait TextRule: Rule {
 
 /// Implemented by rules that analyse the abstract syntax tree.
 pub trait ASTRule: Rule {
-    fn check(&self, node: &tree_sitter::Node, source: &str) -> Option<Vec<Violation>>;
+    fn check(&self, node: &tree_sitter::Node, source: &SourceFile) -> Option<Vec<Violation>>;
 
     /// Return list of tree-sitter node types on which a rule should trigger.
     fn entrypoints(&self) -> Vec<&'static str>;
 
     /// Apply a rule over some text, generating all violations raised as a result.
-    fn apply(&self, source: &str) -> anyhow::Result<Vec<Violation>> {
+    fn apply(&self, source: &SourceFile) -> anyhow::Result<Vec<Violation>> {
         let entrypoints = self.entrypoints();
-        Ok(parse(source)?
+        Ok(parse(source.source_text())?
             .root_node()
             .named_descendants()
             .filter(|x| entrypoints.contains(&x.kind()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,17 +93,20 @@ impl Violation {
         )
     }
 
-    pub fn from_line_start_end_col<T: AsRef<str>>(
+    /// Create new `Violation` from zero-index start/end line/column numbers
+    pub fn from_start_end_line_col<T: AsRef<str>>(
         message: T,
         source: &SourceFile,
-        line: usize,
+        start_line: usize,
         start_col: usize,
+        end_line: usize,
         end_col: usize,
     ) -> Self {
         let source_code = source.to_source_code();
-        let line_offset = source_code.line_start(OneIndexed::from_zero_indexed(line));
-        let start_offset = line_offset + TextSize::try_from(start_col).unwrap();
-        let end_offset = line_offset + TextSize::try_from(end_col).unwrap();
+        let start_line_offset = source_code.line_start(OneIndexed::from_zero_indexed(start_line));
+        let start_offset = start_line_offset + TextSize::try_from(start_col).unwrap();
+        let end_line_offset = source_code.line_start(OneIndexed::from_zero_indexed(end_line));
+        let end_offset = end_line_offset + TextSize::try_from(end_col).unwrap();
         Violation::new(
             message,
             ViolationPosition::Range(TextRange::new(start_offset, end_offset)),
@@ -281,9 +284,13 @@ fn format_violation_line_col(
 
     let source = source_code.slice(TextRange::new(start_offset, end_offset));
     let message_range = range - start_offset;
-    
-    let start_char = source[TextRange::up_to(message_range.start())].chars().count();
-    let end_char = source[TextRange::up_to(message_range.end())].chars().count();
+
+    let start_char = source[TextRange::up_to(message_range.start())]
+        .chars()
+        .count();
+    let end_char = source[TextRange::up_to(message_range.end())]
+        .chars()
+        .count();
 
     // Some annoyance here: we *have* to have some level prefix to our
     // message. Might be fixed in future version of annotate-snippets

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,13 +240,13 @@ impl<'a> fmt::Display for Diagnostic<'a> {
                 write!(f, "{}: {} {}", path, code, message)
             }
             ViolationPosition::Range(range) => {
-                format_violation_line_col(self, f, &range, message, &path, &code)
+                format_violation(self, f, &range, message, &path, &code)
             }
         }
     }
 }
 
-fn format_violation_line_col(
+fn format_violation(
     diagnostic: &Diagnostic,
     f: &mut fmt::Formatter,
     range: &TextRange,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,13 +296,13 @@ fn format_violation_line_col(
     // message. Might be fixed in future version of annotate-snippets
     // -- or we use an earlier version with more control.
     // Also, we could use `.origin(path)` to get the filename and
-    // line:col automatically, but see above about off-by-one error
-
-    // let message_line = format!("{path}:{st}:{}: {} {}", path, line, col, code, message);
-    let snippet = Level::Warning.title(message).snippet(
+    // line:col automatically, but there is currently a bug in the
+    // library when annotating the start of the line
+    let SourceLocation { row, column } = source_code.source_location(range.start());
+    let message_line = format!("{path}:{row}:{column}: {code} {message}");
+    let snippet = Level::Warning.title(&message_line).snippet(
         Snippet::source(source)
-            .origin(path)
-            .line_start(start_index.to_zero_indexed())
+            .line_start(start_index.get())
             .annotation(Level::Error.span(start_char..end_char).label(code)),
     );
 

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -1,5 +1,6 @@
 use crate::settings::Settings;
 use crate::{some_vec, ASTRule, Rule, Violation};
+use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// Rules that check for syntax errors.
@@ -25,7 +26,7 @@ impl Rule for SyntaxError {
 }
 
 impl ASTRule for SyntaxError {
-    fn check(&self, node: &Node, _src: &str) -> Option<Vec<Violation>> {
+    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Violation>> {
         some_vec![Violation::from_node("syntax_error", node)]
     }
 

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -43,7 +43,6 @@ impl ASTRule for ExternalFunction {
 mod tests {
     use super::*;
     use crate::settings::default_settings;
-    use crate::violation;
     use pretty_assertions::assert_eq;
     use ruff_source_file::SourceFileBuilder;
     use textwrap::dedent;
@@ -67,11 +66,17 @@ mod tests {
             ),
         )
         .finish();
-        let expected: Vec<Violation> = [(2, 1, "function"), (7, 1, "subroutine")]
+        let expected: Vec<Violation> = [(2, 1, 2, 1, "function"), (7, 1, 7, 1, "subroutine")]
             .iter()
-            .map(|(line, col, kind)| {
-                let msg = format!("{} not contained within (sub)module or program", kind);
-                violation!(&msg, *line, *col)
+            .map(|(start_line, start_col, end_line, end_col, kind)| {
+                Violation::from_start_end_line_col(
+                    format!("{kind} not contained within (sub)module or program"),
+                    &source,
+                    *start_line,
+                    *start_col,
+                    *end_line,
+                    *end_col,
+                )
             })
             .collect();
         let rule = ExternalFunction::new(&default_settings());

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -43,17 +43,13 @@ impl ASTRule for ExternalFunction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_function_not_in_module() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             integer function double(x)
               integer, intent(in) :: x
               double = 2 * x
@@ -64,9 +60,7 @@ mod tests {
               x = 3 * x
             end subroutine
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [(1, 0, 1, 26, "function"), (6, 0, 6, 20, "subroutine")]
             .iter()
             .map(|(start_line, start_col, end_line, end_col, kind)| {
@@ -88,10 +82,8 @@ mod tests {
 
     #[test]
     fn test_function_in_module() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             module my_module
                 implicit none
             contains
@@ -106,9 +98,7 @@ mod tests {
                 end subroutine
             end module
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = vec![];
         let rule = ExternalFunction::new(&default_settings());
         let actual = rule.apply(&source)?;

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -29,7 +29,8 @@ impl ASTRule for ExternalFunction {
                 "{} not contained within (sub)module or program",
                 node.kind()
             );
-            return some_vec![Violation::from_node(msg, node)];
+            let procedure_stmt = node.child(0)?;
+            return some_vec![Violation::from_node(msg, &procedure_stmt)];
         }
         None
     }
@@ -66,7 +67,7 @@ mod tests {
             ),
         )
         .finish();
-        let expected: Vec<Violation> = [(2, 1, 2, 1, "function"), (7, 1, 7, 1, "subroutine")]
+        let expected: Vec<Violation> = [(1, 0, 1, 26, "function"), (6, 0, 6, 20, "subroutine")]
             .iter()
             .map(|(start_line, start_col, end_line, end_col, kind)| {
                 Violation::from_start_end_line_col(

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -53,7 +53,6 @@ impl ASTRule for UseAll {
 mod tests {
     use super::*;
     use crate::settings::default_settings;
-    use crate::violation;
     use pretty_assertions::assert_eq;
     use ruff_source_file::SourceFileBuilder;
     use textwrap::dedent;
@@ -72,7 +71,14 @@ mod tests {
             ),
         )
         .finish();
-        let expected = vec![violation!("'use' statement missing 'only' clause", 4, 5)];
+        let expected = vec![Violation::from_start_end_line_col(
+            "'use' statement missing 'only' clause",
+            &source,
+            3,
+            4,
+            3,
+            35,
+        )];
         let rule = UseAll::new(&default_settings());
         let actual = rule.apply(&source)?;
         assert_eq!(actual, expected);

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -52,25 +52,19 @@ impl ASTRule for UseAll {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_use_all() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             module my_module
                 use, intrinsic :: iso_fortran_env, only: real32
                 use, intrinsic :: iso_c_binding
             end module
             ",
-            ),
-        )
-        .finish();
+        );
         let expected = vec![Violation::from_start_end_line_col(
             "'use' statement missing 'only' clause",
             &source,

--- a/src/rules/precision/double_precision.rs
+++ b/src/rules/precision/double_precision.rs
@@ -60,17 +60,13 @@ impl ASTRule for DoublePrecision {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_double_precision() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             double precision function double(x)
               double precision, intent(in) :: x
               double = 2 * x
@@ -88,9 +84,7 @@ mod tests {
               complex_mul = x * y
             end function
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (1, 0, 1, 16, "double precision"),
             (2, 2, 2, 18, "double precision"),

--- a/src/rules/precision/double_precision.rs
+++ b/src/rules/precision/double_precision.rs
@@ -61,7 +61,6 @@ impl ASTRule for DoublePrecision {
 mod tests {
     use super::*;
     use crate::settings::default_settings;
-    use crate::violation;
     use pretty_assertions::assert_eq;
     use ruff_source_file::SourceFileBuilder;
     use textwrap::dedent;
@@ -93,17 +92,23 @@ mod tests {
         )
         .finish();
         let expected: Vec<Violation> = [
-            (2, 1, "double precision"),
-            (3, 3, "double precision"),
-            (8, 3, "double precision"),
-            (13, 3, "double precision"),
-            (14, 3, "double complex"),
-            (15, 3, "double complex"),
+            (1, 0, 1, 16, "double precision"),
+            (2, 2, 2, 18, "double precision"),
+            (7, 2, 7, 18, "double precision"),
+            (12, 2, 12, 18, "double precision"),
+            (13, 2, 13, 16, "double complex"),
+            (14, 2, 14, 16, "double complex"),
         ]
         .iter()
-        .map(|(line, col, kind)| {
-            let msg = double_precision_err_msg(kind).unwrap();
-            violation!(&msg, *line, *col)
+        .map(|(start_line, start_col, end_line, end_col, kind)| {
+            Violation::from_start_end_line_col(
+                double_precision_err_msg(kind).unwrap(),
+                &source,
+                *start_line,
+                *start_col,
+                *end_line,
+                *end_col,
+            )
         })
         .collect();
         let rule = DoublePrecision::new(&default_settings());

--- a/src/rules/precision/implicit_kinds.rs
+++ b/src/rules/precision/implicit_kinds.rs
@@ -44,17 +44,13 @@ impl ASTRule for ImplicitRealKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_implicit_real_kind() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             real function my_func(a, b, c, d, e)       ! catch
               real, intent(in) :: a                    ! catch
               real(4), intent(in) :: b                 ! ignore
@@ -65,9 +61,7 @@ mod tests {
               myfunc = a
             end function my_func
             ",
-            ),
-        )
-        .finish();
+        );
 
         let expected: Vec<Violation> = [
             (1, 0, 1, 4, "real"),

--- a/src/rules/precision/kind_suffixes.rs
+++ b/src/rules/precision/kind_suffixes.rs
@@ -2,8 +2,8 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{ASTRule, Rule, Violation};
 use lazy_regex::regex_is_match;
-use tree_sitter::Node;
 use ruff_source_file::SourceFile;
+use tree_sitter::Node;
 /// Defines rule to ensure real precision is explicit, as this avoids accidental loss of precision.
 
 pub struct NoRealSuffix {}
@@ -76,15 +76,16 @@ impl ASTRule for NoRealSuffix {
 mod tests {
     use super::*;
     use crate::settings::default_settings;
-    use crate::violation;
     use pretty_assertions::assert_eq;
-    use textwrap::dedent;
     use ruff_source_file::SourceFileBuilder;
+    use textwrap::dedent;
 
     #[test]
     fn test_no_real_suffix() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new("test", dedent(
-            "
+        let source = SourceFileBuilder::new(
+            "test",
+            dedent(
+                "
             use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
 
             real(sp), parameter :: x1 = 1.234567
@@ -100,21 +101,29 @@ mod tests {
             real(sp), parameter :: y2 = 1.2e3
 
             ",
-        )).finish();
+            ),
+        )
+        .finish();
         let expected: Vec<Violation> = [
-            (4, 29, "1.234567"),
-            (7, 29, "9.876"),
-            (9, 29, "2."),
-            (10, 29, ".0"),
-            (11, 29, "1E2"),
-            (12, 29, ".1e2"),
-            (13, 29, "1.E2"),
-            (14, 29, "1.2e3"),
+            (3, 28, 3, 36, "1.234567"),
+            (6, 28, 6, 33, "9.876"),
+            (8, 28, 8, 30, "2."),
+            (9, 28, 9, 30, ".0"),
+            (10, 28, 10, 31, "1E2"),
+            (11, 28, 11, 32, ".1e2"),
+            (12, 28, 12, 32, "1.E2"),
+            (13, 28, 13, 33, "1.2e3"),
         ]
         .iter()
-        .map(|(line, col, num)| {
-            let msg = format!("real literal {} missing kind suffix", num);
-            violation!(&msg, *line, *col)
+        .map(|(start_line, start_col, end_line, end_col, num)| {
+            Violation::from_start_end_line_col(
+                format!("real literal {num} missing kind suffix"),
+                &source,
+                *start_line,
+                *start_col,
+                *end_line,
+                *end_col,
+            )
         })
         .collect();
         let rule = NoRealSuffix::new(&default_settings());

--- a/src/rules/precision/kind_suffixes.rs
+++ b/src/rules/precision/kind_suffixes.rs
@@ -75,17 +75,13 @@ impl ASTRule for NoRealSuffix {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_no_real_suffix() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
 
             real(sp), parameter :: x1 = 1.234567
@@ -101,9 +97,7 @@ mod tests {
             real(sp), parameter :: y2 = 1.2e3
 
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (3, 28, 3, 36, "1.234567"),
             (6, 28, 6, 33, "9.876"),

--- a/src/rules/style/end_statements.rs
+++ b/src/rules/style/end_statements.rs
@@ -98,17 +98,13 @@ impl ASTRule for UnnamedEndStatement {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_unnamed_end_statement() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             module mymod1
               implicit none
               type mytype
@@ -171,9 +167,7 @@ mod tests {
               write (*,*) 'hello world'
             end                             ! catch this
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (5, 2, 5, 32, "type", "mytype"),
             (9, 2, 9, 32, "subroutine", "mysub1"),

--- a/src/rules/style/exit_labels.rs
+++ b/src/rules/style/exit_labels.rs
@@ -60,17 +60,13 @@ impl ASTRule for MissingExitOrCycleLabel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_missing_exit_label() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             program test
               label1: do
                 if (.true.) then
@@ -116,9 +112,7 @@ mod tests {
               end do
             end program test
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (4, 6, 4, 10, "exit", "label1"),
             (9, 16, 9, 20, "exit", "label2"),

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_line_too_long() -> anyhow::Result<()> {
-        let source = dedent(
+        let source = SourceFileBuilder::new("test", dedent(
             "
             program test
               use some_really_long_module_name, only : integer_working_precision
@@ -77,8 +77,7 @@ mod tests {
               integer(integer_working_precision), parameter, dimension(1) :: a = [1]
             end program test
             ",
-        );
-        let file = SourceFileBuilder::new("test", source.as_str()).finish();
+        )).finish();
 
         let line_length = 20;
         let short_line_settings = Settings { line_length };
@@ -93,7 +92,7 @@ mod tests {
             })
             .collect();
         let rule = LineTooLong::new(&short_line_settings);
-        let actual = rule.check(&file);
+        let actual = rule.check(&source);
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -67,26 +67,22 @@ impl TextRule for LineTooLong {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_file;
+
     use super::*;
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_line_too_long() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             program test
               use some_really_long_module_name, only : integer_working_precision
               implicit none
               integer(integer_working_precision), parameter, dimension(1) :: a = [1]
             end program test
             ",
-            ),
-        )
-        .finish();
+        );
 
         let line_length = 20;
         let short_line_settings = Settings { line_length };

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -1,5 +1,4 @@
 use crate::settings::Settings;
-use crate::violation;
 use crate::{Rule, TextRule, Violation};
 use lazy_regex::regex_is_match;
 use ruff_source_file::SourceFile;
@@ -52,7 +51,7 @@ impl TextRule for LineTooLong {
                     "line length of {}, exceeds maximum {}",
                     len, self.line_length
                 );
-                violations.push(violation!(&msg, idx + 1, self.line_length));
+                violations.push(Violation::from_line_start_end_col(msg, source, idx, self.line_length, len))
             }
         }
         violations

--- a/src/rules/style/old_style_array_literal.rs
+++ b/src/rules/style/old_style_array_literal.rs
@@ -37,17 +37,13 @@ impl ASTRule for OldStyleArrayLiteral {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_old_style_array_literal() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             program test
               integer :: a(3) = (/1, 2, 3/)
               integer :: b(3) = (/ &
@@ -63,9 +59,7 @@ mod tests {
               /)
              end program test
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (2, 20, 2, 31),
             (3, 20, 7, 4),

--- a/src/rules/style/relational_operators.rs
+++ b/src/rules/style/relational_operators.rs
@@ -50,17 +50,13 @@ impl ASTRule for DeprecatedRelationalOperator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_relational_symbol() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             program test
               if (0 .gt. 1) error stop
               if (1 .le. 0) error stop
@@ -69,9 +65,7 @@ mod tests {
               if (2 /= 2) error stop  ! OK
             end program test
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> =
             [
                 (2, 8, 2, 12, ".gt.", ">"),

--- a/src/rules/style/relational_operators.rs
+++ b/src/rules/style/relational_operators.rs
@@ -1,8 +1,8 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{ASTRule, Rule, Violation};
-use tree_sitter::Node;
 use ruff_source_file::SourceFile;
+use tree_sitter::Node;
 
 fn map_relational_symbols(name: &str) -> Option<&'static str> {
     match name {
@@ -51,15 +51,16 @@ impl ASTRule for DeprecatedRelationalOperator {
 mod tests {
     use super::*;
     use crate::settings::default_settings;
-    use crate::violation;
     use pretty_assertions::assert_eq;
-    use textwrap::dedent;
     use ruff_source_file::SourceFileBuilder;
+    use textwrap::dedent;
 
     #[test]
     fn test_relational_symbol() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new("test", dedent(
-            "
+        let source = SourceFileBuilder::new(
+            "test",
+            dedent(
+                "
             program test
               if (0 .gt. 1) error stop
               if (1 .le. 0) error stop
@@ -68,20 +69,30 @@ mod tests {
               if (2 /= 2) error stop  ! OK
             end program test
             ",
-        )).finish();
-        let expected: Vec<Violation> = [
-            (3, 9, ".gt.", ">"),
-            (4, 9, ".le.", "<="),
-            (5, 8, ".eq.", "=="),
-            (5, 19, ".ne.", "/="),
-        ]
-        .iter()
-        .map(|(line, col, symbol, new_symbol)| {
-            let msg =
-                format!("deprecated relational operator '{symbol}', prefer '{new_symbol}' instead");
-            violation!(&msg, *line, *col)
-        })
-        .collect();
+            ),
+        )
+        .finish();
+        let expected: Vec<Violation> =
+            [
+                (2, 8, 2, 12, ".gt.", ">"),
+                (3, 8, 3, 12, ".le.", "<="),
+                (4, 7, 4, 11, ".eq.", "=="),
+                (4, 18, 4, 22, ".ne.", "/="),
+            ]
+            .iter()
+            .map(
+                |(start_line, start_col, end_line, end_col, symbol, new_symbol)| {
+                    Violation::from_start_end_line_col(
+                format!("deprecated relational operator '{symbol}', prefer '{new_symbol}' instead"),
+                &source,
+                *start_line,
+                *start_col,
+                *end_line,
+                *end_col,
+            )
+                },
+            )
+            .collect();
         let rule = DeprecatedRelationalOperator::new(&default_settings());
         let actual = rule.apply(&source)?;
         assert_eq!(actual, expected);

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -1,7 +1,6 @@
 use ruff_source_file::SourceFile;
 
 use crate::settings::Settings;
-use crate::violation;
 use crate::{Rule, TextRule, Violation};
 /// Defines rules that enforce widely accepted whitespace rules.
 
@@ -26,10 +25,12 @@ impl TextRule for TrailingWhitespace {
         let mut violations = Vec::new();
         for (idx, line) in source.source_text().split('\n').enumerate() {
             if line.ends_with(&[' ', '\t']) {
-                violations.push(violation!(
+                violations.push(Violation::from_line_start_end_col(
                     "trailing whitespace",
-                    idx + 1,
-                    line.trim_end().len() + 1
+                    source,
+                    idx,
+                    line.trim_end().len(),
+                    line.len(),
                 ));
             }
         }

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -1,3 +1,5 @@
+use ruff_source_file::SourceFile;
+
 use crate::settings::Settings;
 use crate::violation;
 use crate::{Rule, TextRule, Violation};
@@ -20,9 +22,9 @@ impl Rule for TrailingWhitespace {
 }
 
 impl TextRule for TrailingWhitespace {
-    fn check(&self, source: &str) -> Vec<Violation> {
+    fn check(&self, source: &SourceFile) -> Vec<Violation> {
         let mut violations = Vec::new();
-        for (idx, line) in source.split('\n').enumerate() {
+        for (idx, line) in source.source_text().split('\n').enumerate() {
             if line.ends_with(&[' ', '\t']) {
                 violations.push(violation!(
                     "trailing whitespace",
@@ -41,6 +43,7 @@ mod tests {
     use crate::settings::default_settings;
     use crate::violation;
     use pretty_assertions::assert_eq;
+    use ruff_source_file::SourceFileBuilder;
 
     #[test]
     fn test_trailing_whitespace() -> anyhow::Result<()> {
@@ -58,12 +61,14 @@ program test
    
 end program test
 ";
+        let file = SourceFileBuilder::new("test", source).finish();
+
         let expected: Vec<Violation> = [(2, 13), (4, 24), (8, 4), (9, 1)]
             .iter()
             .map(|(line, col)| violation!("trailing whitespace", *line, *col))
             .collect();
         let rule = TrailingWhitespace::new(&default_settings());
-        let actual = rule.check(source);
+        let actual = rule.check(&file);
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/typing/assumed_size.rs
+++ b/src/rules/typing/assumed_size.rs
@@ -282,17 +282,13 @@ impl ASTRule for DeprecatedAssumedSizeCharacter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_assumed_size() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             subroutine assumed_size_dimension(array, n, m, l, o, p, options, thing, q)
               integer, intent(in) :: n, m
               integer, dimension(n, m, *), intent(in) :: array
@@ -307,9 +303,7 @@ mod tests {
               character(*), dimension(*), parameter :: param_char = ['hello']
             end subroutine assumed_size_dimension
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (3, 27, 3, 28, "array"),
             (4, 27, 4, 28, "l"),
@@ -338,10 +332,8 @@ mod tests {
     #[test]
     fn test_assumed_size_character_intent() -> anyhow::Result<()> {
         // test case from stylist
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             program cases
               ! A char array outside a function or subroutine, no exception
               character (*) :: autochar_glob
@@ -362,9 +354,7 @@ mod tests {
               end subroutine char_input
             end program cases
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (3, 13, 3, 14, "autochar_glob"),
             (9, 14, 9, 15, "autochar_inout"),
@@ -392,10 +382,8 @@ mod tests {
     #[test]
     fn test_deprecated_assumed_size_character() -> anyhow::Result<()> {
         // test case from stylist
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             program cases
             contains
               subroutine char_input(a, b, c, d, e, f)
@@ -410,9 +398,7 @@ mod tests {
               end subroutine char_input
             end program cases
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (4, 14, 4, 15, "a"),
             (5, 13, 5, 14, "b"),

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -132,17 +132,13 @@ impl ASTRule for SuperfluousImplicitNone {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_implicit_typing() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             module my_module
                 parameter(N = 1)
             end module
@@ -151,9 +147,7 @@ mod tests {
                 write(*,*) 42
             end program
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [(0, 1, 0, 17, "module"), (5, 0, 5, 18, "program")]
             .iter()
             .map(|(start_line, start_col, end_line, end_col, kind)| {
@@ -175,10 +169,8 @@ mod tests {
 
     #[test]
     fn test_implicit_none() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             module my_module
                 implicit none
             contains
@@ -194,9 +186,7 @@ mod tests {
                 write(*,*) x
             end program
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = vec![];
         let rule = ImplicitTyping::new(&default_settings());
         let actual = rule.apply(&source)?;
@@ -206,10 +196,8 @@ mod tests {
 
     #[test]
     fn test_interface_implicit_typing() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             module my_module
                 implicit none
                 interface
@@ -229,9 +217,7 @@ mod tests {
                 write(*,*) 42
             end program
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [(4, 8, 4, 34, "function"), (13, 8, 13, 29, "subroutine")]
             .iter()
             .map(|(start_line, start_col, end_line, end_col, kind)| {
@@ -253,10 +239,8 @@ mod tests {
 
     #[test]
     fn test_interface_implicit_none() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             module my_module
                 implicit none
                 interface
@@ -278,9 +262,7 @@ mod tests {
                 write(*,*) 42
             end program
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = vec![];
         let rule = InterfaceImplicitTyping::new(&default_settings());
         let actual = rule.apply(&source)?;
@@ -290,10 +272,8 @@ mod tests {
 
     #[test]
     fn test_superfluous_implicit_none() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             module my_module
                 implicit none
             contains
@@ -327,9 +307,7 @@ mod tests {
                 end subroutine
             end program
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (5, 8, 5, 21, "module"),
             (10, 8, 10, 21, "module"),
@@ -356,10 +334,8 @@ mod tests {
 
     #[test]
     fn test_no_superfluous_implicit_none() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             module my_module
                 implicit none
 
@@ -397,9 +373,7 @@ mod tests {
                 end subroutine
             end program
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = vec![];
         let rule = SuperfluousImplicitNone::new(&default_settings());
         let actual = rule.apply(&source)?;

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -39,7 +39,8 @@ impl ASTRule for ImplicitTyping {
     fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Violation>> {
         if !child_is_implicit_none(node) {
             let msg = format!("{} missing 'implicit none'", node.kind());
-            return some_vec![Violation::from_node(msg, node)];
+            let block_stmt = node.child(0)?;
+            return some_vec![Violation::from_node(msg, &block_stmt)];
         }
         None
     }
@@ -69,7 +70,8 @@ impl ASTRule for InterfaceImplicitTyping {
         let parent = node.parent()?;
         if parent.kind() == "interface" && !child_is_implicit_none(node) {
             let msg = format!("interface {} missing 'implicit none'", node.kind());
-            return some_vec![Violation::from_node(msg, node)];
+            let interface_stmt = node.child(0)?;
+            return some_vec![Violation::from_node(msg, &interface_stmt)];
         }
         None
     }
@@ -152,7 +154,7 @@ mod tests {
             ),
         )
         .finish();
-        let expected: Vec<Violation> = [(1, 0, 1, 1, "module"), (5, 0, 5, 1, "program")]
+        let expected: Vec<Violation> = [(0, 1, 0, 17, "module"), (5, 0, 5, 18, "program")]
             .iter()
             .map(|(start_line, start_col, end_line, end_col, kind)| {
                 Violation::from_start_end_line_col(
@@ -230,7 +232,7 @@ mod tests {
             ),
         )
         .finish();
-        let expected: Vec<Violation> = [(4, 8, 4, 21, "function"), (13, 8, 13, 21, "subroutine")]
+        let expected: Vec<Violation> = [(4, 8, 4, 34, "function"), (13, 8, 13, 29, "subroutine")]
             .iter()
             .map(|(start_line, start_col, end_line, end_col, kind)| {
                 Violation::from_start_end_line_col(

--- a/src/rules/typing/init_decls.rs
+++ b/src/rules/typing/init_decls.rs
@@ -107,17 +107,13 @@ impl ASTRule for InitialisationInDeclaration {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_init_decl() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             module test
               integer :: global = 0  ! Ok at module level
 
@@ -141,9 +137,7 @@ mod tests {
 
             end module test
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (10, 13, 10, 20, "foo"),
             (19, 18, 19, 25, "bar"),

--- a/src/rules/typing/intent.rs
+++ b/src/rules/typing/intent.rs
@@ -109,17 +109,13 @@ impl ASTRule for MissingIntent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_missing_intent() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             integer function foo(a, b, c)
               use mod
               integer :: a, c(2), f
@@ -133,9 +129,7 @@ mod tests {
               integer :: g
             end subroutine
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (3, 13, 3, 14, "function", "a"),
             (3, 16, 3, 20, "function", "c"),

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -182,17 +182,13 @@ impl ASTRule for LiteralKindSuffix {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_literal_kind() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             integer(8) function add_if(x, y, z)
               integer :: w
               integer(kind=2), intent(in) :: x
@@ -219,9 +215,7 @@ mod tests {
               complex_add = y + x
             end function
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (1, 8, 1, 9, "integer", 8),
             (3, 15, 3, 16, "integer", 2),
@@ -250,10 +244,8 @@ mod tests {
 
     #[test]
     fn test_literal_kind_suffix() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
 
             real(sp), parameter :: x1 = 1.234567_4
@@ -262,9 +254,7 @@ mod tests {
             real(dp), parameter :: x4 = 9.876_8
             real(sp), parameter :: x5 = 2.468_sp
             ",
-            ),
-        )
-        .finish();
+        );
         let expected: Vec<Violation> = [
             (3, 37, 3, 38, "1.234567_4", "4"),
             (6, 34, 6, 35, "9.876_8", "8"),

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -58,17 +58,13 @@ impl ASTRule for StarKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
+    use crate::{settings::default_settings, test_file};
     use pretty_assertions::assert_eq;
-    use ruff_source_file::SourceFileBuilder;
-    use textwrap::dedent;
 
     #[test]
     fn test_star_kind() -> anyhow::Result<()> {
-        let source = SourceFileBuilder::new(
-            "test",
-            dedent(
-                "
+        let source = test_file(
+            "
             integer*8 function add_if(x, y, z)
               integer(kind=2), intent(in) :: x
               integer *4, intent(in) :: y
@@ -90,9 +86,7 @@ mod tests {
               real = real * 8
             end subroutine
             ",
-            ),
-        )
-        .finish();
+        );
 
         let expected: Vec<Violation> = [
             (1, 7, 1, 9, "integer*8", "integer(8)"),


### PR DESCRIPTION
Closes #44 

Uses the `ruff_source_file` and `ruff_text_size` crates to implement ranges for violations. Among other things, using these directly should make it easier to adapt other parts of ruff.

A bit rough but it works. Required some rejigging of the tests that I'm not overly happy with -- namely using zero-indexed line/column for the start/end ranges. Might be better to just use offsets in the tests as well, but then we probably want something to make it easier to work out the expected ranges. Maybe a way to optionally print the parse tree for the test snippet? Or to print the snippet with line-start-offsets, e.g.:

```
     0    5    1
               0   
0  | program test
13 |   implicit none
30 | end program test
```