### PR TITLE
Use ruff's diagnostics crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,17 +376,16 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "ruff_source_file"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.6.8#ae39ce56c0cc1f8ac15f980c0b457b16b67c1f2a"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
 dependencies = [
  "memchr",
- "once_cell",
  "ruff_text_size",
 ]
 
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.6.8#ae39ce56c0cc1f8ac15f980c0b457b16b67c1f2a"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
 
 [[package]]
 name = "rustix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,10 +217,12 @@ dependencies = [
  "clap",
  "clap_config",
  "colored",
- "itertools",
+ "itertools 0.12.1",
  "lazy-regex",
  "lazy_static",
  "pretty_assertions",
+ "ruff_diagnostics",
+ "ruff_macros",
  "ruff_source_file",
  "ruff_text_size",
  "serde",
@@ -249,6 +257,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2069faacbe981460232f880d26bf3c7634e322d49053aa48c27e3ae642f728f1"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +279,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -303,6 +332,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -372,6 +407,40 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "ruff_diagnostics"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
+dependencies = [
+ "anyhow",
+ "is-macro",
+ "log",
+ "ruff_text_size",
+]
+
+[[package]]
+name = "ruff_macros"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
+dependencies = [
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "ruff_python_trivia",
+ "syn",
+]
+
+[[package]]
+name = "ruff_python_trivia"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
+dependencies = [
+ "itertools 0.13.0",
+ "ruff_source_file",
+ "ruff_text_size",
+ "unicode-ident",
+]
 
 [[package]]
 name = "ruff_source_file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ colored = "2.1.0"
 itertools = "0.12.0"
 lazy-regex = "3.3.0"
 lazy_static = "1.5.0"
+ruff_diagnostics = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
+ruff_macros = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
 ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
 ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
 serde = { version = "1.0.210", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ colored = "2.1.0"
 itertools = "0.12.0"
 lazy-regex = "3.3.0"
 lazy_static = "1.5.0"
-ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.6.8", version = "0.0.0" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.6.8", version = "0.0.0" }
+ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
 serde = { version = "1.0.210", features = ["derive"] }
 textwrap = "0.16.0"
 toml = "0.8.19"

--- a/src/check.rs
+++ b/src/check.rs
@@ -5,7 +5,7 @@ use crate::rules::{
     text_rule_map, ASTEntryPointMap, PathRuleMap, RuleSet, TextRuleMap,
 };
 use crate::settings::Settings;
-use crate::FortitudeDiagnostic;
+use crate::DiagnosticMessage;
 use anyhow::Result;
 use colored::Colorize;
 use itertools::{chain, join};
@@ -159,7 +159,7 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                             TextRange::default(),
                         );
                         let diagnostic =
-                            FortitudeDiagnostic::from_ruff(&empty_file, "E000", &violation);
+                            DiagnosticMessage::from_ruff(&empty_file, "E000", violation);
                         println!("{diagnostic}");
                         total_errors += 1;
                         continue;
@@ -172,7 +172,7 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                     Ok(violations) => {
                         let mut diagnostics: Vec<_> = violations
                             .into_iter()
-                            .map(|(c, v)| FortitudeDiagnostic::from_ruff(&file, c, &v))
+                            .map(|(c, v)| DiagnosticMessage::from_ruff(&file, c, v))
                             .collect();
                         if !diagnostics.is_empty() {
                             diagnostics.sort_unstable();
@@ -188,7 +188,7 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                             TextRange::default(),
                         );
                         let diagnostic =
-                            FortitudeDiagnostic::from_ruff(&empty_file, "E000", &violation);
+                            DiagnosticMessage::from_ruff(&empty_file, "E000", violation);
                         println!("{diagnostic}");
                         total_errors += 1;
                     }

--- a/src/check.rs
+++ b/src/check.rs
@@ -6,7 +6,7 @@ use crate::rules::{
 };
 use crate::settings::Settings;
 use crate::violation;
-use crate::{Diagnostic, Violation};
+use crate::{FortitudeDiagnostic, FortitudeViolation};
 use anyhow::Result;
 use colored::Colorize;
 use itertools::{chain, join};
@@ -76,7 +76,7 @@ fn check_file(
     ast_entrypoints: &ASTEntryPointMap,
     path: &Path,
     file: &SourceFile,
-) -> anyhow::Result<Vec<(String, Violation)>> {
+) -> anyhow::Result<Vec<(String, FortitudeViolation)>> {
     // TODO replace Vec<(String, Violation)> with Vec<(&str, Violation)>
     let mut violations = Vec::new();
 
@@ -152,7 +152,7 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                     Ok(source) => source,
                     Err(error) => {
                         let violation = violation!(format!("Error opening file: {error}"));
-                        let diagnostic = Diagnostic::new(&empty_file, "E000", &violation);
+                        let diagnostic = FortitudeDiagnostic::new(&empty_file, "E000", &violation);
                         println!("{diagnostic}");
                         total_errors += 1;
                         continue;
@@ -163,9 +163,9 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
 
                 match check_file(&path_rules, &text_rules, &ast_entrypoints, &path, &file) {
                     Ok(violations) => {
-                        let mut diagnostics: Vec<Diagnostic> = violations
+                        let mut diagnostics: Vec<FortitudeDiagnostic> = violations
                             .into_iter()
-                            .map(|(c, v)| Diagnostic::new(&file, c, &v))
+                            .map(|(c, v)| FortitudeDiagnostic::new(&file, c, &v))
                             .collect();
                         if !diagnostics.is_empty() {
                             diagnostics.sort_unstable();
@@ -175,7 +175,7 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                     }
                     Err(msg) => {
                         let violation = violation!(format!("Failed to process: {msg}"));
-                        let diagnostic = Diagnostic::new(&empty_file, "E000", &violation);
+                        let diagnostic = FortitudeDiagnostic::new(&empty_file, "E000", &violation);
                         println!("{diagnostic}");
                         total_errors += 1;
                     }

--- a/src/check.rs
+++ b/src/check.rs
@@ -152,14 +152,12 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                 let source = match read_to_string(&path) {
                     Ok(source) => source,
                     Err(error) => {
-                        let violation = Diagnostic::new(
-                            IOError {
-                                message: format!("Error opening file: {error}"),
-                            },
-                            TextRange::default(),
+                        let message = format!("Error opening file: {error}");
+                        let diagnostic = DiagnosticMessage::from_ruff(
+                            &empty_file,
+                            "E000",
+                            Diagnostic::new(IOError { message }, TextRange::default()),
                         );
-                        let diagnostic =
-                            DiagnosticMessage::from_ruff(&empty_file, "E000", violation);
                         println!("{diagnostic}");
                         total_errors += 1;
                         continue;
@@ -181,14 +179,12 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                         total_errors += diagnostics.len();
                     }
                     Err(msg) => {
-                        let violation = Diagnostic::new(
-                            IOError {
-                                message: format!("Failed to process: {msg}"),
-                            },
-                            TextRange::default(),
+                        let message = format!("Failed to process: {msg}");
+                        let diagnostic = DiagnosticMessage::from_ruff(
+                            &empty_file,
+                            "E000",
+                            Diagnostic::new(IOError { message }, TextRange::default()),
                         );
-                        let diagnostic =
-                            DiagnosticMessage::from_ruff(&empty_file, "E000", violation);
                         println!("{diagnostic}");
                         total_errors += 1;
                     }

--- a/src/check.rs
+++ b/src/check.rs
@@ -5,7 +5,6 @@ use crate::rules::{
     ASTEntryPointMap, PathRuleMap, RuleSet, TextRuleMap,
 };
 use crate::settings::Settings;
-use crate::violation;
 use crate::{FortitudeDiagnostic, FortitudeViolation};
 use anyhow::Result;
 use colored::Colorize;
@@ -151,7 +150,9 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                 let source = match read_to_string(&path) {
                     Ok(source) => source,
                     Err(error) => {
-                        let violation = violation!(format!("Error opening file: {error}"));
+                        let violation = FortitudeViolation::new_no_range(format!(
+                            "Error opening file: {error}"
+                        ));
                         let diagnostic = FortitudeDiagnostic::new(&empty_file, "E000", &violation);
                         println!("{diagnostic}");
                         total_errors += 1;
@@ -174,7 +175,8 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                         total_errors += diagnostics.len();
                     }
                     Err(msg) => {
-                        let violation = violation!(format!("Failed to process: {msg}"));
+                        let violation =
+                            FortitudeViolation::new_no_range(format!("Failed to process: {msg}"));
                         let diagnostic = FortitudeDiagnostic::new(&empty_file, "E000", &violation);
                         println!("{diagnostic}");
                         total_errors += 1;

--- a/src/check.rs
+++ b/src/check.rs
@@ -9,6 +9,7 @@ use crate::{FortitudeDiagnostic, FortitudeViolation};
 use anyhow::Result;
 use colored::Colorize;
 use itertools::{chain, join};
+use ruff_diagnostics::Diagnostic;
 use ruff_source_file::{SourceFile, SourceFileBuilder};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -75,7 +76,7 @@ fn check_file(
     ast_entrypoints: &ASTEntryPointMap,
     path: &Path,
     file: &SourceFile,
-) -> anyhow::Result<Vec<(String, FortitudeViolation)>> {
+) -> anyhow::Result<Vec<(String, Diagnostic)>> {
     // TODO replace Vec<(String, Violation)> with Vec<(&str, Violation)>
     let mut violations = Vec::new();
 
@@ -164,9 +165,9 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
 
                 match check_file(&path_rules, &text_rules, &ast_entrypoints, &path, &file) {
                     Ok(violations) => {
-                        let mut diagnostics: Vec<FortitudeDiagnostic> = violations
+                        let mut diagnostics: Vec<_> = violations
                             .into_iter()
-                            .map(|(c, v)| FortitudeDiagnostic::new(&file, c, &v))
+                            .map(|(c, v)| FortitudeDiagnostic::from_ruff(&file, c, &v))
                             .collect();
                         if !diagnostics.is_empty() {
                             diagnostics.sort_unstable();

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -2,7 +2,6 @@ use std::process::ExitCode;
 
 use crate::cli::ExplainArgs;
 use crate::rules::{explain_rule, full_ruleset, RuleSet};
-use crate::settings::default_settings;
 use anyhow::Result;
 use colored::Colorize;
 use textwrap::dedent;
@@ -26,11 +25,10 @@ pub fn explain(args: ExplainArgs) -> Result<ExitCode> {
     match ruleset(&args) {
         Ok(rules) => {
             let mut outputs = Vec::new();
-            let settings = default_settings();
             for rule in rules {
                 outputs.push((
                     format!("{} {}", "#".bright_red(), rule.bright_red()),
-                    dedent(explain_rule(rule, &settings)),
+                    dedent(explain_rule(rule)),
                 ));
             }
             outputs.sort_by(|a, b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,11 @@ impl Category {
 // Violation type
 // --------------
 
-pub trait FromTSNode {
+pub trait FromASTNode {
     fn from_node<T: Into<DiagnosticKind>>(violation: T, node: &Node) -> Self;
 }
 
-impl FromTSNode for Diagnostic {
+impl FromASTNode for Diagnostic {
     fn from_node<T: Into<DiagnosticKind>>(violation: T, node: &Node) -> Self {
         Self::new(
             violation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,11 @@ impl<'a> fmt::Display for FortitudeDiagnostic<'a> {
                 write!(f, "{}: {} {}", path, code, message)
             }
             ViolationPosition::Range(range) => {
-                format_violation(self, f, &range, message, &path, &code)
+                if range == TextRange::default() {
+                    write!(f, "{}: {} {}", path, code, message)
+                } else {
+                    format_violation(self, f, &range, message, &path, &code)
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,19 +302,6 @@ fn format_violation(
     writeln!(f, "{}", source_block)
 }
 
-pub trait SourceLocationToOffset {
-    fn line_location(&self, row: usize, column: u32) -> SourceLocation;
-}
-
-impl SourceLocationToOffset for SourceFile {
-    fn line_location(&self, row: usize, column: u32) -> SourceLocation {
-        let source_code = self.to_source_code();
-        let offset =
-            source_code.line_start(OneIndexed::from_zero_indexed(row)) + TextSize::new(column);
-        source_code.source_location(offset)
-    }
-}
-
 /// Simplify making a `SourceFile` in tests
 #[cfg(test)]
 pub fn test_file(source: &str) -> SourceFile {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,10 +137,6 @@ pub trait Rule {
     fn new(settings: &Settings) -> Self
     where
         Self: Sized;
-
-    /// Return text explaining what the rule tests for, why this is important, and how the user
-    /// might fix it.
-    fn explain(&self) -> &'static str;
 }
 
 /// Implemented by rules that act directly on the file path.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,17 +195,6 @@ pub struct FortitudeDiagnostic<'a> {
 }
 
 impl<'a> FortitudeDiagnostic<'a> {
-    pub fn new<S>(file: &'a SourceFile, code: S, violation: &FortitudeViolation) -> Self
-    where
-        S: AsRef<str>,
-    {
-        Self {
-            file,
-            code: code.as_ref().to_string(),
-            violation: violation.clone(),
-        }
-    }
-
     pub fn from_ruff<S: AsRef<str>>(
         file: &'a SourceFile,
         code: S,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,14 @@ mod settings;
 use annotate_snippets::{Level, Renderer, Snippet};
 use ast::{parse, FortitudeNode};
 use colored::{ColoredString, Colorize};
+use ruff_diagnostics::Violation;
 use ruff_source_file::{OneIndexed, SourceFile, SourceLocation};
 use ruff_text_size::{TextRange, TextSize};
 use settings::Settings;
 use std::cmp::Ordering;
 use std::fmt;
 use std::path::Path;
+use tree_sitter::Node;
 
 // Rule categories and identity codes
 // ----------------------------------
@@ -90,9 +92,9 @@ impl FortitudeViolation {
         }
     }
 
-    pub fn from_node<T: AsRef<str>>(message: T, node: &tree_sitter::Node) -> Self {
-        FortitudeViolation::new(
-            message,
+    pub fn from_node(violation: impl Violation, node: &Node) -> Self {
+        Self::new(
+            violation.message(),
             ViolationPosition::Range(TextRange::new(
                 TextSize::try_from(node.start_byte()).unwrap(),
                 TextSize::try_from(node.end_byte()).unwrap(),
@@ -153,7 +155,7 @@ pub trait TextRule: Rule {
 pub trait ASTRule: Rule {
     fn check(
         &self,
-        node: &tree_sitter::Node,
+        node: &Node,
         source: &SourceFile,
     ) -> Option<Vec<FortitudeViolation>>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,11 @@ pub trait TextRule: Rule {
 
 /// Implemented by rules that analyse the abstract syntax tree.
 pub trait ASTRule: Rule {
-    fn check(&self, node: &tree_sitter::Node, source: &SourceFile) -> Option<Vec<FortitudeViolation>>;
+    fn check(
+        &self,
+        node: &tree_sitter::Node,
+        source: &SourceFile,
+    ) -> Option<Vec<FortitudeViolation>>;
 
     /// Return list of tree-sitter node types on which a rule should trigger.
     fn entrypoints(&self) -> Vec<&'static str>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,13 @@ impl FortitudeViolation {
         }
     }
 
+    pub fn new_no_range<T: AsRef<str>>(message: T) -> Self {
+        Self {
+            message: String::from(message.as_ref()),
+            range: ViolationPosition::None,
+        }
+    }
+
     pub fn from_node<T: AsRef<str>>(message: T, node: &tree_sitter::Node) -> Self {
         FortitudeViolation::new(
             message,
@@ -120,13 +127,6 @@ impl FortitudeViolation {
     pub fn range(&self) -> ViolationPosition {
         self.range
     }
-}
-
-#[macro_export]
-macro_rules! violation {
-    ($msg:expr) => {
-        $crate::FortitudeViolation::new($msg, $crate::ViolationPosition::None)
-    };
 }
 
 // Rule trait

--- a/src/rules/error/ioerror.rs
+++ b/src/rules/error/ioerror.rs
@@ -1,0 +1,61 @@
+// Taken from ruff
+// Copyright 2022 Charles Marsh
+// SPDX-License-Identifier: MIT
+
+use crate::settings::Settings;
+use crate::{PathRule, Rule};
+use std::path::Path;
+
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+
+/// ## What it does
+/// This is not a regular diagnostic; instead, it's raised when a file cannot be read
+/// from disk.
+///
+/// ## Why is this bad?
+/// An `IOError` indicates an error in the development setup. For example, the user may
+/// not have permissions to read a given file, or the filesystem may contain a broken
+/// symlink.
+///
+/// ## Example
+/// On Linux or macOS:
+/// ```shell
+/// $ echo -e 'print*, "hello world!"\nend' > a.f90
+/// $ chmod 000 a.f90
+/// $ fortitude check a.f90
+/// a.f90:1:1: E902 Permission denied (os error 13)
+/// Found 1 error.
+/// ```
+///
+/// ## References
+/// - [UNIX Permissions introduction](https://mason.gmu.edu/~montecin/UNIXpermiss.htm)
+/// - [Command Line Basics: Symbolic Links](https://www.digitalocean.com/community/tutorials/workflow-symbolic-links)
+#[violation]
+pub struct IOError {
+    pub message: String,
+}
+
+/// E000
+impl Violation for IOError {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let IOError { message } = self;
+        format!("{message}")
+    }
+}
+
+impl Rule for IOError {
+    fn new(_settings: &Settings) -> Self {
+        IOError {
+            message: String::default(),
+        }
+    }
+}
+
+// Need to implement some kind of rule, although we only raise this manually
+impl PathRule for IOError {
+    fn check(&self, _path: &Path) -> Option<Diagnostic> {
+        None
+    }
+}

--- a/src/rules/error/mod.rs
+++ b/src/rules/error/mod.rs
@@ -1,1 +1,2 @@
+pub mod ioerror;
 pub mod syntax_error;

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -34,7 +34,7 @@ impl Rule for SyntaxError {
 
 impl ASTRule for SyntaxError {
     fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
-        some_vec![FortitudeViolation::from_node("syntax_error", node)]
+        some_vec![FortitudeViolation::from_node(Self {}, node)]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{some_vec, ASTRule, Rule, Violation};
+use crate::{some_vec, ASTRule, Rule, FortitudeViolation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -26,8 +26,8 @@ impl Rule for SyntaxError {
 }
 
 impl ASTRule for SyntaxError {
-    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Violation>> {
-        some_vec![Violation::from_node("syntax_error", node)]
+    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
+        some_vec![FortitudeViolation::from_node("syntax_error", node)]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{some_vec, ASTRule, FromTSNode, Rule};
+use crate::{some_vec, ASTRule, FromASTNode, Rule};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
-use crate::{some_vec, ASTRule, FortitudeViolation, Rule};
+use crate::{some_vec, ASTRule, FromTSNode, Rule};
 
-use ruff_diagnostics::Violation;
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
@@ -33,8 +33,8 @@ impl Rule for SyntaxError {
 }
 
 impl ASTRule for SyntaxError {
-    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
-        some_vec![FortitudeViolation::from_node(Self {}, node)]
+    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        some_vec![Diagnostic::from_node(Self {}, node)]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{some_vec, ASTRule, Rule, FortitudeViolation};
+use crate::{some_vec, ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -1,27 +1,34 @@
 use crate::settings::Settings;
 use crate::{some_vec, ASTRule, FortitudeViolation, Rule};
+
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
-/// Rules that check for syntax errors.
-
+/// ## What it does
+/// Checks for syntax errors
+///
+/// This rule reports any syntax errors reported by Fortitude's Fortran parser.
+/// This may indicate an error with your code, an aspect of Fortran not recognised
+/// by the parser, or a non-standard extension to Fortran that our parser can't
+/// handle, such as a pre-processor.
+///
+/// If this rule is reporting valid Fortran, please let us know, as it's likely a
+/// bug in our code or in our parser!
+#[violation]
 pub struct SyntaxError {}
+
+impl Violation for SyntaxError {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Syntax error")
+    }
+}
 
 impl Rule for SyntaxError {
     fn new(_settings: &Settings) -> Self {
         SyntaxError {}
-    }
-
-    fn explain(&self) -> &'static str {
-        "
-        This rule reports any syntax errors reported by Fortitude's Fortran parser.
-        This may indicate an error with your code, an aspect of Fortran not recognised
-        by the parser, or a non-standard extension to Fortran that our parser can't
-        handle, such as a pre-processor.
-
-        If this rule is reporting valid Fortran, please let us know, as it's likely a
-        bug in our code or in our parser!
-        "
     }
 }
 

--- a/src/rules/filesystem/extensions.rs
+++ b/src/rules/filesystem/extensions.rs
@@ -1,8 +1,9 @@
-use ruff_diagnostics::Violation;
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_text_size::TextRange;
 
 use crate::settings::Settings;
-use crate::{FortitudeViolation, PathRule, Rule};
+use crate::{PathRule, Rule};
 use std::path::Path;
 
 /// ## What it does
@@ -29,17 +30,17 @@ impl Rule for NonStandardFileExtension {
 }
 
 impl PathRule for NonStandardFileExtension {
-    fn check(&self, path: &Path) -> Option<FortitudeViolation> {
+    fn check(&self, path: &Path) -> Option<Diagnostic> {
         match path.extension() {
             Some(ext) => {
                 // Must check like this as ext is an OsStr
                 if ["f90", "F90"].iter().any(|&x| x == ext) {
                     None
                 } else {
-                    Some(FortitudeViolation::new_no_range(self.message()))
+                    Some(Diagnostic::new(Self {}, TextRange::default()))
                 }
             }
-            None => Some(FortitudeViolation::new_no_range(self.message())),
+            None => Some(Diagnostic::new(Self {}, TextRange::default())),
         }
     }
 }
@@ -55,7 +56,10 @@ mod tests {
         let rule = NonStandardFileExtension::new(&default_settings());
         assert_eq!(
             rule.check(path),
-            Some(FortitudeViolation::new_no_range(rule.message())),
+            Some(Diagnostic::new(
+                NonStandardFileExtension {},
+                TextRange::default()
+            )),
         );
     }
 
@@ -65,7 +69,10 @@ mod tests {
         let rule = NonStandardFileExtension::new(&default_settings());
         assert_eq!(
             rule.check(path),
-            Some(FortitudeViolation::new_no_range(rule.message())),
+            Some(Diagnostic::new(
+                NonStandardFileExtension {},
+                TextRange::default()
+            )),
         );
     }
 

--- a/src/rules/filesystem/extensions.rs
+++ b/src/rules/filesystem/extensions.rs
@@ -1,5 +1,4 @@
 use crate::settings::Settings;
-use crate::violation;
 use crate::{PathRule, Rule, FortitudeViolation};
 use std::path::Path;
 /// Defines rule that enforces use of standard file extensions.
@@ -29,10 +28,10 @@ impl PathRule for NonStandardFileExtension {
                 if ["f90", "F90"].iter().any(|&x| x == ext) {
                     None
                 } else {
-                    Some(violation!(msg))
+                    Some(FortitudeViolation::new_no_range(msg))
                 }
             }
-            None => Some(violation!(msg)),
+            None => Some(FortitudeViolation::new_no_range(msg)),
         }
     }
 }
@@ -41,7 +40,6 @@ impl PathRule for NonStandardFileExtension {
 mod tests {
     use super::*;
     use crate::settings::default_settings;
-    use crate::violation;
 
     #[test]
     fn test_bad_file_extension() {
@@ -49,7 +47,9 @@ mod tests {
         let rule = NonStandardFileExtension::new(&default_settings());
         assert_eq!(
             rule.check(path),
-            Some(violation!["file extension should be '.f90' or '.F90'"]),
+            Some(FortitudeViolation::new_no_range(
+                "file extension should be '.f90' or '.F90'"
+            )),
         );
     }
 
@@ -59,7 +59,9 @@ mod tests {
         let rule = NonStandardFileExtension::new(&default_settings());
         assert_eq!(
             rule.check(path),
-            Some(violation!["file extension should be '.f90' or '.F90'"]),
+            Some(FortitudeViolation::new_no_range(
+                "file extension should be '.f90' or '.F90'"
+            )),
         );
     }
 

--- a/src/rules/filesystem/extensions.rs
+++ b/src/rules/filesystem/extensions.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{PathRule, Rule, FortitudeViolation};
+use crate::{FortitudeViolation, PathRule, Rule};
 use std::path::Path;
 /// Defines rule that enforces use of standard file extensions.
 

--- a/src/rules/filesystem/extensions.rs
+++ b/src/rules/filesystem/extensions.rs
@@ -1,6 +1,6 @@
 use crate::settings::Settings;
 use crate::violation;
-use crate::{PathRule, Rule, Violation};
+use crate::{PathRule, Rule, FortitudeViolation};
 use std::path::Path;
 /// Defines rule that enforces use of standard file extensions.
 
@@ -21,7 +21,7 @@ impl Rule for NonStandardFileExtension {
 }
 
 impl PathRule for NonStandardFileExtension {
-    fn check(&self, path: &Path) -> Option<Violation> {
+    fn check(&self, path: &Path) -> Option<FortitudeViolation> {
         let msg: &str = "file extension should be '.f90' or '.F90'";
         match path.extension() {
             Some(ext) => {

--- a/src/rules/filesystem/extensions.rs
+++ b/src/rules/filesystem/extensions.rs
@@ -1,37 +1,45 @@
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
+
 use crate::settings::Settings;
 use crate::{FortitudeViolation, PathRule, Rule};
 use std::path::Path;
-/// Defines rule that enforces use of standard file extensions.
 
+/// ## What it does
+/// Checks for use of standard file extensions.
+///
+/// ## Why is it bad?
+/// The standard file extensions for modern (free-form) Fortran are '.f90' or  '.F90'.
+/// Forms that reference later Fortran standards such as '.f08' or '.F95' may be rejected
+/// by some compilers and build tools.
+#[violation]
 pub struct NonStandardFileExtension {}
+
+impl Violation for NonStandardFileExtension {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("file extension should be '.f90' or '.F90'")
+    }
+}
 
 impl Rule for NonStandardFileExtension {
     fn new(_settings: &Settings) -> Self {
         NonStandardFileExtension {}
     }
-
-    fn explain(&self) -> &'static str {
-        "
-        The standard file extensions for modern (free-form) Fortran are '.f90' or  '.F90'.
-        Forms that reference later Fortran standards such as '.f08' or '.F95' may be rejected
-        by some compilers and build tools.
-        "
-    }
 }
 
 impl PathRule for NonStandardFileExtension {
     fn check(&self, path: &Path) -> Option<FortitudeViolation> {
-        let msg: &str = "file extension should be '.f90' or '.F90'";
         match path.extension() {
             Some(ext) => {
                 // Must check like this as ext is an OsStr
                 if ["f90", "F90"].iter().any(|&x| x == ext) {
                     None
                 } else {
-                    Some(FortitudeViolation::new_no_range(msg))
+                    Some(FortitudeViolation::new_no_range(self.message()))
                 }
             }
-            None => Some(FortitudeViolation::new_no_range(msg)),
+            None => Some(FortitudeViolation::new_no_range(self.message())),
         }
     }
 }
@@ -47,9 +55,7 @@ mod tests {
         let rule = NonStandardFileExtension::new(&default_settings());
         assert_eq!(
             rule.check(path),
-            Some(FortitudeViolation::new_no_range(
-                "file extension should be '.f90' or '.F90'"
-            )),
+            Some(FortitudeViolation::new_no_range(rule.message())),
         );
     }
 
@@ -59,9 +65,7 @@ mod tests {
         let rule = NonStandardFileExtension::new(&default_settings());
         assert_eq!(
             rule.check(path),
-            Some(FortitudeViolation::new_no_range(
-                "file extension should be '.f90' or '.F90'"
-            )),
+            Some(FortitudeViolation::new_no_range(rule.message())),
         );
     }
 

--- a/src/rules/macros.rs
+++ b/src/rules/macros.rs
@@ -174,7 +174,7 @@ macro_rules! register_rules {
         }
 
         // Print the help text for a rule.
-        pub fn explain_rule<'a>(code: &'a str) -> &'a str {
+        pub fn explain_rule(code: &str) -> &str {
             match code {
                 $($codes => {$rules::explanation().unwrap()})+
                 _ => {

--- a/src/rules/macros.rs
+++ b/src/rules/macros.rs
@@ -174,9 +174,9 @@ macro_rules! register_rules {
         }
 
         // Print the help text for a rule.
-        pub fn explain_rule<'a>(code: &'a str, settings: &'a Settings) -> &'a str {
+        pub fn explain_rule<'a>(code: &'a str) -> &'a str {
             match code {
-                $($codes => {$rules::new(&settings).explain()})+
+                $($codes => {$rules::explanation().unwrap()})+
                 _ => {
                     ""
                 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::useless_format)]
 /// A collection of all rules, and utilities to select a subset at runtime.
-mod error;
+pub(crate) mod error; // Public so we can use `IOError` in other places
 mod filesystem;
 #[macro_use]
 mod macros;
@@ -11,6 +11,7 @@ mod typing;
 use crate::register_rules;
 
 register_rules! {
+    (Category::Error, "E000", PATH, error::ioerror::IOError, IoError),
     (Category::Error, "E001", AST, error::syntax_error::SyntaxError, SyntaxError),
     (Category::Filesystem, "F001", PATH, filesystem::extensions::NonStandardFileExtension, NonStandardFileExtension),
     (Category::Style, "S001", TEXT, style::line_length::LineTooLong, LineTooLong),

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::useless_format)]
 /// A collection of all rules, and utilities to select a subset at runtime.
 mod error;
 mod filesystem;

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -1,34 +1,46 @@
 use crate::settings::Settings;
 use crate::{ASTRule, FortitudeViolation, Rule};
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
-/// Defines rules that check whether functions and subroutines are defined within modules (or one
+/// ## What it does
+/// Checks whether functions and subroutines are defined within modules (or one
 /// of a few acceptable alternatives).
+///
+/// ## Why is this bad?
+/// Functions and subroutines should be contained within (sub)modules or programs.
+/// Fortran compilers are unable to perform type checks and conversions on functions
+/// defined outside of these scopes, and this is a common source of bugs.
+#[violation]
+pub struct ExternalFunction {
+    procedure: String,
+}
 
-pub struct ExternalFunction {}
+impl Violation for ExternalFunction {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let ExternalFunction { procedure } = self;
+        format!("{procedure} not contained within (sub)module or program")
+    }
+}
 
 impl Rule for ExternalFunction {
     fn new(_settings: &Settings) -> Self {
-        ExternalFunction {}
-    }
-
-    fn explain(&self) -> &'static str {
-        "
-        Functions and subroutines should be contained within (sub)modules or programs.
-        Fortran compilers are unable to perform type checks and conversions on functions
-        defined outside of these scopes, and this is a common source of bugs.
-        "
+        ExternalFunction {
+            procedure: String::default(),
+        }
     }
 }
 
 impl ASTRule for ExternalFunction {
     fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         if node.parent()?.kind() == "translation_unit" {
-            let msg = format!(
-                "{} not contained within (sub)module or program",
-                node.kind()
-            );
+            let msg = ExternalFunction {
+                procedure: node.kind().to_string(),
+            }
+            .message();
             let procedure_stmt = node.child(0)?;
             return some_vec![FortitudeViolation::from_node(msg, &procedure_stmt)];
         }
@@ -65,8 +77,12 @@ mod tests {
             [(1, 0, 1, 26, "function"), (6, 0, 6, 20, "subroutine")]
                 .iter()
                 .map(|(start_line, start_col, end_line, end_col, kind)| {
+                    let msg = ExternalFunction {
+                        procedure: kind.to_string(),
+                    }
+                    .message();
                     FortitudeViolation::from_start_end_line_col(
-                        format!("{kind} not contained within (sub)module or program"),
+                        msg,
                         &source,
                         *start_line,
                         *start_col,

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -61,19 +61,20 @@ mod tests {
             end subroutine
             ",
         );
-        let expected: Vec<FortitudeViolation> = [(1, 0, 1, 26, "function"), (6, 0, 6, 20, "subroutine")]
-            .iter()
-            .map(|(start_line, start_col, end_line, end_col, kind)| {
-                FortitudeViolation::from_start_end_line_col(
-                    format!("{kind} not contained within (sub)module or program"),
-                    &source,
-                    *start_line,
-                    *start_col,
-                    *end_line,
-                    *end_col,
-                )
-            })
-            .collect();
+        let expected: Vec<FortitudeViolation> =
+            [(1, 0, 1, 26, "function"), (6, 0, 6, 20, "subroutine")]
+                .iter()
+                .map(|(start_line, start_col, end_line, end_col, kind)| {
+                    FortitudeViolation::from_start_end_line_col(
+                        format!("{kind} not contained within (sub)module or program"),
+                        &source,
+                        *start_line,
+                        *start_col,
+                        *end_line,
+                        *end_col,
+                    )
+                })
+                .collect();
         let rule = ExternalFunction::new(&default_settings());
         let actual = rule.apply(&source)?;
         assert_eq!(actual, expected);

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -37,12 +37,12 @@ impl Rule for ExternalFunction {
 impl ASTRule for ExternalFunction {
     fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         if node.parent()?.kind() == "translation_unit" {
-            let msg = ExternalFunction {
-                procedure: node.kind().to_string(),
-            }
-            .message();
             let procedure_stmt = node.child(0)?;
-            return some_vec![FortitudeViolation::from_node(msg, &procedure_stmt)];
+            let procedure = node.kind().to_string();
+            return some_vec![FortitudeViolation::from_node(
+                ExternalFunction { procedure },
+                &procedure_stmt
+            )];
         }
         None
     }

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -1,45 +1,52 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{ASTRule, FortitudeViolation, Rule};
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
-/// Defines rules that check whether `use` statements are used correctly.
-
 // TODO Check that 'used' entity is actually used somewhere
 
+/// ## What it does
+/// Checks whether `use` statements are used correctly.
+///
+/// ## Why is this bad?
+/// When using a module, it is recommended to add an 'only' clause to specify which
+/// components you intend to use:
+///
+/// ## Example
+/// ```fortran
+/// ! Not recommended
+/// use, intrinsic :: iso_fortran_env
+///
+/// ! Better
+/// use, intrinsic :: iso_fortran_env, only: int32, real64
+/// ```
+///
+/// This makes it easier for programmers to understand where the symbols in your
+/// code have come from, and avoids introducing many unneeded components to your
+/// local scope.
+#[violation]
 pub struct UseAll {}
+
+impl Violation for UseAll {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("'use' statement missing 'only' clause")
+    }
+}
 
 impl Rule for UseAll {
     fn new(_settings: &Settings) -> Self {
         UseAll {}
-    }
-
-    fn explain(&self) -> &'static str {
-        "
-        When using a module, it is recommended to add an 'only' clause to specify which
-        components you intend to use:
-
-        ```
-        ! Not recommended
-        use, intrinsic :: iso_fortran_env
-
-        ! Better
-        use, intrinsic :: iso_fortran_env, only: int32, real64
-        ```
-
-        This makes it easier for programmers to understand where the symbols in your
-        code have come from, and avoids introducing many unneeded components to your
-        local scope.
-        "
     }
 }
 
 impl ASTRule for UseAll {
     fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         if node.child_with_name("included_items").is_none() {
-            let msg = "'use' statement missing 'only' clause";
-            return some_vec![FortitudeViolation::from_node(msg, node)];
+            return some_vec![FortitudeViolation::from_node(self.message(), node)];
         }
         None
     }
@@ -66,7 +73,7 @@ mod tests {
             ",
         );
         let expected = vec![FortitudeViolation::from_start_end_line_col(
-            "'use' statement missing 'only' clause",
+            UseAll {}.message(),
             &source,
             3,
             4,

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -46,7 +46,7 @@ impl Rule for UseAll {
 impl ASTRule for UseAll {
     fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         if node.child_with_name("included_items").is_none() {
-            return some_vec![FortitudeViolation::from_node(self.message(), node)];
+            return some_vec![FortitudeViolation::from_node(UseAll {}, node)];
         }
         None
     }

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FortitudeViolation, Rule};
-use ruff_diagnostics::Violation;
+use crate::{ASTRule, FromTSNode, Rule};
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
@@ -44,9 +44,9 @@ impl Rule for UseAll {
 }
 
 impl ASTRule for UseAll {
-    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
+    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if node.child_with_name("included_items").is_none() {
-            return some_vec![FortitudeViolation::from_node(UseAll {}, node)];
+            return some_vec![Diagnostic::from_node(UseAll {}, node)];
         }
         None
     }
@@ -59,7 +59,7 @@ impl ASTRule for UseAll {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file};
+    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -72,8 +72,8 @@ mod tests {
             end module
             ",
         );
-        let expected = vec![FortitudeViolation::from_start_end_line_col(
-            UseAll {}.message(),
+        let expected = vec![Diagnostic::from_start_end_line_col(
+            UseAll {},
             &source,
             3,
             4,

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, Violation};
+use crate::{ASTRule, Rule, FortitudeViolation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -36,10 +36,10 @@ impl Rule for UseAll {
 }
 
 impl ASTRule for UseAll {
-    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Violation>> {
+    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         if node.child_with_name("included_items").is_none() {
             let msg = "'use' statement missing 'only' clause";
-            return some_vec![Violation::from_node(msg, node)];
+            return some_vec![FortitudeViolation::from_node(msg, node)];
         }
         None
     }
@@ -65,7 +65,7 @@ mod tests {
             end module
             ",
         );
-        let expected = vec![Violation::from_start_end_line_col(
+        let expected = vec![FortitudeViolation::from_start_end_line_col(
             "'use' statement missing 'only' clause",
             &source,
             3,

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/precision/double_precision.rs
+++ b/src/rules/precision/double_precision.rs
@@ -1,53 +1,75 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{ASTRule, FortitudeViolation, Rule};
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
-/// Defines rules to avoid the 'double precision' and 'double complex' types.
 
 // TODO rule to prefer 1.23e4_sp over 1.23e4, and 1.23e4_dp over 1.23d4
 
-fn double_precision_err_msg(dtype: &str) -> Option<String> {
-    match dtype {
-        "double precision" => Some(String::from(
-            "prefer 'real(real64)' to 'double precision' (see 'iso_fortran_env')",
-        )),
-        "double complex" => Some(String::from(
-            "prefer 'complex(real64)' to 'double complex' (see 'iso_fortran_env')",
-        )),
-        _ => None,
+/// ## What it does
+/// Checks for use of 'double precision' and 'double complex' types.
+///
+/// ## Why is this bad?
+/// The 'double precision' type does not guarantee a 64-bit floating point number
+/// as one might expect. It is instead required to be twice the size of a default
+/// 'real', which may vary depending on your system and can be modified by compiler
+/// arguments. For portability, it is recommended to use `real(dp)`, with `dp` set
+/// in one of the following ways:
+///
+/// - `use, intrinsic :: iso_fortran_env, only: dp => real64`
+/// - `integer, parameter :: dp = selected_real_kind(15, 307)`
+///
+/// For code that should be compatible with C, you should instead use
+/// `real(c_double)`, which may be found in the intrinsic module `iso_c_binding`.
+#[violation]
+pub struct DoublePrecision {
+    original: String,           // TODO: could be &'static str
+    preferred: String,
+}
+
+impl DoublePrecision {
+    fn try_new<S: AsRef<str>>(original: S) -> Option<Self> {
+        match original.as_ref() {
+            "double precision" => Some(Self {
+                original: original.as_ref().to_string(),
+                preferred: "real(real64)".to_string(),
+            }),
+            "double complex" => Some(Self {
+                original: original.as_ref().to_string(),
+                preferred: "complex(real64)".to_string(),
+            }),
+            _ => None,
+        }
     }
 }
 
-pub struct DoublePrecision {}
+impl Violation for DoublePrecision {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let DoublePrecision {
+            original,
+            preferred,
+        } = self;
+        format!("prefer '{preferred}' to '{original}' (see 'iso_fortran_env')")
+    }
+}
 
 impl Rule for DoublePrecision {
     fn new(_settings: &Settings) -> Self {
-        Self {}
-    }
-
-    fn explain(&self) -> &'static str {
-        "
-        The 'double precision' type does not guarantee a 64-bit floating point number
-        as one might expect. It is instead required to be twice the size of a default
-        'real', which may vary depending on your system and can be modified by compiler
-        arguments. For portability, it is recommended to use `real(dp)`, with `dp` set
-        in one of the following ways:
-
-        - `use, intrinsic :: iso_fortran_env, only: dp => real64`
-        - `integer, parameter :: dp = selected_real_kind(15, 307)`
-
-        For code that should be compatible with C, you should instead use
-        `real(c_double)`, which may be found in the intrinsic module `iso_c_binding`.
-        "
+        Self {
+            original: String::default(),
+            preferred: String::default(),
+        }
     }
 }
 
 impl ASTRule for DoublePrecision {
     fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         let txt = node.to_text(src.source_text())?.to_lowercase();
-        if let Some(msg) = double_precision_err_msg(txt.as_str()) {
-            return some_vec![FortitudeViolation::from_node(msg.as_str(), node)];
+        if let Some(msg) = DoublePrecision::try_new(txt) {
+            return some_vec![FortitudeViolation::from_node(msg.message(), node)];
         }
         None
     }
@@ -95,8 +117,9 @@ mod tests {
         ]
         .iter()
         .map(|(start_line, start_col, end_line, end_col, kind)| {
+            let msg = DoublePrecision::try_new(kind).unwrap();
             FortitudeViolation::from_start_end_line_col(
-                double_precision_err_msg(kind).unwrap(),
+                msg.message(),
                 &source,
                 *start_line,
                 *start_col,

--- a/src/rules/precision/double_precision.rs
+++ b/src/rules/precision/double_precision.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 /// Defines rules to avoid the 'double precision' and 'double complex' types.

--- a/src/rules/precision/double_precision.rs
+++ b/src/rules/precision/double_precision.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, Violation};
+use crate::{ASTRule, Rule, FortitudeViolation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 /// Defines rules to avoid the 'double precision' and 'double complex' types.
@@ -44,10 +44,10 @@ impl Rule for DoublePrecision {
 }
 
 impl ASTRule for DoublePrecision {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Violation>> {
+    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         let txt = node.to_text(src.source_text())?.to_lowercase();
         if let Some(msg) = double_precision_err_msg(txt.as_str()) {
-            return some_vec![Violation::from_node(msg.as_str(), node)];
+            return some_vec![FortitudeViolation::from_node(msg.as_str(), node)];
         }
         None
     }
@@ -85,7 +85,7 @@ mod tests {
             end function
             ",
         );
-        let expected: Vec<Violation> = [
+        let expected: Vec<FortitudeViolation> = [
             (1, 0, 1, 16, "double precision"),
             (2, 2, 2, 18, "double precision"),
             (7, 2, 7, 18, "double precision"),
@@ -95,7 +95,7 @@ mod tests {
         ]
         .iter()
         .map(|(start_line, start_col, end_line, end_col, kind)| {
-            Violation::from_start_end_line_col(
+            FortitudeViolation::from_start_end_line_col(
                 double_precision_err_msg(kind).unwrap(),
                 &source,
                 *start_line,

--- a/src/rules/precision/double_precision.rs
+++ b/src/rules/precision/double_precision.rs
@@ -25,7 +25,7 @@ use tree_sitter::Node;
 /// `real(c_double)`, which may be found in the intrinsic module `iso_c_binding`.
 #[violation]
 pub struct DoublePrecision {
-    original: String,           // TODO: could be &'static str
+    original: String, // TODO: could be &'static str
     preferred: String,
 }
 
@@ -68,10 +68,10 @@ impl Rule for DoublePrecision {
 impl ASTRule for DoublePrecision {
     fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         let txt = node.to_text(src.source_text())?.to_lowercase();
-        if let Some(msg) = DoublePrecision::try_new(txt) {
-            return some_vec![FortitudeViolation::from_node(msg.message(), node)];
-        }
-        None
+        some_vec![FortitudeViolation::from_node(
+            DoublePrecision::try_new(txt)?,
+            node
+        )]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {

--- a/src/rules/precision/double_precision.rs
+++ b/src/rules/precision/double_precision.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/precision/implicit_kinds.rs
+++ b/src/rules/precision/implicit_kinds.rs
@@ -46,8 +46,10 @@ impl ASTRule for ImplicitRealKind {
             return None;
         }
 
-        let msg = ImplicitRealKind { dtype }.message();
-        some_vec![FortitudeViolation::from_node(msg, node)]
+        some_vec![FortitudeViolation::from_node(
+            ImplicitRealKind { dtype },
+            node
+        )]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {

--- a/src/rules/precision/implicit_kinds.rs
+++ b/src/rules/precision/implicit_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 /// Defines rules that require the user to explicitly specify the kinds of any reals.

--- a/src/rules/precision/implicit_kinds.rs
+++ b/src/rules/precision/implicit_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, Violation};
+use crate::{ASTRule, Rule, FortitudeViolation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 /// Defines rules that require the user to explicitly specify the kinds of any reals.
@@ -21,7 +21,7 @@ impl Rule for ImplicitRealKind {
 }
 
 impl ASTRule for ImplicitRealKind {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Violation>> {
+    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         let dtype = node.child(0)?.to_text(src.source_text())?.to_lowercase();
 
         if !matches!(dtype.as_str(), "real" | "complex") {
@@ -33,7 +33,7 @@ impl ASTRule for ImplicitRealKind {
         }
 
         let msg = format!("{dtype} has implicit kind");
-        some_vec![Violation::from_node(msg, node)]
+        some_vec![FortitudeViolation::from_node(msg, node)]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {
@@ -63,14 +63,14 @@ mod tests {
             ",
         );
 
-        let expected: Vec<Violation> = [
+        let expected: Vec<FortitudeViolation> = [
             (1, 0, 1, 4, "real"),
             (2, 2, 2, 6, "real"),
             (5, 2, 5, 9, "complex"),
         ]
         .iter()
         .map(|(start_line, start_col, end_line, end_col, dtype)| {
-            Violation::from_start_end_line_col(
+            FortitudeViolation::from_start_end_line_col(
                 format!("{dtype} has implicit kind"),
                 &source,
                 *start_line,

--- a/src/rules/precision/implicit_kinds.rs
+++ b/src/rules/precision/implicit_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/precision/kind_suffixes.rs
+++ b/src/rules/precision/kind_suffixes.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};

--- a/src/rules/precision/kind_suffixes.rs
+++ b/src/rules/precision/kind_suffixes.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, Violation};
+use crate::{ASTRule, Rule, FortitudeViolation};
 use lazy_regex::regex_is_match;
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
@@ -54,7 +54,7 @@ impl Rule for NoRealSuffix {
 }
 
 impl ASTRule for NoRealSuffix {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Violation>> {
+    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         // Given a number literal, match anything with one or more of a decimal place or
         // an exponentiation e or E. There should not be an underscore present.
         // Exponentiation with d or D are ignored, and should be handled with a different
@@ -62,7 +62,7 @@ impl ASTRule for NoRealSuffix {
         let txt = node.to_text(src.source_text())?;
         if regex_is_match!(r"^(\d*\.\d*|\d*\.*\d*[eE]\d+)$", txt) {
             let msg = format!("real literal {} missing kind suffix", txt);
-            return some_vec![Violation::from_node(msg, node)];
+            return some_vec![FortitudeViolation::from_node(msg, node)];
         }
         None
     }
@@ -98,7 +98,7 @@ mod tests {
 
             ",
         );
-        let expected: Vec<Violation> = [
+        let expected: Vec<FortitudeViolation> = [
             (3, 28, 3, 36, "1.234567"),
             (6, 28, 6, 33, "9.876"),
             (8, 28, 8, 30, "2."),
@@ -110,7 +110,7 @@ mod tests {
         ]
         .iter()
         .map(|(start_line, start_col, end_line, end_col, num)| {
-            Violation::from_start_end_line_col(
+            FortitudeViolation::from_start_end_line_col(
                 format!("real literal {num} missing kind suffix"),
                 &source,
                 *start_line,

--- a/src/rules/precision/kind_suffixes.rs
+++ b/src/rules/precision/kind_suffixes.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use lazy_regex::regex_is_match;
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;

--- a/src/rules/style/end_statements.rs
+++ b/src/rules/style/end_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/src/rules/style/end_statements.rs
+++ b/src/rules/style/end_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, Violation};
+use crate::{ASTRule, Rule, FortitudeViolation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -58,7 +58,7 @@ fn map_declaration(kind: &str) -> (&'static str, &'static str) {
 }
 
 impl ASTRule for UnnamedEndStatement {
-    fn check<'a>(&self, node: &'a Node, src: &'a SourceFile) -> Option<Vec<Violation>> {
+    fn check<'a>(&self, node: &'a Node, src: &'a SourceFile) -> Option<Vec<FortitudeViolation>> {
         // TODO Also check for optionally labelled constructs like 'do' or 'select'
 
         // If end node is named, move on.
@@ -79,7 +79,7 @@ impl ASTRule for UnnamedEndStatement {
             .child_with_name(name_kind)?
             .to_text(src.source_text())?;
         let msg = format!("end statement should read 'end {statement} {name}'");
-        some_vec![Violation::from_node(msg, node)]
+        some_vec![FortitudeViolation::from_node(msg, node)]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {
@@ -168,7 +168,7 @@ mod tests {
             end                             ! catch this
             ",
         );
-        let expected: Vec<Violation> = [
+        let expected: Vec<FortitudeViolation> = [
             (5, 2, 5, 32, "type", "mytype"),
             (9, 2, 9, 32, "subroutine", "mysub1"),
             (13, 0, 13, 32, "module", "mymod1"),
@@ -182,7 +182,7 @@ mod tests {
         .iter()
         .map(
             |(start_line, start_col, end_line, end_col, statement, name)| {
-                Violation::from_start_end_line_col(
+                FortitudeViolation::from_start_end_line_col(
                     format!("end statement should read 'end {statement} {name}'"),
                     &source,
                     *start_line,

--- a/src/rules/style/end_statements.rs
+++ b/src/rules/style/end_statements.rs
@@ -93,13 +93,13 @@ impl ASTRule for UnnamedEndStatement {
         };
         let name = statement_node
             .child_with_name(name_kind)?
-            .to_text(src.source_text())?;
-        let msg = Self {
-            statement: statement.to_string(),
-            name: name.to_string(),
-        }
-        .message();
-        some_vec![FortitudeViolation::from_node(msg, node)]
+            .to_text(src.source_text())?
+            .to_string();
+        let statement = statement.to_string();
+        some_vec![FortitudeViolation::from_node(
+            Self { statement, name },
+            node
+        )]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {

--- a/src/rules/style/end_statements.rs
+++ b/src/rules/style/end_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/style/exit_labels.rs
+++ b/src/rules/style/exit_labels.rs
@@ -57,12 +57,13 @@ impl ASTRule for MissingExitOrCycleLabel {
             .map(|stmt| (stmt, stmt.to_text(src).unwrap_or_default().to_lowercase()))
             .filter(|(_, name)| name == "exit" || name == "cycle")
             .map(|(stmt, name)| {
-                let msg = Self {
-                    name: name.to_string(),
-                    label: label.to_string(),
-                }
-                .message();
-                FortitudeViolation::from_node(msg, &stmt)
+                FortitudeViolation::from_node(
+                    Self {
+                        name: name.to_string(),
+                        label: label.to_string(),
+                    },
+                    &stmt,
+                )
             })
             .collect();
 

--- a/src/rules/style/exit_labels.rs
+++ b/src/rules/style/exit_labels.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/src/rules/style/exit_labels.rs
+++ b/src/rules/style/exit_labels.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{Rule, TextRule, FortitudeViolation};
+use crate::{FortitudeViolation, Rule, TextRule};
 use lazy_regex::regex_is_match;
 use ruff_source_file::SourceFile;
 /// Defines rules that govern line length.
@@ -86,19 +86,20 @@ mod tests {
 
         let line_length = 20;
         let short_line_settings = Settings { line_length };
-        let expected: Vec<FortitudeViolation> = [(2, line_length, 2, 68, 68), (4, line_length, 4, 72, 72)]
-            .iter()
-            .map(|(start_line, start_col, end_line, end_col, length)| {
-                FortitudeViolation::from_start_end_line_col(
-                    format!("line length of {length}, exceeds maximum {line_length}"),
-                    &source,
-                    *start_line,
-                    *start_col,
-                    *end_line,
-                    *end_col,
-                )
-            })
-            .collect();
+        let expected: Vec<FortitudeViolation> =
+            [(2, line_length, 2, 68, 68), (4, line_length, 4, 72, 72)]
+                .iter()
+                .map(|(start_line, start_col, end_line, end_col, length)| {
+                    FortitudeViolation::from_start_end_line_col(
+                        format!("line length of {length}, exceeds maximum {line_length}"),
+                        &source,
+                        *start_line,
+                        *start_col,
+                        *end_line,
+                        *end_col,
+                    )
+                })
+                .collect();
         let rule = LineTooLong::new(&short_line_settings);
         let actual = rule.check(&source);
         assert_eq!(actual, expected);

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -1,63 +1,78 @@
 use crate::settings::Settings;
 use crate::{FortitudeViolation, Rule, TextRule};
 use lazy_regex::regex_is_match;
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 /// Defines rules that govern line length.
 
+/// ## What does it do?
+/// Checks line length isn't too long
+///
+/// ## Why is this bad?
+/// Long lines are more difficult to read, and may not fit on some developers'
+/// terminals. The line continuation character '&' may be used to split a long line
+/// across multiple lines, and overly long expressions may be broken down into
+/// multiple parts.
+///
+/// The maximum line length can be changed using the flag `--line-length=N`. The
+/// default maximum line length is 100 characters. This is a fair bit more than the
+/// traditional 80, but due to the verbosity of modern Fortran it can sometimes be
+/// difficult to squeeze lines into that width, especially when using large indents
+/// and multiple levels of indentation.
+///
+/// Note that the Fortran standard states a maximum line length of 132 characters,
+/// and while some modern compilers will support longer lines, for portability it
+/// is recommended to stay beneath this limit.
+#[violation]
 pub struct LineTooLong {
-    line_length: usize,
+    max_length: usize,
+    actual_length: usize,
+}
+
+impl Violation for LineTooLong {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self {
+            max_length,
+            actual_length,
+        } = self;
+        format!("line length of {actual_length}, exceeds maximum {max_length}")
+    }
 }
 
 impl Rule for LineTooLong {
     fn new(settings: &Settings) -> Self {
         LineTooLong {
-            line_length: settings.line_length,
+            max_length: settings.line_length,
+            actual_length: 0,
         }
     }
-
-    fn explain(&self) -> &'static str {
-        "
-        Long lines are more difficult to read, and may not fit on some developers'
-        terminals. The line continuation character '&' may be used to split a long line
-        across multiple lines, and overly long expressions may be broken down into
-        multiple parts.
-
-        The maximum line length can be changed using the flag `--line-length=N`. The
-        default maximum line length is 100 characters. This is a fair bit more than the
-        traditional 80, but due to the verbosity of modern Fortran it can sometimes be
-        difficult to squeeze lines into that width, especially when using large indents
-        and multiple levels of indentation.
-
-        Note that the Fortran standard states a maximum line length of 132 characters,
-        and while some modern compilers will support longer lines, for portability it
-        is recommended to stay beneath this limit.
-        "
-    }
 }
-
 impl TextRule for LineTooLong {
     fn check(&self, source: &SourceFile) -> Vec<FortitudeViolation> {
         let mut violations = Vec::new();
         for (idx, line) in source.source_text().split('\n').enumerate() {
-            let len = line.len();
-            if len > self.line_length {
+            let actual_length = line.len();
+            if actual_length > self.max_length {
                 // Are we ending on a string or comment? If so, we'll allow it through, as it may
                 // contain something like a long URL that cannot be reasonably split across multiple
                 // lines.
                 if regex_is_match!(r#"(["']\w*&?$)|(!.*$)|(^\w*&)"#, line) {
                     continue;
                 }
-                let msg = format!(
-                    "line length of {}, exceeds maximum {}",
-                    len, self.line_length
-                );
+                let msg = Self {
+                    max_length: self.max_length,
+                    actual_length,
+                }
+                .message();
                 violations.push(FortitudeViolation::from_start_end_line_col(
                     msg,
                     source,
                     idx,
-                    self.line_length,
+                    self.max_length,
                     idx,
-                    len,
+                    actual_length,
                 ))
             }
         }
@@ -84,21 +99,29 @@ mod tests {
             ",
         );
 
-        let line_length = 20;
-        let short_line_settings = Settings { line_length };
+        let max_length = 20;
+        let short_line_settings = Settings {
+            line_length: max_length,
+        };
         let expected: Vec<FortitudeViolation> =
-            [(2, line_length, 2, 68, 68), (4, line_length, 4, 72, 72)]
+            [(2, max_length, 2, 68, 68usize), (4, max_length, 4, 72, 72usize)]
                 .iter()
-                .map(|(start_line, start_col, end_line, end_col, length)| {
-                    FortitudeViolation::from_start_end_line_col(
-                        format!("line length of {length}, exceeds maximum {line_length}"),
-                        &source,
-                        *start_line,
-                        *start_col,
-                        *end_line,
-                        *end_col,
-                    )
-                })
+                .map(
+                    |(start_line, start_col, end_line, end_col, actual_length)| {
+                        FortitudeViolation::from_start_end_line_col(
+                            LineTooLong {
+                                max_length,
+                                actual_length: *actual_length,
+                            }
+                            .message(),
+                            &source,
+                            *start_line,
+                            *start_col,
+                            *end_line,
+                            *end_col,
+                        )
+                    },
+                )
                 .collect();
         let rule = LineTooLong::new(&short_line_settings);
         let actual = rule.check(&source);

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -103,26 +103,28 @@ mod tests {
         let short_line_settings = Settings {
             line_length: max_length,
         };
-        let expected: Vec<FortitudeViolation> =
-            [(2, max_length, 2, 68, 68usize), (4, max_length, 4, 72, 72usize)]
-                .iter()
-                .map(
-                    |(start_line, start_col, end_line, end_col, actual_length)| {
-                        FortitudeViolation::from_start_end_line_col(
-                            LineTooLong {
-                                max_length,
-                                actual_length: *actual_length,
-                            }
-                            .message(),
-                            &source,
-                            *start_line,
-                            *start_col,
-                            *end_line,
-                            *end_col,
-                        )
-                    },
+        let expected: Vec<FortitudeViolation> = [
+            (2, max_length, 2, 68, 68usize),
+            (4, max_length, 4, 72, 72usize),
+        ]
+        .iter()
+        .map(
+            |(start_line, start_col, end_line, end_col, actual_length)| {
+                FortitudeViolation::from_start_end_line_col(
+                    LineTooLong {
+                        max_length,
+                        actual_length: *actual_length,
+                    }
+                    .message(),
+                    &source,
+                    *start_line,
+                    *start_col,
+                    *end_line,
+                    *end_col,
                 )
-                .collect();
+            },
+        )
+        .collect();
         let rule = LineTooLong::new(&short_line_settings);
         let actual = rule.check(&source);
         assert_eq!(actual, expected);

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{Rule, TextRule, Violation};
+use crate::{Rule, TextRule, FortitudeViolation};
 use lazy_regex::regex_is_match;
 use ruff_source_file::SourceFile;
 /// Defines rules that govern line length.
@@ -36,7 +36,7 @@ impl Rule for LineTooLong {
 }
 
 impl TextRule for LineTooLong {
-    fn check(&self, source: &SourceFile) -> Vec<Violation> {
+    fn check(&self, source: &SourceFile) -> Vec<FortitudeViolation> {
         let mut violations = Vec::new();
         for (idx, line) in source.source_text().split('\n').enumerate() {
             let len = line.len();
@@ -51,7 +51,7 @@ impl TextRule for LineTooLong {
                     "line length of {}, exceeds maximum {}",
                     len, self.line_length
                 );
-                violations.push(Violation::from_start_end_line_col(
+                violations.push(FortitudeViolation::from_start_end_line_col(
                     msg,
                     source,
                     idx,
@@ -86,10 +86,10 @@ mod tests {
 
         let line_length = 20;
         let short_line_settings = Settings { line_length };
-        let expected: Vec<Violation> = [(2, line_length, 2, 68, 68), (4, line_length, 4, 72, 72)]
+        let expected: Vec<FortitudeViolation> = [(2, line_length, 2, 68, 68), (4, line_length, 4, 72, 72)]
             .iter()
             .map(|(start_line, start_col, end_line, end_col, length)| {
-                Violation::from_start_end_line_col(
+                FortitudeViolation::from_start_end_line_col(
                     format!("line length of {length}, exceeds maximum {line_length}"),
                     &source,
                     *start_line,

--- a/src/rules/style/old_style_array_literal.rs
+++ b/src/rules/style/old_style_array_literal.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, Violation};
+use crate::{ASTRule, Rule, FortitudeViolation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -21,10 +21,10 @@ impl Rule for OldStyleArrayLiteral {
 }
 
 impl ASTRule for OldStyleArrayLiteral {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Violation>> {
+    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         if node.to_text(src.source_text())?.starts_with("(/") {
             let msg = "Array literal uses old-style syntax: prefer `[...]`";
-            return some_vec!(Violation::from_node(msg, node));
+            return some_vec!(FortitudeViolation::from_node(msg, node));
         }
         None
     }
@@ -60,7 +60,7 @@ mod tests {
              end program test
             ",
         );
-        let expected: Vec<Violation> = [
+        let expected: Vec<FortitudeViolation> = [
             (2, 20, 2, 31),
             (3, 20, 7, 4),
             (8, 17, 8, 28),
@@ -68,7 +68,7 @@ mod tests {
         ]
         .iter()
         .map(|(start_line, start_col, end_line, end_col)| {
-            Violation::from_start_end_line_col(
+            FortitudeViolation::from_start_end_line_col(
                 "Array literal uses old-style syntax: prefer `[...]`",
                 &source,
                 *start_line,

--- a/src/rules/style/old_style_array_literal.rs
+++ b/src/rules/style/old_style_array_literal.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/src/rules/style/old_style_array_literal.rs
+++ b/src/rules/style/old_style_array_literal.rs
@@ -31,7 +31,7 @@ impl Rule for OldStyleArrayLiteral {
 impl ASTRule for OldStyleArrayLiteral {
     fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         if node.to_text(src.source_text())?.starts_with("(/") {
-            return some_vec!(FortitudeViolation::from_node(Self {}.message(), node));
+            return some_vec!(FortitudeViolation::from_node(Self {}, node));
         }
         None
     }
@@ -76,7 +76,7 @@ mod tests {
         .iter()
         .map(|(start_line, start_col, end_line, end_col)| {
             FortitudeViolation::from_start_end_line_col(
-                OldStyleArrayLiteral{}.message(),
+                OldStyleArrayLiteral {}.message(),
                 &source,
                 *start_line,
                 *start_col,

--- a/src/rules/style/old_style_array_literal.rs
+++ b/src/rules/style/old_style_array_literal.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FortitudeViolation, Rule};
-use ruff_diagnostics::Violation;
+use crate::{ASTRule, FromTSNode, Rule};
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
@@ -29,9 +29,9 @@ impl Rule for OldStyleArrayLiteral {
     }
 }
 impl ASTRule for OldStyleArrayLiteral {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
+    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if node.to_text(src.source_text())?.starts_with("(/") {
-            return some_vec!(FortitudeViolation::from_node(Self {}, node));
+            return some_vec!(Diagnostic::from_node(Self {}, node));
         }
         None
     }
@@ -44,7 +44,7 @@ impl ASTRule for OldStyleArrayLiteral {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file};
+    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -67,7 +67,7 @@ mod tests {
              end program test
             ",
         );
-        let expected: Vec<FortitudeViolation> = [
+        let expected: Vec<_> = [
             (2, 20, 2, 31),
             (3, 20, 7, 4),
             (8, 17, 8, 28),
@@ -75,8 +75,8 @@ mod tests {
         ]
         .iter()
         .map(|(start_line, start_col, end_line, end_col)| {
-            FortitudeViolation::from_start_end_line_col(
-                OldStyleArrayLiteral {}.message(),
+            Diagnostic::from_start_end_line_col(
+                OldStyleArrayLiteral {},
                 &source,
                 *start_line,
                 *start_col,

--- a/src/rules/style/old_style_array_literal.rs
+++ b/src/rules/style/old_style_array_literal.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/style/relational_operators.rs
+++ b/src/rules/style/relational_operators.rs
@@ -55,8 +55,10 @@ impl ASTRule for DeprecatedRelationalOperator {
             .to_lowercase()
             .to_string();
         let new_symbol = map_relational_symbols(symbol.as_str())?.to_string();
-        let msg = Self { symbol, new_symbol }.message();
-        some_vec![FortitudeViolation::from_node(msg, &relation)]
+        some_vec![FortitudeViolation::from_node(
+            Self { symbol, new_symbol },
+            &relation
+        )]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {

--- a/src/rules/style/relational_operators.rs
+++ b/src/rules/style/relational_operators.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/src/rules/style/relational_operators.rs
+++ b/src/rules/style/relational_operators.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, Violation};
+use crate::{ASTRule, Rule, FortitudeViolation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -33,13 +33,13 @@ impl Rule for DeprecatedRelationalOperator {
 }
 
 impl ASTRule for DeprecatedRelationalOperator {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Violation>> {
+    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         let relation = node.child(1)?;
         let symbol = relation.to_text(src.source_text())?.to_lowercase();
         let new_symbol = map_relational_symbols(symbol.as_str())?;
         let msg =
             format!("deprecated relational operator '{symbol}', prefer '{new_symbol}' instead");
-        some_vec![Violation::from_node(msg, &relation)]
+        some_vec![FortitudeViolation::from_node(msg, &relation)]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {
@@ -66,7 +66,7 @@ mod tests {
             end program test
             ",
         );
-        let expected: Vec<Violation> =
+        let expected: Vec<FortitudeViolation> =
             [
                 (2, 8, 2, 12, ".gt.", ">"),
                 (3, 8, 3, 12, ".le.", "<="),
@@ -76,7 +76,7 @@ mod tests {
             .iter()
             .map(
                 |(start_line, start_col, end_line, end_col, symbol, new_symbol)| {
-                    Violation::from_start_end_line_col(
+                    FortitudeViolation::from_start_end_line_col(
                 format!("deprecated relational operator '{symbol}', prefer '{new_symbol}' instead"),
                 &source,
                 *start_line,

--- a/src/rules/style/relational_operators.rs
+++ b/src/rules/style/relational_operators.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/style/relational_operators.rs
+++ b/src/rules/style/relational_operators.rs
@@ -1,6 +1,8 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{ASTRule, FortitudeViolation, Rule};
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -16,29 +18,44 @@ fn map_relational_symbols(name: &str) -> Option<&'static str> {
     }
 }
 
-pub struct DeprecatedRelationalOperator {}
+/// ## What does it do?
+/// Checks for deprecated relational operators
+///
+/// ## Why is this bad?
+/// Fortran 90 introduced the traditional symbols for relational operators: `>`,
+/// `>=`, `<`, and so on. Prefer these over the deprecated forms `.gt.`, `.le.`, and
+/// so on.
+#[violation]
+pub struct DeprecatedRelationalOperator {
+    symbol: String,
+    new_symbol: String,
+}
 
-impl Rule for DeprecatedRelationalOperator {
-    fn new(_settings: &Settings) -> Self {
-        Self {}
-    }
-
-    fn explain(&self) -> &'static str {
-        "
-        Fortran 90 introduced the traditional symbols for relational operators: `>`,
-        `>=`, `<`, and so on. Prefer these over the deprecated forms `.gt.`, `.le.`, and
-        so on.
-        "
+impl Violation for DeprecatedRelationalOperator {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self { symbol, new_symbol } = self;
+        format!("deprecated relational operator '{symbol}', prefer '{new_symbol}' instead")
     }
 }
 
+impl Rule for DeprecatedRelationalOperator {
+    fn new(_settings: &Settings) -> Self {
+        Self {
+            symbol: String::default(),
+            new_symbol: String::default(),
+        }
+    }
+}
 impl ASTRule for DeprecatedRelationalOperator {
     fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         let relation = node.child(1)?;
-        let symbol = relation.to_text(src.source_text())?.to_lowercase();
-        let new_symbol = map_relational_symbols(symbol.as_str())?;
-        let msg =
-            format!("deprecated relational operator '{symbol}', prefer '{new_symbol}' instead");
+        let symbol = relation
+            .to_text(src.source_text())?
+            .to_lowercase()
+            .to_string();
+        let new_symbol = map_relational_symbols(symbol.as_str())?.to_string();
+        let msg = Self { symbol, new_symbol }.message();
         some_vec![FortitudeViolation::from_node(msg, &relation)]
     }
 
@@ -66,27 +83,30 @@ mod tests {
             end program test
             ",
         );
-        let expected: Vec<FortitudeViolation> =
-            [
-                (2, 8, 2, 12, ".gt.", ">"),
-                (3, 8, 3, 12, ".le.", "<="),
-                (4, 7, 4, 11, ".eq.", "=="),
-                (4, 18, 4, 22, ".ne.", "/="),
-            ]
-            .iter()
-            .map(
-                |(start_line, start_col, end_line, end_col, symbol, new_symbol)| {
-                    FortitudeViolation::from_start_end_line_col(
-                format!("deprecated relational operator '{symbol}', prefer '{new_symbol}' instead"),
-                &source,
-                *start_line,
-                *start_col,
-                *end_line,
-                *end_col,
-            )
-                },
-            )
-            .collect();
+        let expected: Vec<FortitudeViolation> = [
+            (2, 8, 2, 12, ".gt.", ">"),
+            (3, 8, 3, 12, ".le.", "<="),
+            (4, 7, 4, 11, ".eq.", "=="),
+            (4, 18, 4, 22, ".ne.", "/="),
+        ]
+        .iter()
+        .map(
+            |(start_line, start_col, end_line, end_col, symbol, new_symbol)| {
+                FortitudeViolation::from_start_end_line_col(
+                    DeprecatedRelationalOperator {
+                        symbol: symbol.to_string(),
+                        new_symbol: new_symbol.to_string(),
+                    }
+                    .message(),
+                    &source,
+                    *start_line,
+                    *start_col,
+                    *end_line,
+                    *end_col,
+                )
+            },
+        )
+        .collect();
         let rule = DeprecatedRelationalOperator::new(&default_settings());
         let actual = rule.apply(&source)?;
         assert_eq!(actual, expected);

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -1,9 +1,9 @@
-use ruff_diagnostics::Violation;
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 
 use crate::settings::Settings;
-use crate::{FortitudeViolation, Rule, TextRule};
+use crate::{FromStartEndLineCol, Rule, TextRule};
 /// Defines rules that enforce widely accepted whitespace rules.
 
 /// ## What does it do?
@@ -29,12 +29,12 @@ impl Rule for TrailingWhitespace {
     }
 }
 impl TextRule for TrailingWhitespace {
-    fn check(&self, source: &SourceFile) -> Vec<FortitudeViolation> {
+    fn check(&self, source: &SourceFile) -> Vec<Diagnostic> {
         let mut violations = Vec::new();
         for (idx, line) in source.source_text().split('\n').enumerate() {
-            if line.ends_with(&[' ', '\t']) {
-                violations.push(FortitudeViolation::from_start_end_line_col(
-                    Self {}.message(),
+            if line.ends_with([' ', '\t']) {
+                violations.push(Diagnostic::from_start_end_line_col(
+                    Self {},
                     source,
                     idx,
                     line.trim_end().len(),
@@ -72,12 +72,12 @@ end program test
 ";
         let file = SourceFileBuilder::new("test", source).finish();
 
-        let expected: Vec<FortitudeViolation> =
+        let expected: Vec<Diagnostic> =
             [(0, 13, 0, 15), (3, 23, 3, 24), (7, 3, 7, 7), (8, 0, 8, 3)]
                 .iter()
                 .map(|(start_line, start_col, end_line, end_col)| {
-                    FortitudeViolation::from_start_end_line_col(
-                        TrailingWhitespace {}.message(),
+                    Diagnostic::from_start_end_line_col(
+                        TrailingWhitespace {},
                         &file,
                         *start_line,
                         *start_col,

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -34,7 +34,7 @@ impl TextRule for TrailingWhitespace {
         for (idx, line) in source.source_text().split('\n').enumerate() {
             if line.ends_with(&[' ', '\t']) {
                 violations.push(FortitudeViolation::from_start_end_line_col(
-                    Self{}.message(),
+                    Self {}.message(),
                     source,
                     idx,
                     line.trim_end().len(),
@@ -77,7 +77,7 @@ end program test
                 .iter()
                 .map(|(start_line, start_col, end_line, end_col)| {
                     FortitudeViolation::from_start_end_line_col(
-                        TrailingWhitespace{}.message(),
+                        TrailingWhitespace {}.message(),
                         &file,
                         *start_line,
                         *start_col,

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -1,7 +1,7 @@
 use ruff_source_file::SourceFile;
 
 use crate::settings::Settings;
-use crate::{Rule, TextRule, Violation};
+use crate::{Rule, TextRule, FortitudeViolation};
 /// Defines rules that enforce widely accepted whitespace rules.
 
 pub struct TrailingWhitespace {}
@@ -21,11 +21,11 @@ impl Rule for TrailingWhitespace {
 }
 
 impl TextRule for TrailingWhitespace {
-    fn check(&self, source: &SourceFile) -> Vec<Violation> {
+    fn check(&self, source: &SourceFile) -> Vec<FortitudeViolation> {
         let mut violations = Vec::new();
         for (idx, line) in source.source_text().split('\n').enumerate() {
             if line.ends_with(&[' ', '\t']) {
-                violations.push(Violation::from_start_end_line_col(
+                violations.push(FortitudeViolation::from_start_end_line_col(
                     "trailing whitespace",
                     source,
                     idx,
@@ -64,10 +64,10 @@ end program test
 ";
         let file = SourceFileBuilder::new("test", source).finish();
 
-        let expected: Vec<Violation> = [(0, 13, 0, 15), (3, 23, 3, 24), (7, 3, 7, 7), (8, 0, 8, 3)]
+        let expected: Vec<FortitudeViolation> = [(0, 13, 0, 15), (3, 23, 3, 24), (7, 3, 7, 7), (8, 0, 8, 3)]
             .iter()
             .map(|(start_line, start_col, end_line, end_col)| {
-                Violation::from_start_end_line_col(
+                FortitudeViolation::from_start_end_line_col(
                     "trailing whitespace",
                     &file,
                     *start_line,

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -1,32 +1,40 @@
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 
 use crate::settings::Settings;
 use crate::{FortitudeViolation, Rule, TextRule};
 /// Defines rules that enforce widely accepted whitespace rules.
 
+/// ## What does it do?
+/// Checks for tailing whitespace
+///
+/// ## Why is this bad?
+/// Trailing whitespace is difficult to spot, and as some editors will remove it
+/// automatically while others leave it, it can cause unwanted 'diff noise' in
+/// shared projects.
+#[violation]
 pub struct TrailingWhitespace {}
+
+impl Violation for TrailingWhitespace {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("trailing whitespace")
+    }
+}
 
 impl Rule for TrailingWhitespace {
     fn new(_settings: &Settings) -> Self {
         TrailingWhitespace {}
     }
-
-    fn explain(&self) -> &'static str {
-        "
-        Trailing whitespace is difficult to spot, and as some editors will remove it
-        automatically while others leave it, it can cause unwanted 'diff noise' in
-        shared projects.
-        "
-    }
 }
-
 impl TextRule for TrailingWhitespace {
     fn check(&self, source: &SourceFile) -> Vec<FortitudeViolation> {
         let mut violations = Vec::new();
         for (idx, line) in source.source_text().split('\n').enumerate() {
             if line.ends_with(&[' ', '\t']) {
                 violations.push(FortitudeViolation::from_start_end_line_col(
-                    "trailing whitespace",
+                    Self{}.message(),
                     source,
                     idx,
                     line.trim_end().len(),
@@ -69,7 +77,7 @@ end program test
                 .iter()
                 .map(|(start_line, start_col, end_line, end_col)| {
                     FortitudeViolation::from_start_end_line_col(
-                        "trailing whitespace",
+                        TrailingWhitespace{}.message(),
                         &file,
                         *start_line,
                         *start_col,

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -1,7 +1,7 @@
 use ruff_source_file::SourceFile;
 
 use crate::settings::Settings;
-use crate::{Rule, TextRule, FortitudeViolation};
+use crate::{FortitudeViolation, Rule, TextRule};
 /// Defines rules that enforce widely accepted whitespace rules.
 
 pub struct TrailingWhitespace {}
@@ -64,19 +64,20 @@ end program test
 ";
         let file = SourceFileBuilder::new("test", source).finish();
 
-        let expected: Vec<FortitudeViolation> = [(0, 13, 0, 15), (3, 23, 3, 24), (7, 3, 7, 7), (8, 0, 8, 3)]
-            .iter()
-            .map(|(start_line, start_col, end_line, end_col)| {
-                FortitudeViolation::from_start_end_line_col(
-                    "trailing whitespace",
-                    &file,
-                    *start_line,
-                    *start_col,
-                    *end_line,
-                    *end_col,
-                )
-            })
-            .collect();
+        let expected: Vec<FortitudeViolation> =
+            [(0, 13, 0, 15), (3, 23, 3, 24), (7, 3, 7, 7), (8, 0, 8, 3)]
+                .iter()
+                .map(|(start_line, start_col, end_line, end_col)| {
+                    FortitudeViolation::from_start_end_line_col(
+                        "trailing whitespace",
+                        &file,
+                        *start_line,
+                        *start_col,
+                        *end_line,
+                        *end_col,
+                    )
+                })
+                .collect();
         let rule = TrailingWhitespace::new(&default_settings());
         let actual = rule.check(&file);
         assert_eq!(actual, expected);

--- a/src/rules/typing/assumed_size.rs
+++ b/src/rules/typing/assumed_size.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use itertools::Itertools;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};

--- a/src/rules/typing/assumed_size.rs
+++ b/src/rules/typing/assumed_size.rs
@@ -93,8 +93,7 @@ impl ASTRule for AssumedSize {
         {
             let identifier = sized_decl.child_with_name("identifier")?;
             let name = identifier.to_text(src)?.to_string();
-            let msg = Self { name }.message();
-            return some_vec![FortitudeViolation::from_node(msg, node)];
+            return some_vec![FortitudeViolation::from_node(Self { name }, node)];
         }
 
         // Collect things that look like `dimension(*)` -- this
@@ -110,7 +109,7 @@ impl ASTRule for AssumedSize {
                 identifier.to_text(src)
             })
             .map(|name| name.to_string())
-            .map(|name| FortitudeViolation::from_node(Self { name }.message(), node))
+            .map(|name| FortitudeViolation::from_node(Self { name }, node))
             .collect_vec();
 
         Some(all_decls)
@@ -231,10 +230,7 @@ impl ASTRule for AssumedSizeCharacterIntent {
                 identifier.to_text(src)
             })
             .map(|name| name.to_string())
-            .map(|name| {
-                let msg = Self { name }.message();
-                FortitudeViolation::from_node(msg, node)
-            })
+            .map(|name| FortitudeViolation::from_node(Self { name }, node))
             .collect_vec();
 
         Some(all_decls)
@@ -300,10 +296,7 @@ impl ASTRule for DeprecatedAssumedSizeCharacter {
                 identifier.to_text(src)
             })
             .map(|name| name.to_string())
-            .map(|name| {
-                let msg = Self { name }.message();
-                FortitudeViolation::from_node(msg, node)
-            })
+            .map(|name| FortitudeViolation::from_node(Self { name }, node))
             .collect_vec();
 
         Some(all_decls)

--- a/src/rules/typing/assumed_size.rs
+++ b/src/rules/typing/assumed_size.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use itertools::Itertools;
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -51,12 +51,9 @@ impl Rule for ImplicitTyping {
 impl ASTRule for ImplicitTyping {
     fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         if !child_is_implicit_none(node) {
-            let msg = Self {
-                entity: node.kind().to_string(),
-            }
-            .message();
+            let entity = node.kind().to_string();
             let block_stmt = node.child(0)?;
-            return some_vec![FortitudeViolation::from_node(msg, &block_stmt)];
+            return some_vec![FortitudeViolation::from_node(Self { entity }, &block_stmt)];
         }
         None
     }
@@ -97,9 +94,12 @@ impl ASTRule for InterfaceImplicitTyping {
     fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         let parent = node.parent()?;
         if parent.kind() == "interface" && !child_is_implicit_none(node) {
-            let msg = Self { name: node.kind().to_string() }.message();
+            let name = node.kind().to_string();
             let interface_stmt = node.child(0)?;
-            return some_vec![FortitudeViolation::from_node(msg, &interface_stmt)];
+            return some_vec![FortitudeViolation::from_node(
+                Self { name },
+                &interface_stmt
+            )];
         }
         None
     }
@@ -147,15 +147,11 @@ impl ASTRule for SuperfluousImplicitNone {
                 let kind = ancestor.kind();
                 match kind {
                     "module" | "submodule" | "program" | "function" | "subroutine" => {
-                        if child_is_implicit_none(&ancestor) {
-                            return some_vec![FortitudeViolation::from_node(
-                                Self {
-                                    entity: kind.to_string()
-                                }
-                                .message(),
-                                node
-                            )];
+                        if !child_is_implicit_none(&ancestor) {
+                            continue;
                         }
+                        let entity = kind.to_string();
+                        return some_vec![FortitudeViolation::from_node(Self { entity }, node)];
                     }
                     "interface" => {
                         break;

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -218,19 +218,20 @@ mod tests {
             end program
             ",
         );
-        let expected: Vec<FortitudeViolation> = [(4, 8, 4, 34, "function"), (13, 8, 13, 29, "subroutine")]
-            .iter()
-            .map(|(start_line, start_col, end_line, end_col, kind)| {
-                FortitudeViolation::from_start_end_line_col(
-                    format!("interface {kind} missing 'implicit none'"),
-                    &source,
-                    *start_line,
-                    *start_col,
-                    *end_line,
-                    *end_col,
-                )
-            })
-            .collect();
+        let expected: Vec<FortitudeViolation> =
+            [(4, 8, 4, 34, "function"), (13, 8, 13, 29, "subroutine")]
+                .iter()
+                .map(|(start_line, start_col, end_line, end_col, kind)| {
+                    FortitudeViolation::from_start_end_line_col(
+                        format!("interface {kind} missing 'implicit none'"),
+                        &source,
+                        *start_line,
+                        *start_col,
+                        *end_line,
+                        *end_col,
+                    )
+                })
+                .collect();
         let rule = InterfaceImplicitTyping::new(&default_settings());
         let actual = rule.apply(&source)?;
         assert_eq!(actual, expected);

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/typing/init_decls.rs
+++ b/src/rules/typing/init_decls.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, Violation};
+use crate::{ASTRule, Rule, FortitudeViolation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -74,7 +74,7 @@ impl Rule for InitialisationInDeclaration {
 }
 
 impl ASTRule for InitialisationInDeclaration {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Violation>> {
+    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         let src = src.source_text();
         // Only check in procedures
         node.ancestors().find(|parent| {
@@ -96,7 +96,7 @@ impl ASTRule for InitialisationInDeclaration {
 
         let name = node.child_by_field_name("left")?.to_text(src)?;
         let msg = format!("'{name}' is initialised in its declaration and has no explicit `save` or `parameter` attribute");
-        some_vec![Violation::from_node(msg, node)]
+        some_vec![FortitudeViolation::from_node(msg, node)]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {
@@ -138,14 +138,14 @@ mod tests {
             end module test
             ",
         );
-        let expected: Vec<Violation> = [
+        let expected: Vec<FortitudeViolation> = [
             (10, 13, 10, 20, "foo"),
             (19, 18, 19, 25, "bar"),
             (19, 34, 19, 42, "zapp"),
         ]
         .iter()
         .map(|(start_line, start_col, end_line, end_col, variable)| {
-            Violation::from_start_end_line_col(
+            FortitudeViolation::from_start_end_line_col(
                 format!("'{variable}' is initialised in its declaration and has no explicit `save` or `parameter` attribute"),
                 &source,
                 *start_line,

--- a/src/rules/typing/init_decls.rs
+++ b/src/rules/typing/init_decls.rs
@@ -108,7 +108,7 @@ impl ASTRule for InitialisationInDeclaration {
         }
 
         let name = node.child_by_field_name("left")?.to_text(src)?.to_string();
-        some_vec![FortitudeViolation::from_node(Self { name }.message(), node)]
+        some_vec![FortitudeViolation::from_node(Self { name }, node)]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {

--- a/src/rules/typing/init_decls.rs
+++ b/src/rules/typing/init_decls.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/src/rules/typing/init_decls.rs
+++ b/src/rules/typing/init_decls.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/typing/intent.rs
+++ b/src/rules/typing/intent.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/src/rules/typing/intent.rs
+++ b/src/rules/typing/intent.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, Violation};
+use crate::{ASTRule, Rule, FortitudeViolation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -34,7 +34,7 @@ impl Rule for MissingIntent {
 }
 
 impl ASTRule for MissingIntent {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Violation>> {
+    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         let src = src.source_text();
         // Names of all the dummy arguments
         let parameters: Vec<&str> = node
@@ -92,9 +92,9 @@ impl ASTRule for MissingIntent {
                         let msg = format!(
                             "{procedure_kind} argument '{name}' missing 'intent' attribute"
                         );
-                        Violation::from_node(msg, &dummy)
+                        FortitudeViolation::from_node(msg, &dummy)
                     })
-                    .collect::<Vec<Violation>>()
+                    .collect::<Vec<FortitudeViolation>>()
             })
             .collect();
 
@@ -130,7 +130,7 @@ mod tests {
             end subroutine
             ",
         );
-        let expected: Vec<Violation> = [
+        let expected: Vec<FortitudeViolation> = [
             (3, 13, 3, 14, "function", "a"),
             (3, 16, 3, 20, "function", "c"),
             (8, 22, 8, 23, "subroutine", "d"),
@@ -138,7 +138,7 @@ mod tests {
         ]
         .iter()
         .map(|(start_line, start_col, end_line, end_col, entity, arg)| {
-            Violation::from_start_end_line_col(
+            FortitudeViolation::from_start_end_line_col(
                 format!("{entity} argument '{arg}' missing 'intent' attribute"),
                 &source,
                 *start_line,

--- a/src/rules/typing/intent.rs
+++ b/src/rules/typing/intent.rs
@@ -1,35 +1,49 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{ASTRule, FortitudeViolation, Rule};
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
-/// Rules for catching missing intent
+/// ## What it does
+/// Checks for missing `intent` on dummy arguments
+///
+/// ## Why is this bad?
+/// Procedure dummy arguments should have an explicit `intent`
+/// attributes. This can help catch logic errors, potentially improve
+/// performance, as well as serving as documentation for users of
+/// the procedure.
+///
+/// Arguments with `intent(in)` are read-only input variables, and cannot be
+/// modified by the routine.
+///
+/// Arguments with `intent(out)` are output variables, and their value on
+/// entry into the routine can be safely ignored.
+////
+/// Finally, `intent(inout)` arguments can be both read and modified by the
+/// routine. If an `intent` is not specified, it will default to
+/// `intent(inout)`.
+#[violation]
+pub struct MissingIntent {
+    entity: String,
+    name: String,
+}
 
-pub struct MissingIntent {}
+impl Violation for MissingIntent {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self { entity, name } = self;
+        format!("{entity} argument '{name}' missing 'intent' attribute")
+    }
+}
 
 impl Rule for MissingIntent {
     fn new(_settings: &Settings) -> Self {
-        MissingIntent {}
-    }
-
-    fn explain(&self) -> &'static str {
-        "
-        Procedure dummy arguments should have an explicit `intent`
-        attributes. This can help catch logic errors, potentially improve
-        performance, as well as serving as documentation for users of
-        the procedure.
-
-        Arguments with `intent(in)` are read-only input variables, and cannot be
-        modified by the routine.
-
-        Arguments with `intent(out)` are output variables, and their value on
-        entry into the routine can be safely ignored.
-
-        Finally, `intent(inout)` arguments can be both read and modified by the
-        routine. If an `intent` is not specified, it will default to
-        `intent(inout)`.
-        "
+        MissingIntent {
+            entity: String::default(),
+            name: String::default(),
+        }
     }
 }
 
@@ -44,7 +58,7 @@ impl ASTRule for MissingIntent {
             .collect();
 
         let parent = node.parent()?;
-        let procedure_kind = parent.kind();
+        let entity = parent.kind().to_string();
 
         // Logic here is:
         // 1. find variable declarations
@@ -89,9 +103,11 @@ impl ASTRule for MissingIntent {
                         None
                     })
                     .map(|(dummy, name)| {
-                        let msg = format!(
-                            "{procedure_kind} argument '{name}' missing 'intent' attribute"
-                        );
+                        let msg = Self {
+                            entity: entity.to_string(),
+                            name: name.to_string(),
+                        }
+                        .message();
                         FortitudeViolation::from_node(msg, &dummy)
                     })
                     .collect::<Vec<FortitudeViolation>>()
@@ -139,7 +155,7 @@ mod tests {
         .iter()
         .map(|(start_line, start_col, end_line, end_col, entity, arg)| {
             FortitudeViolation::from_start_end_line_col(
-                format!("{entity} argument '{arg}' missing 'intent' attribute"),
+                MissingIntent{entity: entity.to_string(), name: arg.to_string()}.message(),
                 &source,
                 *start_line,
                 *start_col,

--- a/src/rules/typing/intent.rs
+++ b/src/rules/typing/intent.rs
@@ -103,12 +103,13 @@ impl ASTRule for MissingIntent {
                         None
                     })
                     .map(|(dummy, name)| {
-                        let msg = Self {
-                            entity: entity.to_string(),
-                            name: name.to_string(),
-                        }
-                        .message();
-                        FortitudeViolation::from_node(msg, &dummy)
+                        FortitudeViolation::from_node(
+                            Self {
+                                entity: entity.to_string(),
+                                name: name.to_string(),
+                            },
+                            &dummy,
+                        )
                     })
                     .collect::<Vec<FortitudeViolation>>()
             })
@@ -155,7 +156,11 @@ mod tests {
         .iter()
         .map(|(start_line, start_col, end_line, end_col, entity, arg)| {
             FortitudeViolation::from_start_end_line_col(
-                MissingIntent{entity: entity.to_string(), name: arg.to_string()}.message(),
+                MissingIntent {
+                    entity: entity.to_string(),
+                    name: arg.to_string(),
+                }
+                .message(),
                 &source,
                 *start_line,
                 *start_col,

--- a/src/rules/typing/intent.rs
+++ b/src/rules/typing/intent.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -99,8 +99,10 @@ impl ASTRule for LiteralKind {
         let literal = literal_node.to_text(src)?.to_string();
         // TODO: Can we recommend the "correct" size? Although
         // non-standard, `real*8` _usually_ means `real(real64)`
-        let msg = Self { dtype, literal }.message();
-        some_vec![FortitudeViolation::from_node(msg, &literal_node)]
+        some_vec![FortitudeViolation::from_node(
+            Self { dtype, literal },
+            &literal_node
+        )]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {
@@ -191,12 +193,12 @@ impl ASTRule for LiteralKindSuffix {
         if kind.kind() != "number_literal" {
             return None;
         }
-        let msg = Self {
-            literal: node.to_text(src)?.to_string(),
-            suffix: kind.to_text(src)?.to_string(),
-        }
-        .message();
-        some_vec![FortitudeViolation::from_node(msg, &kind)]
+        let literal = node.to_text(src)?.to_string();
+        let suffix = kind.to_text(src)?.to_string();
+        some_vec![FortitudeViolation::from_node(
+            Self { literal, suffix },
+            &kind
+        )]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -1,74 +1,87 @@
 use crate::ast::{dtype_is_plain_number, FortitudeNode};
 use crate::settings::Settings;
 use crate::{ASTRule, FortitudeViolation, Rule};
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
-/// Defines rules that discourage the use of raw number literals as kinds, as this can result in
-/// non-portable code.
-
 // TODO rules for intrinsic kinds in real(x, [KIND]) and similar type casting functions
 
-pub struct LiteralKind {}
+/// ## What it does
+/// Checks for use of raw number literals as kinds
+///
+/// ## Why is this bad?
+/// Rather than setting an intrinsic type's kind using an integer literal, such as
+/// `real(8)` or `integer(kind=4)`, consider setting kinds using parameters in the
+/// intrinsic module `iso_fortran_env` such as `real64` and `int32`. For
+/// C-compatible types, consider instead `iso_c_binding` types such as
+/// `real(c_double)`.
+///
+/// Although it is widely believed that `real(8)` represents an 8-byte floating
+/// point (and indeed, this is the case for most compilers and architectures),
+/// there is nothing in the standard to mandate this, and compiler vendors are free
+/// to choose any mapping between kind numbers and machine precision. This may lead
+/// to surprising results if your code is ported to another machine or compiler.
+///
+/// For floating point variables, we recommended using `real(sp)` (single
+/// precision), `real(dp)` (double precision), and `real(qp)` (quadruple precision),
+/// using:
+///
+/// ```fortran
+/// use, intrinsic :: iso_fortran_env, only: sp => real32, &
+///                                          dp => real64, &
+///                                          qp => real128
+/// ```
+///
+/// Or alternatively:
+///
+/// ```fortran
+/// integer, parameter :: sp = selected_real_kind(6, 37)
+/// integer, parameter :: dp = selected_real_kind(15, 307)
+/// integer, parameter :: qp = selected_real_kind(33, 4931)
+/// ```
+///
+/// Some prefer to set one precision parameter `wp` (working precision), which is
+/// set in one module and used throughout a project.
+///
+/// Integer sizes may be set similarly:
+///
+/// ```fortran
+/// integer, parameter :: i1 = selected_int_kind(2)  ! 8 bits
+/// integer, parameter :: i2 = selected_int_kind(4)  ! 16 bits
+/// integer, parameter :: i4 = selected_int_kind(9)  ! 32 bits
+/// integer, parameter :: i8 = selected_int_kind(18) ! 64 bits
+/// ```
+///
+/// Or:
+///
+/// ```fortran
+/// use, intrinsic :: iso_fortran_env, only: i1 => int8, &
+///                                          i2 => int16, &
+///                                          i4 => int32, &
+///                                          i8 => int64
+/// ```
+#[violation]
+pub struct LiteralKind {
+    dtype: String,
+    literal: String,
+}
+
+impl Violation for LiteralKind {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self { dtype, literal } = self;
+        format!("{dtype} kind set with number literal '{literal}', use 'iso_fortran_env' parameter",)
+    }
+}
 
 impl Rule for LiteralKind {
     fn new(_settings: &Settings) -> Self {
-        LiteralKind {}
-    }
-
-    fn explain(&self) -> &'static str {
-        "
-        Rather than setting an intrinsic type's kind using an integer literal, such as
-        `real(8)` or `integer(kind=4)`, consider setting kinds using parameters in the
-        intrinsic module `iso_fortran_env` such as `real64` and `int32`. For
-        C-compatible types, consider instead `iso_c_binding` types such as
-        `real(c_double)`.
-
-        Although it is widely believed that `real(8)` represents an 8-byte floating
-        point (and indeed, this is the case for most compilers and architectures),
-        there is nothing in the standard to mandate this, and compiler vendors are free
-        to choose any mapping between kind numbers and machine precision. This may lead
-        to surprising results if your code is ported to another machine or compiler.
-
-        For floating point variables, we recommended using `real(sp)` (single
-        precision), `real(dp)` (double precision), and `real(qp)` (quadruple precision),
-        using:
-
-        ```
-        use, intrinsic :: iso_fortran_env, only: sp => real32, &
-                                                 dp => real64, &
-                                                 qp => real128
-        ```
-
-        Or alternatively:
-
-        ```
-        integer, parameter :: sp = selected_real_kind(6, 37)
-        integer, parameter :: dp = selected_real_kind(15, 307)
-        integer, parameter :: qp = selected_real_kind(33, 4931)
-        ```
-
-        Some prefer to set one precision parameter `wp` (working precision), which is
-        set in one module and used throughout a project.
-
-        Integer sizes may be set similarly:
-
-        ```
-        integer, parameter :: i1 = selected_int_kind(2)  ! 8 bits
-        integer, parameter :: i2 = selected_int_kind(4)  ! 16 bits
-        integer, parameter :: i4 = selected_int_kind(9)  ! 32 bits
-        integer, parameter :: i8 = selected_int_kind(18) ! 64 bits
-        ```
-
-        Or:
-
-        ```
-        use, intrinsic :: iso_fortran_env, only: i1 => int8, &
-                                                 i2 => int16, &
-                                                 i4 => int32, &
-                                                 i8 => int64
-        ```
-        "
+        LiteralKind {
+            dtype: String::default(),
+            literal: String::default(),
+        }
     }
 }
 
@@ -82,14 +95,12 @@ impl ASTRule for LiteralKind {
         }
 
         let kind_node = node.child_by_field_name("kind")?;
-        let literal_value = integer_literal_kind(&kind_node, src)?;
+        let literal_node = integer_literal_kind(&kind_node, src)?;
+        let literal = literal_node.to_text(src)?.to_string();
         // TODO: Can we recommend the "correct" size? Although
         // non-standard, `real*8` _usually_ means `real(real64)`
-        let msg = format!(
-            "{dtype} kind set with number literal '{}', use 'iso_fortran_env' parameter",
-            literal_value.to_text(src)?
-        );
-        some_vec![FortitudeViolation::from_node(msg, &literal_value)]
+        let msg = Self { dtype, literal }.message();
+        some_vec![FortitudeViolation::from_node(msg, &literal_node)]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {
@@ -125,37 +136,51 @@ fn integer_literal_kind<'a>(node: &'a Node, src: &str) -> Option<Node<'a>> {
     None
 }
 
-pub struct LiteralKindSuffix {}
+/// ## What it does
+/// Checks for using an integer literal as a kind suffix
+///
+/// ## Why is this bad?
+/// Using an integer literal as a kind specifier gives no guarantees regarding the
+/// precision of the type, as kind numbers are not specified in the Fortran
+/// standards. It is recommended to use parameter types from `iso_fortran_env`:
+///
+/// ```fortran
+/// use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
+/// ```
+///
+/// or alternatively:
+///
+/// ```fortran
+/// integer, parameter :: sp => selected_real_kind(6, 37)
+/// integer, parameter :: dp => selected_real_kind(15, 307)
+/// ```
+///
+/// Floating point constants can then be specified as follows:
+///
+/// ```fortran
+/// real(sp), parameter :: sqrt2 = 1.41421_sp
+/// real(dp), parameter :: pi = 3.14159265358979_dp
+/// ```
+#[violation]
+pub struct LiteralKindSuffix {
+    literal: String,
+    suffix: String,
+}
+
+impl Violation for LiteralKindSuffix {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self { literal, suffix } = self;
+        format!("'{literal}' has literal suffix '{suffix}', use 'iso_fortran_env' parameter")
+    }
+}
 
 impl Rule for LiteralKindSuffix {
     fn new(_settings: &Settings) -> Self {
-        LiteralKindSuffix {}
-    }
-
-    fn explain(&self) -> &'static str {
-        "
-        Using an integer literal as a kind specifier gives no guarantees regarding the
-        precision of the type, as kind numbers are not specified in the Fortran
-        standards. It is recommended to use parameter types from `iso_fortran_env`:
-
-        ```
-        use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
-        ```
-
-        or alternatively:
-
-        ```
-        integer, parameter :: sp => selected_real_kind(6, 37)
-        integer, parameter :: dp => selected_real_kind(15, 307)
-        ```
-
-        Floating point constants can then be specified as follows:
-
-        ```
-        real(sp), parameter :: sqrt2 = 1.41421_sp
-        real(dp), parameter :: pi = 3.14159265358979_dp
-        ```
-        "
+        LiteralKindSuffix {
+            literal: String::default(),
+            suffix: String::default(),
+        }
     }
 }
 
@@ -166,11 +191,11 @@ impl ASTRule for LiteralKindSuffix {
         if kind.kind() != "number_literal" {
             return None;
         }
-        let msg = format!(
-            "'{}' has literal suffix '{}', use 'iso_fortran_env' parameter",
-            node.to_text(src)?,
-            &kind.to_text(src)?,
-        );
+        let msg = Self {
+            literal: node.to_text(src)?.to_string(),
+            suffix: kind.to_text(src)?.to_string(),
+        }
+        .message();
         some_vec![FortitudeViolation::from_node(msg, &kind)]
     }
 
@@ -225,16 +250,22 @@ mod tests {
             (23, 15, 23, 16, "complex", 4),
         ]
         .iter()
-        .map(|(start_line, start_col, end_line, end_col, kind, literal)| {
-            FortitudeViolation::from_start_end_line_col(
-                format!("{kind} kind set with number literal '{literal}', use 'iso_fortran_env' parameter"),
-                &source,
-                *start_line,
-                *start_col,
-                *end_line,
-                *end_col,
-            )
-        })
+        .map(
+            |(start_line, start_col, end_line, end_col, kind, literal)| {
+                FortitudeViolation::from_start_end_line_col(
+                    LiteralKind {
+                        dtype: kind.to_string(),
+                        literal: literal.to_string(),
+                    }
+                    .message(),
+                    &source,
+                    *start_line,
+                    *start_col,
+                    *end_line,
+                    *end_col,
+                )
+            },
+        )
         .collect();
         let rule = LiteralKind::new(&default_settings());
         let actual = rule.apply(&source)?;
@@ -262,7 +293,11 @@ mod tests {
         .iter()
         .map(|(start_line, start_col, end_line, end_col, num, kind)| {
             FortitudeViolation::from_start_end_line_col(
-                format!("'{num}' has literal suffix '{kind}', use 'iso_fortran_env' parameter",),
+                LiteralKindSuffix {
+                    literal: num.to_string(),
+                    suffix: kind.to_string(),
+                }
+                .message(),
                 &source,
                 *start_line,
                 *start_col,

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{dtype_is_plain_number, FortitudeNode};
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{dtype_is_plain_number, FortitudeNode};
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{dtype_is_plain_number, strip_line_breaks, FortitudeNode};
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, Violation};
+use crate::{ASTRule, Rule, FortitudeViolation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 /// Defines rules that discourage the use of the non-standard kind specifiers such as
@@ -27,7 +27,7 @@ impl Rule for StarKind {
 }
 
 impl ASTRule for StarKind {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Violation>> {
+    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<FortitudeViolation>> {
         let src = src.source_text();
         let dtype = node.child(0)?.to_text(src)?.to_lowercase();
         // TODO: Handle characters
@@ -47,7 +47,7 @@ impl ASTRule for StarKind {
         let kind = literal.to_text(src)?;
         // TODO: Better suggestion, rather than use integer literal
         let msg = format!("{dtype}{size} is non-standard, use {dtype}({kind})");
-        some_vec![Violation::from_node(msg, &kind_node)]
+        some_vec![FortitudeViolation::from_node(msg, &kind_node)]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {
@@ -88,7 +88,7 @@ mod tests {
             ",
         );
 
-        let expected: Vec<Violation> = [
+        let expected: Vec<FortitudeViolation> = [
             (1, 7, 1, 9, "integer*8", "integer(8)"),
             (3, 10, 3, 12, "integer*4", "integer(4)"),
             (4, 9, 4, 14, "logical*4", "logical(4)"),
@@ -98,7 +98,7 @@ mod tests {
         ]
         .iter()
         .map(|(start_line, start_col, end_line, end_col, from, to)| {
-            Violation::from_start_end_line_col(
+            FortitudeViolation::from_start_end_line_col(
                 format!("{from} is non-standard, use {to}"),
                 &source,
                 *start_line,

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{dtype_is_plain_number, strip_line_breaks, FortitudeNode};
 use crate::settings::Settings;
-use crate::{ASTRule, FromTSNode, Rule};
+use crate::{ASTRule, FromASTNode, Rule};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -64,8 +64,10 @@ impl ASTRule for StarKind {
         let literal = kind_node.child_with_name("number_literal")?;
         let kind = literal.to_text(src)?.to_string();
         // TODO: Better suggestion, rather than use integer literal
-        let msg = Self { dtype, size, kind }.message();
-        some_vec![FortitudeViolation::from_node(msg, &kind_node)]
+        some_vec![FortitudeViolation::from_node(
+            Self { dtype, size, kind },
+            &kind_node
+        )]
     }
 
     fn entrypoints(&self) -> Vec<&'static str> {

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{dtype_is_plain_number, strip_line_breaks, FortitudeNode};
 use crate::settings::Settings;
-use crate::{ASTRule, Rule, FortitudeViolation};
+use crate::{ASTRule, FortitudeViolation, Rule};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 /// Defines rules that discourage the use of the non-standard kind specifiers such as


### PR DESCRIPTION
This is about 80/90% complete. I'd like to finish removing (the renamed) `Fortitude{Violation,Diagnostic}`. Pretty sure `FortitudeViolation` can now go entirely, and `FortitudeDiagnostic` will probably be replaced with a `Message` for output to different formats.

I think passing `Settings` into `Rule::check` will allow me to remove `Rule::new` completely, just not managed to thread that needle yet.