### PR TITLE
Add support for config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "cc"
 version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +111,21 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_config"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46efb9cbf691f5505d0b7b2c8055aec0c9a770eaac8a06834b6d84b5be93279a"
+dependencies = [
+ "clap",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
 ]
 
 [[package]]
@@ -154,12 +175,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fortitude"
 version = "0.3.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
  "clap",
+ "clap_config",
  "colored",
  "itertools",
  "lazy-regex",
@@ -167,17 +205,35 @@ dependencies = [
  "pretty_assertions",
  "ruff_source_file",
  "ruff_text_size",
+ "serde",
  "textwrap",
+ "toml",
  "tree-sitter",
  "tree-sitter-fortran",
  "walkdir",
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -222,6 +278,18 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.161"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "memchr"
@@ -308,12 +376,54 @@ version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff.git?tag=0.6.8#ae39ce56c0cc1f8ac15f980c0b457b16b67c1f2a"
 
 [[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -346,6 +456,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +474,40 @@ dependencies = [
  "smawk",
  "unicode-linebreak",
  "unicode-width",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -574,6 +728,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
 name = "fortitude"
 version = "0.3.0"
 dependencies = [
@@ -206,6 +218,7 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "serde",
+ "tempfile",
  "textwrap",
  "toml",
  "tree-sitter",
@@ -453,6 +466,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,16 @@ exclude = [".*", "test.f90"]
 annotate-snippets = "0.11.4"
 anyhow = "1.0.79"
 clap = { version = "4.4.16", features = ["derive"] }
+clap_config = "0.1.1"
 colored = "2.1.0"
 itertools = "0.12.0"
 lazy-regex = "3.3.0"
 lazy_static = "1.5.0"
 ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.6.8", version = "0.0.0" }
 ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.6.8", version = "0.0.0" }
+serde = { version = "1.0.210", features = ["derive"] }
 textwrap = "0.16.0"
+toml = "0.8.19"
 tree-sitter = "~0.23.0"
 tree-sitter-fortran = "0.1.0"
 walkdir = "2.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ walkdir = "2.4.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
+tempfile = "3.13.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 PlasmaFAIR
+Copyright (c) 2024 Liam Pattinson, Peter Hill, the PlasmaFAIR team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,31 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+end of terms and conditions
+
+Portions of this software use ruff, licensed as follows:
+
+"""
+MIT License
+
+Copyright (c) 2022 Charles Marsh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""

--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ conduct](CODE_OF_CONDUCT.md) before contributing.
 
 This work is distributed under the MIT License. See [`LICENSE`](LICENSE) for more
 information.
+
+Fortitude is inspired by, and uses parts from
+[ruff](https://github.com/astral-sh/ruff), used under the MIT licence. See
+[`LICENSE`](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ fortitude --help
 fortitude check --help
 ```
 
+## Configuration
+
+Fortitude will look for either a `fortitude.toml` or `fpm.toml` file in the
+current directory, or one of its parents. If using `fortitude.toml`, settings
+should be under the command name:
+
+```toml
+[check]
+ignore = ["S001", "S051"]
+line-length = 132
+```
+
+For `fpm.toml` files, this has to be additionally nested under the
+`extra.fortitude` table:
+
+```toml
+[extra.fortitude.check]
+ignore = ["S001", "S051"]
+line-length = 132
+```
+
 ## Contributing
 
 Please feel free to add or suggest new rules or comment on the layout of the project

--- a/src/check.rs
+++ b/src/check.rs
@@ -7,10 +7,12 @@ use crate::rules::{
 use crate::settings::Settings;
 use crate::violation;
 use crate::{Diagnostic, Violation};
+use anyhow::Result;
 use colored::Colorize;
 use itertools::{chain, join};
 use ruff_source_file::{SourceFile, SourceFileBuilder};
 use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 use walkdir::WalkDir;
 
 /// Get the list of active rules for this session.
@@ -135,7 +137,7 @@ fn read_to_string(path: &Path) -> std::io::Result<String> {
 }
 
 /// Check all files, report issues found, and return error code.
-pub fn check(args: CheckArgs) -> i32 {
+pub fn check(args: CheckArgs) -> Result<ExitCode> {
     let settings = Settings {
         line_length: args.line_length,
     };
@@ -183,18 +185,18 @@ pub fn check(args: CheckArgs) -> i32 {
                 }
             }
             if total_errors == 0 {
-                0
+                Ok(ExitCode::SUCCESS)
             } else {
                 let err_no = format!("Number of errors: {}", total_errors.to_string().bold());
                 let info = "For more information, run:";
                 let explain = format!("{} {}", "fortitude explain", "[ERROR_CODES]".bold());
                 println!("\n-- {}\n-- {}\n\n    {}\n", err_no, info, explain);
-                1
+                Ok(ExitCode::FAILURE)
             }
         }
         Err(msg) => {
             eprintln!("{}: {}", "ERROR".bright_red(), msg);
-            1
+            Ok(ExitCode::FAILURE)
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,8 +117,7 @@ fn from_clap_config_subsection<P: AsRef<Path>>(path: P) -> Result<Cli> {
     let matches = <Cli as CommandFactory>::command().get_matches();
 
     let config_str = if path.as_ref().ends_with("fpm.toml") {
-        let config = std::fs::read_to_string(path)?
-            .parse::<Table>()?;
+        let config = std::fs::read_to_string(path)?.parse::<Table>()?;
 
         // Unwrap should be ok here because we've already checked this
         // file as these tables

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,21 +1,29 @@
-use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use anyhow::{Context, Result};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_config::ClapConfig;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use toml::Table;
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, ClapConfig)]
 #[command(version, about)]
 pub struct Cli {
-    #[command(subcommand)]
+    #[clap(subcommand)]
     pub command: SubCommands,
+
+    /// Config file to read
+    #[arg()]
+    pub config_file: Option<String>,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Subcommand, ClapConfig, Clone, PartialEq)]
 pub enum SubCommands {
     Check(CheckArgs),
     Explain(ExplainArgs),
 }
 
 /// Get descriptions, rationales, and solutions for each rule.
-#[derive(Debug, clap::Parser)]
+#[derive(Debug, clap::Parser, ClapConfig, Clone, PartialEq)]
 pub struct ExplainArgs {
     /// List of rules to explain. If omitted, explains all rules.
     #[arg()]
@@ -23,7 +31,7 @@ pub struct ExplainArgs {
 }
 
 /// Perform static analysis on files and report issues.
-#[derive(Debug, clap::Parser)]
+#[derive(Debug, clap::Parser, Deserialize, Serialize, ClapConfig, Clone, PartialEq)]
 pub struct CheckArgs {
     /// List of files to analyze
     #[arg(default_value = ".")]
@@ -42,6 +50,94 @@ pub struct CheckArgs {
     pub line_length: usize,
 }
 
-pub fn parse_args() -> Cli {
-    Cli::parse()
+// These are just helper structs to let us quickly work out if there's
+// a fortitude section in an fpm.toml file
+#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+struct Fpm {
+    extra: Option<Extra>,
+}
+
+#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+struct Extra {
+    fortitude: Option<EmptyConfig>,
+}
+
+#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+struct EmptyConfig {}
+
+// Adapted from ruff
+fn parse_fpm_toml<P: AsRef<Path>>(path: P) -> Result<Fpm> {
+    let contents = std::fs::read_to_string(path.as_ref())
+        .with_context(|| format!("Failed to read {}", path.as_ref().display()))?;
+    toml::from_str(&contents)
+        .with_context(|| format!("Failed to parse {}", path.as_ref().display()))
+}
+
+pub fn fortitude_enabled<P: AsRef<Path>>(path: P) -> Result<bool> {
+    let fpm = parse_fpm_toml(path)?;
+    Ok(fpm.extra.and_then(|extra| extra.fortitude).is_some())
+}
+
+/// Return the path to the `fpm.toml` or `fortitude.toml` file in a given
+/// directory. Adapated from ruff
+pub fn settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
+    // Check for `.fortitude.toml`.
+    let fortitude_toml = path.as_ref().join(".fortitude.toml");
+    if fortitude_toml.is_file() {
+        return Ok(Some(fortitude_toml));
+    }
+
+    // Check for `fortitude.toml`.
+    let fortitude_toml = path.as_ref().join("fortitude.toml");
+    if fortitude_toml.is_file() {
+        return Ok(Some(fortitude_toml));
+    }
+
+    // Check for `fpm.toml`.
+    let fpm_toml = path.as_ref().join("fpm.toml");
+    if fpm_toml.is_file() && fortitude_enabled(&fpm_toml)? {
+        return Ok(Some(fpm_toml));
+    }
+
+    Ok(None)
+}
+
+/// Find the path to the `pyproject.toml` or `ruff.toml` file, if such a file
+/// exists. Adapated from ruff
+pub fn find_settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
+    for directory in path.as_ref().ancestors() {
+        if let Some(pyproject) = settings_toml(directory)? {
+            return Ok(Some(pyproject));
+        }
+    }
+    Ok(None)
+}
+
+fn from_clap_config_subsection<P: AsRef<Path>>(path: P) -> Result<Cli> {
+    let matches = <Cli as CommandFactory>::command().get_matches();
+
+    let config_str = if path.as_ref().ends_with("fpm.toml") {
+        let config = std::fs::read_to_string(path)?
+            .parse::<Table>()?;
+
+        // Unwrap should be ok here because we've already checked this
+        // file as these tables
+        let extra = &config["extra"].as_table().unwrap();
+        let fortitude = &extra["fortitude"].as_table().unwrap();
+        fortitude.to_string()
+    } else {
+        std::fs::read_to_string(path)?
+    };
+
+    let config: CliConfig = toml::from_str(&config_str)?;
+
+    Ok(Cli::from_merged(matches, Some(config)))
+}
+
+pub fn parse_args() -> Result<Cli> {
+    if let Some(toml_file) = find_settings_toml(".")? {
+        from_clap_config_subsection(toml_file)
+    } else {
+        Ok(Cli::parse())
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,6 +153,7 @@ mod tests {
 
     use anyhow::{Context, Result};
     use tempfile::TempDir;
+    use textwrap::dedent;
 
     use super::*;
 
@@ -162,13 +163,15 @@ mod tests {
         let fpm_toml = tempdir.path().join("fpm.toml");
         fs::write(
             fpm_toml,
-            r#"
-some-stuff = 1
-other-things = "hello"
+            dedent(
+                r#"
+                some-stuff = 1
+                other-things = "hello"
 
-[extra.fortitude.check]
-ignore = ["T001"]
-"#,
+                [extra.fortitude.check]
+                ignore = ["T001"]
+                "#,
+            ),
         )?;
 
         let fpm = find_settings_toml(tempdir.path())?.context("Failed to find fpm.toml")?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,8 +106,8 @@ pub fn settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
 /// exists. Adapated from ruff
 pub fn find_settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
     for directory in path.as_ref().ancestors() {
-        if let Some(pyproject) = settings_toml(directory)? {
-            return Ok(Some(pyproject));
+        if let Some(settings) = settings_toml(directory)? {
+            return Ok(Some(settings));
         }
     }
     Ok(None)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,9 +11,9 @@ pub struct Cli {
     #[clap(subcommand)]
     pub command: SubCommands,
 
-    /// Config file to read
-    #[arg()]
-    pub config_file: Option<String>,
+    /// Path to a TOML configuration file
+    #[arg(long)]
+    pub config_file: Option<PathBuf>,
 }
 
 #[derive(Debug, Subcommand, ClapConfig, Clone, PartialEq)]
@@ -134,9 +134,15 @@ fn from_clap_config_subsection<P: AsRef<Path>>(path: P) -> Result<Cli> {
 }
 
 pub fn parse_args() -> Result<Cli> {
+    let args = Cli::parse();
+
+    if args.config_file.is_some() {
+        return from_clap_config_subsection(args.config_file.unwrap());
+    }
+
     if let Some(toml_file) = find_settings_toml(".")? {
         from_clap_config_subsection(toml_file)
     } else {
-        Ok(Cli::parse())
+        Ok(args)
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,7 +102,7 @@ pub fn settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
     Ok(None)
 }
 
-/// Find the path to the `pyproject.toml` or `ruff.toml` file, if such a file
+/// Find the path to the `fpm.toml` or `fortitude.toml` file, if such a file
 /// exists. Adapated from ruff
 pub fn find_settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
     for directory in path.as_ref().ancestors() {

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1,3 +1,6 @@
+use std::process::ExitCode;
+
+use anyhow::Result;
 use crate::cli::ExplainArgs;
 use crate::rules::{explain_rule, full_ruleset, RuleSet};
 use crate::settings::default_settings;
@@ -19,7 +22,7 @@ fn ruleset(args: &ExplainArgs) -> anyhow::Result<RuleSet> {
 }
 
 /// Check all files, report issues found, and return error code.
-pub fn explain(args: ExplainArgs) -> i32 {
+pub fn explain(args: ExplainArgs) -> Result<ExitCode> {
     match ruleset(&args) {
         Ok(rules) => {
             let mut outputs = Vec::new();
@@ -37,11 +40,11 @@ pub fn explain(args: ExplainArgs) -> i32 {
             for (code, desc) in outputs {
                 println!("{}\n{}", code, desc);
             }
-            0
+            Ok(ExitCode::SUCCESS)
         }
         Err(msg) => {
             eprintln!("{}: {}", "ERROR".bright_red(), msg);
-            1
+            Ok(ExitCode::FAILURE)
         }
     }
 }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1,9 +1,9 @@
 use std::process::ExitCode;
 
-use anyhow::Result;
 use crate::cli::ExplainArgs;
 use crate::rules::{explain_rule, full_ruleset, RuleSet};
 use crate::settings::default_settings;
+use anyhow::Result;
 use colored::Colorize;
 use textwrap::dedent;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,12 +10,8 @@ fn main() -> ExitCode {
         Err(_) => return ExitCode::FAILURE,
     };
     let status = match args.command {
-        SubCommands::Check(args) => {
-            check(args)
-        }
-        SubCommands::Explain(args) => {
-            explain(args)
-        }
+        SubCommands::Check(args) => check(args),
+        SubCommands::Explain(args) => explain(args),
     };
     match status {
         Ok(code) => code,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,24 @@
+use std::process::ExitCode;
+
 use fortitude::check::check;
 use fortitude::cli::{parse_args, SubCommands};
 use fortitude::explain::explain;
 
-fn main() {
-    let args = parse_args();
-    match args.command {
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(_) => return ExitCode::FAILURE,
+    };
+    let status = match args.command {
         SubCommands::Check(args) => {
-            std::process::exit(check(args));
+            check(args)
         }
         SubCommands::Explain(args) => {
-            std::process::exit(explain(args));
+            explain(args)
         }
+    };
+    match status {
+        Ok(code) => code,
+        Err(_) => ExitCode::FAILURE,
     }
 }


### PR DESCRIPTION
Closes #5 

Adds support for `fortitude.toml` and `fpm.toml` files. Still needs tests and documentation.

`fortitude.toml` file:

```toml
global_options = "when we have any"

[check]
ignore = ["S001", "T041"]
line_length = 132
```

`fpm.toml`:

```toml
[extra.fortitude]
global_options = "when we have any"

[extra.fortitude.check]
ignore = ["S001", "T041"]
line_length = 132
```

Looks for settings files in the current directory, or any of its parents.