### PR TITLE
Update dev README to provide correct commands for installing from source

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -3,7 +3,8 @@
 ## Installation from source
 
 To install from source, you must first have a working Rust environment (see
-[rustup](https://rustup.rs/)). The project may then be installed either using `pip`:
+[rustup](https://rustup.rs/)). The project may then be installed from the root directory
+using either `pip`:
 
 ```bash
 python -m venv venv # Or use your preferred virtual environment method...
@@ -14,7 +15,7 @@ pip install .[lint]
 Or using `cargo`:
 
 ```bash
-cargo install --path .
+cargo install --path fortitude
 ```
 
 ## Testing

--- a/README.dev.md
+++ b/README.dev.md
@@ -3,8 +3,8 @@
 ## Installation from source
 
 To install from source, you must first have a working Rust environment (see
-[rustup](https://rustup.rs/)). The project may then be installed from the root directory
-using either `pip`:
+[rustup](https://rustup.rs/)). The project may then be installed from the project
+root directory using either `pip`:
 
 ```bash
 python -m venv venv # Or use your preferred virtual environment method...


### PR DESCRIPTION
Thanks again for this project.
I am looking at building for development, but on my way came across this issue in the developer guidelines, so thought I'd submit a small patch.

Hopefully fixes #101 

I have updated to point cargo to `fortitude` rather than the local directory.

I also added a clarification that this should be run from the root directory of the project.
This is because `cargo install --path .` works from `fortitude/fortitude/`, but based on the pip installation instructions I assumed both are to be run from the root directory.