### PR TITLE
Make `check` functions static

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,25 +108,18 @@ impl FromStartEndLineCol for Diagnostic {
 // Rule trait
 // ----------
 
-/// Implemented by all rules.
-pub trait Rule {
-    fn new(settings: &Settings) -> Self
-    where
-        Self: Sized;
-}
-
 /// Implemented by rules that act directly on the file path.
-pub trait PathRule: Rule {
+pub trait PathRule {
     fn check(settings: &Settings, path: &Path) -> Option<Diagnostic>;
 }
 
 /// Implemented by rules that analyse lines of code directly, using regex or otherwise.
-pub trait TextRule: Rule {
+pub trait TextRule {
     fn check(settings: &Settings, source: &SourceFile) -> Vec<Diagnostic>;
 }
 
 /// Implemented by rules that analyse the abstract syntax tree.
-pub trait ASTRule: Rule {
+pub trait ASTRule {
     fn check(settings: &Settings, node: &Node, source: &SourceFile) -> Option<Vec<Diagnostic>>;
 
     /// Return list of tree-sitter node types on which a rule should trigger.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use colored::{ColoredString, Colorize};
 use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_source_file::{OneIndexed, SourceFile, SourceLocation};
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use settings::Settings;
+use settings::{default_settings, Settings};
 use std::cmp::Ordering;
 use std::fmt;
 use std::path::Path;
@@ -117,29 +117,30 @@ pub trait Rule {
 
 /// Implemented by rules that act directly on the file path.
 pub trait PathRule: Rule {
-    fn check(&self, path: &Path) -> Option<Diagnostic>;
+    fn check(settings: &Settings, path: &Path) -> Option<Diagnostic>;
 }
 
 /// Implemented by rules that analyse lines of code directly, using regex or otherwise.
 pub trait TextRule: Rule {
-    fn check(&self, source: &SourceFile) -> Vec<Diagnostic>;
+    fn check(settings: &Settings, source: &SourceFile) -> Vec<Diagnostic>;
 }
 
 /// Implemented by rules that analyse the abstract syntax tree.
 pub trait ASTRule: Rule {
-    fn check(&self, node: &Node, source: &SourceFile) -> Option<Vec<Diagnostic>>;
+    fn check(settings: &Settings, node: &Node, source: &SourceFile) -> Option<Vec<Diagnostic>>;
 
     /// Return list of tree-sitter node types on which a rule should trigger.
-    fn entrypoints(&self) -> Vec<&'static str>;
+    fn entrypoints() -> Vec<&'static str>;
 
     /// Apply a rule over some text, generating all violations raised as a result.
-    fn apply(&self, source: &SourceFile) -> anyhow::Result<Vec<Diagnostic>> {
-        let entrypoints = self.entrypoints();
+    fn apply(source: &SourceFile) -> anyhow::Result<Vec<Diagnostic>> {
+        let entrypoints = Self::entrypoints();
+        let default_settings = default_settings();
         Ok(parse(source.source_text())?
             .root_node()
             .named_descendants()
             .filter(|x| entrypoints.contains(&x.kind()))
-            .filter_map(|x| self.check(&x, source))
+            .filter_map(|x| Self::check(&default_settings, &x, source))
             .flatten()
             .collect())
     }

--- a/src/rules/error/ioerror.rs
+++ b/src/rules/error/ioerror.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::settings::Settings;
-use crate::{PathRule, Rule};
+use crate::PathRule;
 use std::path::Path;
 
 use ruff_diagnostics::{Diagnostic, Violation};
@@ -42,14 +42,6 @@ impl Violation for IOError {
     fn message(&self) -> String {
         let IOError { message } = self;
         format!("{message}")
-    }
-}
-
-impl Rule for IOError {
-    fn new(_settings: &Settings) -> Self {
-        IOError {
-            message: String::default(),
-        }
     }
 }
 

--- a/src/rules/error/ioerror.rs
+++ b/src/rules/error/ioerror.rs
@@ -55,7 +55,7 @@ impl Rule for IOError {
 
 // Need to implement some kind of rule, although we only raise this manually
 impl PathRule for IOError {
-    fn check(&self, _path: &Path) -> Option<Diagnostic> {
+    fn check(_settings: &Settings, _path: &Path) -> Option<Diagnostic> {
         None
     }
 }

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -33,11 +33,11 @@ impl Rule for SyntaxError {
 }
 
 impl ASTRule for SyntaxError {
-    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         some_vec![Diagnostic::from_node(Self {}, node)]
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["ERROR"]
     }
 }

--- a/src/rules/error/syntax_error.rs
+++ b/src/rules/error/syntax_error.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{some_vec, ASTRule, FromASTNode, Rule};
+use crate::{some_vec, ASTRule, FromASTNode};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -23,12 +23,6 @@ impl Violation for SyntaxError {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Syntax error")
-    }
-}
-
-impl Rule for SyntaxError {
-    fn new(_settings: &Settings) -> Self {
-        SyntaxError {}
     }
 }
 

--- a/src/rules/filesystem/extensions.rs
+++ b/src/rules/filesystem/extensions.rs
@@ -3,7 +3,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_text_size::TextRange;
 
 use crate::settings::Settings;
-use crate::{PathRule, Rule};
+use crate::PathRule;
 use std::path::Path;
 
 /// ## What it does
@@ -20,12 +20,6 @@ impl Violation for NonStandardFileExtension {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("file extension should be '.f90' or '.F90'")
-    }
-}
-
-impl Rule for NonStandardFileExtension {
-    fn new(_settings: &Settings) -> Self {
-        NonStandardFileExtension {}
     }
 }
 

--- a/src/rules/filesystem/extensions.rs
+++ b/src/rules/filesystem/extensions.rs
@@ -30,7 +30,7 @@ impl Rule for NonStandardFileExtension {
 }
 
 impl PathRule for NonStandardFileExtension {
-    fn check(&self, path: &Path) -> Option<Diagnostic> {
+    fn check(_settings: &Settings, path: &Path) -> Option<Diagnostic> {
         match path.extension() {
             Some(ext) => {
                 // Must check like this as ext is an OsStr
@@ -53,9 +53,8 @@ mod tests {
     #[test]
     fn test_bad_file_extension() {
         let path = Path::new("my/dir/to/file.f95");
-        let rule = NonStandardFileExtension::new(&default_settings());
         assert_eq!(
-            rule.check(path),
+            NonStandardFileExtension::check(&default_settings(), path),
             Some(Diagnostic::new(
                 NonStandardFileExtension {},
                 TextRange::default()
@@ -66,9 +65,8 @@ mod tests {
     #[test]
     fn test_missing_file_extension() {
         let path = Path::new("my/dir/to/file");
-        let rule = NonStandardFileExtension::new(&default_settings());
         assert_eq!(
-            rule.check(path),
+            NonStandardFileExtension::check(&default_settings(), path),
             Some(Diagnostic::new(
                 NonStandardFileExtension {},
                 TextRange::default()
@@ -80,8 +78,13 @@ mod tests {
     fn test_correct_file_extensions() {
         let path1 = Path::new("my/dir/to/file.f90");
         let path2 = Path::new("my/dir/to/file.F90");
-        let rule = NonStandardFileExtension::new(&default_settings());
-        assert_eq!(rule.check(path1), None);
-        assert_eq!(rule.check(path2), None);
+        assert_eq!(
+            NonStandardFileExtension::check(&default_settings(), path1),
+            None
+        );
+        assert_eq!(
+            NonStandardFileExtension::check(&default_settings(), path2),
+            None
+        );
     }
 }

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -23,14 +23,6 @@ impl Violation for ExternalFunction {
     fn message(&self) -> String {
         let ExternalFunction { procedure } = self;
         format!("{procedure} not contained within (sub)module or program")
-    }
-}
-
-impl Rule for ExternalFunction {
-    fn new(_settings: &Settings) -> Self {
-        ExternalFunction {
-            procedure: String::default(),
-        }
     }
 }
 

--- a/src/rules/modules/external_functions.rs
+++ b/src/rules/modules/external_functions.rs
@@ -35,7 +35,7 @@ impl Rule for ExternalFunction {
 }
 
 impl ASTRule for ExternalFunction {
-    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if node.parent()?.kind() == "translation_unit" {
             let procedure_stmt = node.child(0)?;
             let procedure = node.kind().to_string();
@@ -47,7 +47,7 @@ impl ASTRule for ExternalFunction {
         None
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["function", "subroutine"]
     }
 }
@@ -55,7 +55,7 @@ impl ASTRule for ExternalFunction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -88,8 +88,7 @@ mod tests {
                 )
             })
             .collect();
-        let rule = ExternalFunction::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = ExternalFunction::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -114,8 +113,7 @@ mod tests {
             ",
         );
         let expected: Vec<Diagnostic> = vec![];
-        let rule = ExternalFunction::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = ExternalFunction::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -44,14 +44,14 @@ impl Rule for UseAll {
 }
 
 impl ASTRule for UseAll {
-    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if node.child_with_name("included_items").is_none() {
             return some_vec![Diagnostic::from_node(UseAll {}, node)];
         }
         None
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["use_statement"]
     }
 }
@@ -59,7 +59,7 @@ impl ASTRule for UseAll {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -80,8 +80,7 @@ mod tests {
             3,
             35,
         )];
-        let rule = UseAll::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = UseAll::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/modules/use_statements.rs
+++ b/src/rules/modules/use_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -34,12 +34,6 @@ impl Violation for UseAll {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("'use' statement missing 'only' clause")
-    }
-}
-
-impl Rule for UseAll {
-    fn new(_settings: &Settings) -> Self {
-        UseAll {}
     }
 }
 

--- a/src/rules/precision/double_precision.rs
+++ b/src/rules/precision/double_precision.rs
@@ -66,12 +66,12 @@ impl Rule for DoublePrecision {
 }
 
 impl ASTRule for DoublePrecision {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let txt = node.to_text(src.source_text())?.to_lowercase();
         some_vec![Diagnostic::from_node(DoublePrecision::try_new(txt)?, node)]
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["intrinsic_type"]
     }
 }
@@ -79,7 +79,7 @@ impl ASTRule for DoublePrecision {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -125,8 +125,7 @@ mod tests {
             )
         })
         .collect();
-        let rule = DoublePrecision::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = DoublePrecision::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/precision/double_precision.rs
+++ b/src/rules/precision/double_precision.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -53,15 +53,6 @@ impl Violation for DoublePrecision {
             preferred,
         } = self;
         format!("prefer '{preferred}' to '{original}' (see 'iso_fortran_env')")
-    }
-}
-
-impl Rule for DoublePrecision {
-    fn new(_settings: &Settings) -> Self {
-        Self {
-            original: String::default(),
-            preferred: String::default(),
-        }
     }
 }
 

--- a/src/rules/precision/implicit_kinds.rs
+++ b/src/rules/precision/implicit_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -23,14 +23,6 @@ impl Violation for ImplicitRealKind {
     fn message(&self) -> String {
         let ImplicitRealKind { dtype } = self;
         format!("{dtype} has implicit kind")
-    }
-}
-
-impl Rule for ImplicitRealKind {
-    fn new(_settings: &Settings) -> Self {
-        ImplicitRealKind {
-            dtype: String::default(),
-        }
     }
 }
 

--- a/src/rules/precision/implicit_kinds.rs
+++ b/src/rules/precision/implicit_kinds.rs
@@ -35,7 +35,7 @@ impl Rule for ImplicitRealKind {
 }
 
 impl ASTRule for ImplicitRealKind {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let dtype = node.child(0)?.to_text(src.source_text())?.to_lowercase();
 
         if !matches!(dtype.as_str(), "real" | "complex") {
@@ -49,7 +49,7 @@ impl ASTRule for ImplicitRealKind {
         some_vec![Diagnostic::from_node(ImplicitRealKind { dtype }, node)]
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["intrinsic_type"]
     }
 }
@@ -57,7 +57,7 @@ impl ASTRule for ImplicitRealKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -95,9 +95,7 @@ mod tests {
             )
         })
         .collect();
-
-        let rule = ImplicitRealKind::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = ImplicitRealKind::apply(&source)?;
         assert_eq!(actual, expected);
 
         Ok(())

--- a/src/rules/precision/kind_suffixes.rs
+++ b/src/rules/precision/kind_suffixes.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -52,14 +52,6 @@ impl Violation for NoRealSuffix {
     fn message(&self) -> String {
         let NoRealSuffix { literal } = self;
         format!("real literal {literal} missing kind suffix")
-    }
-}
-
-impl Rule for NoRealSuffix {
-    fn new(_settings: &Settings) -> Self {
-        Self {
-            literal: String::default(),
-        }
     }
 }
 

--- a/src/rules/precision/kind_suffixes.rs
+++ b/src/rules/precision/kind_suffixes.rs
@@ -64,7 +64,7 @@ impl Rule for NoRealSuffix {
 }
 
 impl ASTRule for NoRealSuffix {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         // Given a number literal, match anything with one or more of a decimal place or
         // an exponentiation e or E. There should not be an underscore present.
         // Exponentiation with d or D are ignored, and should be handled with a different
@@ -77,7 +77,7 @@ impl ASTRule for NoRealSuffix {
         some_vec![Diagnostic::from_node(NoRealSuffix { literal }, node)]
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["number_literal"]
     }
 }
@@ -85,7 +85,7 @@ impl ASTRule for NoRealSuffix {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -132,8 +132,7 @@ mod tests {
             )
         })
         .collect();
-        let rule = NoRealSuffix::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = NoRealSuffix::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/style/end_statements.rs
+++ b/src/rules/style/end_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -47,15 +47,6 @@ impl Violation for UnnamedEndStatement {
     fn message(&self) -> String {
         let UnnamedEndStatement { statement, name } = self;
         format!("end statement should read 'end {statement} {name}'")
-    }
-}
-
-impl Rule for UnnamedEndStatement {
-    fn new(_settings: &Settings) -> Self {
-        Self {
-            statement: String::default(),
-            name: String::default(),
-        }
     }
 }
 

--- a/src/rules/style/end_statements.rs
+++ b/src/rules/style/end_statements.rs
@@ -74,7 +74,11 @@ fn map_declaration(kind: &str) -> (&'static str, &'static str) {
 }
 
 impl ASTRule for UnnamedEndStatement {
-    fn check<'a>(&self, node: &'a Node, src: &'a SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(
+        _settings: &Settings,
+        node: &'a Node,
+        src: &'a SourceFile,
+    ) -> Option<Vec<Diagnostic>> {
         // TODO Also check for optionally labelled constructs like 'do' or 'select'
 
         // If end node is named, move on.
@@ -99,7 +103,7 @@ impl ASTRule for UnnamedEndStatement {
         some_vec![Diagnostic::from_node(Self { statement, name }, node)]
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec![
             "end_module_statement",
             "end_submodule_statement",
@@ -115,7 +119,7 @@ impl ASTRule for UnnamedEndStatement {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -213,8 +217,7 @@ mod tests {
             },
         )
         .collect();
-        let rule = UnnamedEndStatement::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = UnnamedEndStatement::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/style/exit_labels.rs
+++ b/src/rules/style/exit_labels.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -31,15 +31,6 @@ impl Violation for MissingExitOrCycleLabel {
     fn message(&self) -> String {
         let Self { name, label } = self;
         format!("'{name}' statement in named 'do' loop missing label '{label}'")
-    }
-}
-
-impl Rule for MissingExitOrCycleLabel {
-    fn new(_settings: &Settings) -> Self {
-        Self {
-            name: String::default(),
-            label: String::default(),
-        }
     }
 }
 impl ASTRule for MissingExitOrCycleLabel {

--- a/src/rules/style/exit_labels.rs
+++ b/src/rules/style/exit_labels.rs
@@ -43,7 +43,11 @@ impl Rule for MissingExitOrCycleLabel {
     }
 }
 impl ASTRule for MissingExitOrCycleLabel {
-    fn check<'a>(&self, node: &'a Node, src: &'a SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(
+        _settings: &Settings,
+        node: &'a Node,
+        src: &'a SourceFile,
+    ) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         // Skip unlabelled loops
         let label = node
@@ -70,7 +74,7 @@ impl ASTRule for MissingExitOrCycleLabel {
         Some(violations)
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["do_loop_statement"]
     }
 }
@@ -78,7 +82,7 @@ impl ASTRule for MissingExitOrCycleLabel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -153,8 +157,7 @@ mod tests {
             },
         )
         .collect();
-        let rule = MissingExitOrCycleLabel::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = MissingExitOrCycleLabel::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -51,11 +51,12 @@ impl Rule for LineTooLong {
 }
 
 impl TextRule for LineTooLong {
-    fn check(&self, source: &SourceFile) -> Vec<Diagnostic> {
+    fn check(settings: &Settings, source: &SourceFile) -> Vec<Diagnostic> {
+        let max_length = settings.line_length;
         let mut violations = Vec::new();
         for (idx, line) in source.source_text().split('\n').enumerate() {
             let actual_length = line.len();
-            if actual_length > self.max_length {
+            if actual_length > max_length {
                 // Are we ending on a string or comment? If so, we'll allow it through, as it may
                 // contain something like a long URL that cannot be reasonably split across multiple
                 // lines.
@@ -64,12 +65,12 @@ impl TextRule for LineTooLong {
                 }
                 violations.push(Diagnostic::from_start_end_line_col(
                     Self {
-                        max_length: self.max_length,
+                        max_length,
                         actual_length,
                     },
                     source,
                     idx,
-                    self.max_length,
+                    max_length,
                     idx,
                     actual_length,
                 ))
@@ -123,8 +124,7 @@ mod tests {
             },
         )
         .collect();
-        let rule = LineTooLong::new(&short_line_settings);
-        let actual = rule.check(&source);
+        let actual = LineTooLong::check(&short_line_settings, &source);
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/style/line_length.rs
+++ b/src/rules/style/line_length.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{FromStartEndLineCol, Rule, TextRule};
+use crate::{FromStartEndLineCol, TextRule};
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -38,15 +38,6 @@ impl Violation for LineTooLong {
             actual_length,
         } = self;
         format!("line length of {actual_length}, exceeds maximum {max_length}")
-    }
-}
-
-impl Rule for LineTooLong {
-    fn new(settings: &Settings) -> Self {
-        LineTooLong {
-            max_length: settings.line_length,
-            actual_length: 0,
-        }
     }
 }
 

--- a/src/rules/style/old_style_array_literal.rs
+++ b/src/rules/style/old_style_array_literal.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -20,12 +20,6 @@ impl Violation for OldStyleArrayLiteral {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Array literal uses old-style syntax: prefer `[...]`")
-    }
-}
-
-impl Rule for OldStyleArrayLiteral {
-    fn new(_settings: &Settings) -> Self {
-        Self {}
     }
 }
 impl ASTRule for OldStyleArrayLiteral {

--- a/src/rules/style/old_style_array_literal.rs
+++ b/src/rules/style/old_style_array_literal.rs
@@ -29,14 +29,14 @@ impl Rule for OldStyleArrayLiteral {
     }
 }
 impl ASTRule for OldStyleArrayLiteral {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if node.to_text(src.source_text())?.starts_with("(/") {
             return some_vec!(Diagnostic::from_node(Self {}, node));
         }
         None
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["array_literal"]
     }
 }
@@ -44,7 +44,7 @@ impl ASTRule for OldStyleArrayLiteral {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -85,8 +85,7 @@ mod tests {
             )
         })
         .collect();
-        let rule = OldStyleArrayLiteral::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = OldStyleArrayLiteral::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/style/relational_operators.rs
+++ b/src/rules/style/relational_operators.rs
@@ -48,7 +48,7 @@ impl Rule for DeprecatedRelationalOperator {
     }
 }
 impl ASTRule for DeprecatedRelationalOperator {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let relation = node.child(1)?;
         let symbol = relation
             .to_text(src.source_text())?
@@ -61,7 +61,7 @@ impl ASTRule for DeprecatedRelationalOperator {
         )]
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["relational_expression"]
     }
 }
@@ -69,7 +69,7 @@ impl ASTRule for DeprecatedRelationalOperator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -108,8 +108,7 @@ mod tests {
             },
         )
         .collect();
-        let rule = DeprecatedRelationalOperator::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = DeprecatedRelationalOperator::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/style/relational_operators.rs
+++ b/src/rules/style/relational_operators.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -36,15 +36,6 @@ impl Violation for DeprecatedRelationalOperator {
     fn message(&self) -> String {
         let Self { symbol, new_symbol } = self;
         format!("deprecated relational operator '{symbol}', prefer '{new_symbol}' instead")
-    }
-}
-
-impl Rule for DeprecatedRelationalOperator {
-    fn new(_settings: &Settings) -> Self {
-        Self {
-            symbol: String::default(),
-            new_symbol: String::default(),
-        }
     }
 }
 impl ASTRule for DeprecatedRelationalOperator {

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -3,7 +3,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 
 use crate::settings::Settings;
-use crate::{FromStartEndLineCol, Rule, TextRule};
+use crate::{FromStartEndLineCol, TextRule};
 /// Defines rules that enforce widely accepted whitespace rules.
 
 /// ## What does it do?
@@ -20,12 +20,6 @@ impl Violation for TrailingWhitespace {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("trailing whitespace")
-    }
-}
-
-impl Rule for TrailingWhitespace {
-    fn new(_settings: &Settings) -> Self {
-        TrailingWhitespace {}
     }
 }
 impl TextRule for TrailingWhitespace {

--- a/src/rules/style/whitespace.rs
+++ b/src/rules/style/whitespace.rs
@@ -29,7 +29,7 @@ impl Rule for TrailingWhitespace {
     }
 }
 impl TextRule for TrailingWhitespace {
-    fn check(&self, source: &SourceFile) -> Vec<Diagnostic> {
+    fn check(_settings: &Settings, source: &SourceFile) -> Vec<Diagnostic> {
         let mut violations = Vec::new();
         for (idx, line) in source.source_text().split('\n').enumerate() {
             if line.ends_with([' ', '\t']) {
@@ -86,8 +86,7 @@ end program test
                     )
                 })
                 .collect();
-        let rule = TrailingWhitespace::new(&default_settings());
-        let actual = rule.check(&file);
+        let actual = TrailingWhitespace::check(&default_settings(), &file);
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/typing/assumed_size.rs
+++ b/src/rules/typing/assumed_size.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use itertools::Itertools;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -51,14 +51,6 @@ impl Violation for AssumedSize {
     fn message(&self) -> String {
         let Self { name } = self;
         format!("'{name}' has assumed size")
-    }
-}
-
-impl Rule for AssumedSize {
-    fn new(_settings: &Settings) -> Self {
-        AssumedSize {
-            name: String::default(),
-        }
     }
 }
 impl ASTRule for AssumedSize {
@@ -168,14 +160,6 @@ impl Violation for AssumedSizeCharacterIntent {
         format!("character '{name}' has assumed size but does not have `intent(in)`")
     }
 }
-
-impl Rule for AssumedSizeCharacterIntent {
-    fn new(_settings: &Settings) -> Self {
-        Self {
-            name: String::default(),
-        }
-    }
-}
 impl ASTRule for AssumedSizeCharacterIntent {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
@@ -257,14 +241,6 @@ impl Violation for DeprecatedAssumedSizeCharacter {
     fn message(&self) -> String {
         let Self { name } = self;
         format!("character '{name}' uses deprecated syntax for assumed size")
-    }
-}
-
-impl Rule for DeprecatedAssumedSizeCharacter {
-    fn new(_settings: &Settings) -> Self {
-        Self {
-            name: String::default(),
-        }
     }
 }
 impl ASTRule for DeprecatedAssumedSizeCharacter {

--- a/src/rules/typing/assumed_size.rs
+++ b/src/rules/typing/assumed_size.rs
@@ -62,7 +62,7 @@ impl Rule for AssumedSize {
     }
 }
 impl ASTRule for AssumedSize {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         let declaration = node
             .ancestors()
@@ -115,7 +115,7 @@ impl ASTRule for AssumedSize {
         Some(all_decls)
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["assumed_size"]
     }
 }
@@ -177,7 +177,7 @@ impl Rule for AssumedSizeCharacterIntent {
     }
 }
 impl ASTRule for AssumedSizeCharacterIntent {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         // TODO: This warning will also catch:
         // - non-dummy arguments -- these are always invalid, should be a separate warning?
@@ -236,7 +236,7 @@ impl ASTRule for AssumedSizeCharacterIntent {
         Some(all_decls)
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["assumed_size"]
     }
 }
@@ -268,7 +268,7 @@ impl Rule for DeprecatedAssumedSizeCharacter {
     }
 }
 impl ASTRule for DeprecatedAssumedSizeCharacter {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         let declaration = node
             .ancestors()
@@ -302,7 +302,7 @@ impl ASTRule for DeprecatedAssumedSizeCharacter {
         Some(all_decls)
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["assumed_size"]
     }
 }
@@ -310,7 +310,7 @@ impl ASTRule for DeprecatedAssumedSizeCharacter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -353,8 +353,7 @@ mod tests {
             )
         })
         .collect();
-        let rule = AssumedSize::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = AssumedSize::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -405,8 +404,7 @@ mod tests {
             )
         })
         .collect();
-        let rule = AssumedSizeCharacterIntent::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = AssumedSizeCharacterIntent::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -452,8 +450,7 @@ mod tests {
             )
         })
         .collect();
-        let rule = DeprecatedAssumedSizeCharacter::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = DeprecatedAssumedSizeCharacter::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -40,14 +40,6 @@ impl Violation for ImplicitTyping {
         format!("{entity} missing 'implicit none'")
     }
 }
-
-impl Rule for ImplicitTyping {
-    fn new(_settings: &Settings) -> Self {
-        ImplicitTyping {
-            entity: String::default(),
-        }
-    }
-}
 impl ASTRule for ImplicitTyping {
     fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if !child_is_implicit_none(node) {
@@ -79,14 +71,6 @@ impl Violation for InterfaceImplicitTyping {
     fn message(&self) -> String {
         let Self { name } = self;
         format!("interface '{name}' missing 'implicit none'")
-    }
-}
-
-impl Rule for InterfaceImplicitTyping {
-    fn new(_settings: &Settings) -> Self {
-        InterfaceImplicitTyping {
-            name: String::default(),
-        }
     }
 }
 
@@ -122,14 +106,6 @@ impl Violation for SuperfluousImplicitNone {
     fn message(&self) -> String {
         let Self { entity } = self;
         format!("'implicit none' set on the enclosing {entity}")
-    }
-}
-
-impl Rule for SuperfluousImplicitNone {
-    fn new(_settings: &Settings) -> Self {
-        SuperfluousImplicitNone {
-            entity: String::default(),
-        }
     }
 }
 

--- a/src/rules/typing/implicit_typing.rs
+++ b/src/rules/typing/implicit_typing.rs
@@ -49,7 +49,7 @@ impl Rule for ImplicitTyping {
     }
 }
 impl ASTRule for ImplicitTyping {
-    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if !child_is_implicit_none(node) {
             let entity = node.kind().to_string();
             let block_stmt = node.child(0)?;
@@ -58,7 +58,7 @@ impl ASTRule for ImplicitTyping {
         None
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["module", "submodule", "program"]
     }
 }
@@ -91,7 +91,7 @@ impl Rule for InterfaceImplicitTyping {
 }
 
 impl ASTRule for InterfaceImplicitTyping {
-    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let parent = node.parent()?;
         if parent.kind() == "interface" && !child_is_implicit_none(node) {
             let name = node.kind().to_string();
@@ -101,7 +101,7 @@ impl ASTRule for InterfaceImplicitTyping {
         None
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["function", "subroutine"]
     }
 }
@@ -134,7 +134,7 @@ impl Rule for SuperfluousImplicitNone {
 }
 
 impl ASTRule for SuperfluousImplicitNone {
-    fn check(&self, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if !implicit_statement_is_none(node) {
             return None;
         }
@@ -162,7 +162,7 @@ impl ASTRule for SuperfluousImplicitNone {
         None
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["implicit_statement"]
     }
 }
@@ -170,7 +170,7 @@ impl ASTRule for SuperfluousImplicitNone {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -201,8 +201,7 @@ mod tests {
                 )
             })
             .collect();
-        let rule = ImplicitTyping::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = ImplicitTyping::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -228,8 +227,7 @@ mod tests {
             ",
         );
         let expected: Vec<Diagnostic> = vec![];
-        let rule = ImplicitTyping::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = ImplicitTyping::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -273,8 +271,7 @@ mod tests {
                 )
             })
             .collect();
-        let rule = InterfaceImplicitTyping::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = InterfaceImplicitTyping::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -306,8 +303,7 @@ mod tests {
             ",
         );
         let expected: Vec<Diagnostic> = vec![];
-        let rule = InterfaceImplicitTyping::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = InterfaceImplicitTyping::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -370,8 +366,7 @@ mod tests {
             )
         })
         .collect();
-        let rule = SuperfluousImplicitNone::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = SuperfluousImplicitNone::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -419,8 +414,7 @@ mod tests {
             ",
         );
         let expected: Vec<Diagnostic> = vec![];
-        let rule = SuperfluousImplicitNone::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = SuperfluousImplicitNone::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/typing/init_decls.rs
+++ b/src/rules/typing/init_decls.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -75,14 +75,6 @@ impl Violation for InitialisationInDeclaration {
     fn message(&self) -> String {
         let Self { name } = self;
         format!("'{name}' is initialised in its declaration and has no explicit `save` or `parameter` attribute")
-    }
-}
-
-impl Rule for InitialisationInDeclaration {
-    fn new(_settings: &Settings) -> Self {
-        InitialisationInDeclaration {
-            name: String::default(),
-        }
     }
 }
 

--- a/src/rules/typing/init_decls.rs
+++ b/src/rules/typing/init_decls.rs
@@ -87,7 +87,7 @@ impl Rule for InitialisationInDeclaration {
 }
 
 impl ASTRule for InitialisationInDeclaration {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         // Only check in procedures
         node.ancestors().find(|parent| {
@@ -111,7 +111,7 @@ impl ASTRule for InitialisationInDeclaration {
         some_vec![Diagnostic::from_node(Self { name }, node)]
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["init_declarator"]
     }
 }
@@ -119,7 +119,7 @@ impl ASTRule for InitialisationInDeclaration {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -169,8 +169,7 @@ mod tests {
             )
         })
         .collect();
-        let rule = InitialisationInDeclaration::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = InitialisationInDeclaration::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/typing/intent.rs
+++ b/src/rules/typing/intent.rs
@@ -48,7 +48,7 @@ impl Rule for MissingIntent {
 }
 
 impl ASTRule for MissingIntent {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         // Names of all the dummy arguments
         let parameters: Vec<&str> = node
@@ -118,7 +118,7 @@ impl ASTRule for MissingIntent {
         Some(violations)
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["function_statement", "subroutine_statement"]
     }
 }
@@ -126,7 +126,7 @@ impl ASTRule for MissingIntent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -168,8 +168,7 @@ mod tests {
             )
         })
         .collect();
-        let rule = MissingIntent::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = MissingIntent::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/typing/intent.rs
+++ b/src/rules/typing/intent.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -35,15 +35,6 @@ impl Violation for MissingIntent {
     fn message(&self) -> String {
         let Self { entity, name } = self;
         format!("{entity} argument '{name}' missing 'intent' attribute")
-    }
-}
-
-impl Rule for MissingIntent {
-    fn new(_settings: &Settings) -> Self {
-        MissingIntent {
-            entity: String::default(),
-            name: String::default(),
-        }
     }
 }
 

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -86,7 +86,7 @@ impl Rule for LiteralKind {
 }
 
 impl ASTRule for LiteralKind {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         let dtype = node.child(0)?.to_text(src)?.to_lowercase();
         // TODO: Deal with characters
@@ -105,7 +105,7 @@ impl ASTRule for LiteralKind {
         )]
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["intrinsic_type"]
     }
 }
@@ -187,7 +187,7 @@ impl Rule for LiteralKindSuffix {
 }
 
 impl ASTRule for LiteralKindSuffix {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         let kind = node.child_by_field_name("kind")?;
         if kind.kind() != "number_literal" {
@@ -198,7 +198,7 @@ impl ASTRule for LiteralKindSuffix {
         some_vec![Diagnostic::from_node(Self { literal, suffix }, &kind)]
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["number_literal"]
     }
 }
@@ -206,7 +206,7 @@ impl ASTRule for LiteralKindSuffix {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -265,8 +265,7 @@ mod tests {
             },
         )
         .collect();
-        let rule = LiteralKind::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = LiteralKind::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -303,8 +302,7 @@ mod tests {
             )
         })
         .collect();
-        let rule = LiteralKindSuffix::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = LiteralKindSuffix::apply(&source)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rules/typing/literal_kinds.rs
+++ b/src/rules/typing/literal_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{dtype_is_plain_number, FortitudeNode};
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -73,15 +73,6 @@ impl Violation for LiteralKind {
     fn message(&self) -> String {
         let Self { dtype, literal } = self;
         format!("{dtype} kind set with number literal '{literal}', use 'iso_fortran_env' parameter",)
-    }
-}
-
-impl Rule for LiteralKind {
-    fn new(_settings: &Settings) -> Self {
-        LiteralKind {
-            dtype: String::default(),
-            literal: String::default(),
-        }
     }
 }
 
@@ -174,15 +165,6 @@ impl Violation for LiteralKindSuffix {
     fn message(&self) -> String {
         let Self { literal, suffix } = self;
         format!("'{literal}' has literal suffix '{suffix}', use 'iso_fortran_env' parameter")
-    }
-}
-
-impl Rule for LiteralKindSuffix {
-    fn new(_settings: &Settings) -> Self {
-        LiteralKindSuffix {
-            literal: String::default(),
-            suffix: String::default(),
-        }
     }
 }
 

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -45,7 +45,7 @@ impl Rule for StarKind {
 }
 
 impl ASTRule for StarKind {
-    fn check(&self, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         let dtype = node.child(0)?.to_text(src)?.to_lowercase();
         // TODO: Handle characters
@@ -70,7 +70,7 @@ impl ASTRule for StarKind {
         )]
     }
 
-    fn entrypoints(&self) -> Vec<&'static str> {
+    fn entrypoints() -> Vec<&'static str> {
         vec!["intrinsic_type"]
     }
 }
@@ -78,7 +78,7 @@ impl ASTRule for StarKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{settings::default_settings, test_file, FromStartEndLineCol};
+    use crate::{test_file, FromStartEndLineCol};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -135,8 +135,7 @@ mod tests {
         )
         .collect();
 
-        let rule = StarKind::new(&default_settings());
-        let actual = rule.apply(&source)?;
+        let actual = StarKind::apply(&source)?;
         assert_eq!(actual, expected);
 
         Ok(())

--- a/src/rules/typing/star_kinds.rs
+++ b/src/rules/typing/star_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{dtype_is_plain_number, strip_line_breaks, FortitudeNode};
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode, Rule};
+use crate::{ASTRule, FromASTNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -31,16 +31,6 @@ impl Violation for StarKind {
     fn message(&self) -> String {
         let Self { dtype, size, kind } = self;
         format!("{dtype}{size} is non-standard, use {dtype}({kind})")
-    }
-}
-
-impl Rule for StarKind {
-    fn new(_settings: &Settings) -> Self {
-        StarKind {
-            dtype: String::default(),
-            size: String::default(),
-            kind: String::default(),
-        }
     }
 }
 


### PR DESCRIPTION
This is a PR into #96

I think in rust parlance these are now "associated functions", but they're now the equivalent of C++'s static methods. This lets us do several things:

- call `check` without actually having to make an instance
- store the `check` functions in the rule lookup maps
- remove the `Rule` trait entirely