### PR TITLE
Fix explain bug with RuleSelector, improve explain output

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ fortitude check --select=T --ignore=T003
 The `explain` command can be used to get extra information about any rules:
 
 ```bash
-fortitude explain T001
+fortitude explain --rules=T001,T011,...
 ```
 
-If no rules are provided, this will print all rule descriptions to the terminal.
+If `--rules` is not provided, this will print all rule descriptions to the terminal.
 
 To see further commands and optional arguments, try using `--help`:
 

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -267,8 +267,12 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                 Ok(ExitCode::SUCCESS)
             } else {
                 let err_no = format!("Number of errors: {}", total_errors.to_string().bold());
-                let info = "For more information, run:";
-                let explain = format!("{} {}", "fortitude explain", "[ERROR_CODES]".bold());
+                let info = "For more information about specific rules, run:";
+                let explain = format!(
+                    "fortitude explain --rules={},{},...",
+                    "X001".bold().bright_red(),
+                    "Y002".bold().bright_red()
+                );
                 println!("\n{file_no}\n{err_no}\n\n{info}\n\n    {explain}\n");
                 Ok(ExitCode::FAILURE)
             }

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -41,7 +41,7 @@ pub struct ExplainArgs {
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
-    pub rules: Option<Vec<RuleSelector>>,
+    pub rules: Vec<RuleSelector>,
 }
 
 /// Perform static analysis on files and report issues.

--- a/fortitude/src/explain.rs
+++ b/fortitude/src/explain.rs
@@ -17,7 +17,7 @@ fn ruleset(args: &ExplainArgs) -> anyhow::Result<Vec<Rule>> {
     let preview = PreviewOptions::default();
 
     // The rules_set keeps track of which rules have been selected.
-    let mut rules_set: BTreeSet<Rule> = if args.rules.is_none() {
+    let mut rules_set: BTreeSet<Rule> = if args.rules.is_empty() {
         DEFAULT_SELECTORS
             .iter()
             .flat_map(|selector| selector.rules(&preview))
@@ -26,7 +26,7 @@ fn ruleset(args: &ExplainArgs) -> anyhow::Result<Vec<Rule>> {
         BTreeSet::default()
     };
 
-    for selector in args.rules.iter().flatten() {
+    for selector in args.rules.iter() {
         for rule in selector.rules(&preview) {
             rules_set.insert(rule);
         }
@@ -71,7 +71,8 @@ pub fn explain(args: ExplainArgs) -> Result<ExitCode> {
                 }
 
                 let code = rule.noqa_code().to_string();
-                let title = format!("# {code}");
+                let name = rule.name();
+                let title = format!("# {code}: {name}\n");
                 outputs.push((title.bright_red(), dedent(body.as_str())));
             }
             outputs.sort_by(|a, b| {

--- a/fortitude_macros/src/map_codes.rs
+++ b/fortitude_macros/src/map_codes.rs
@@ -396,6 +396,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
     let mut rule_message_formats_match_arms = quote!();
     let mut rule_fixable_match_arms = quote!();
     let mut rule_explanation_match_arms = quote!();
+    let mut rule_name_match_arms = quote!();
 
     let mut from_impls_for_diagnostic_kind = quote!();
 
@@ -432,6 +433,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
         );
         rule_explanation_match_arms
             .extend(quote! {#(#attrs)* Self::#name => #path::explanation(),});
+        rule_name_match_arms.extend(quote! {#(#attrs)* Self::#name => stringify!(#name),});
 
         // Enable conversion from `DiagnosticKind` to `Rule`.
         from_impls_for_diagnostic_kind
@@ -531,6 +533,11 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
             /// Returns the documentation for this rule.
             pub fn explanation(&self) -> Option<&'static str> {
                 match self { #rule_explanation_match_arms }
+            }
+
+            /// Returns the name for this rule.
+            pub fn name(&self) -> &'static str {
+                match self { #rule_name_match_arms }
             }
 
             /// Returns the fix status of this rule.


### PR DESCRIPTION
While trying out https://github.com/PlasmaFAIR/fortitude/pull/108/commits/7a4b965983001ab387c96d121a0c4c231723afb1 in https://github.com/PlasmaFAIR/fortitude/pull/108, I found that the `explain` command was no longer working properly. This PR fixes the bug, and while I was at it I also improved the output for `explain`, updated the README, and improved the help text that's printed when things go wrong.

`explain` now prints the name of the rule alongside the code, but it's in camel-case. There are a few Rust libraries that allow you to convert to other cases, like [sentence case](https://docs.rs/Inflector/latest/inflector/cases/sentencecase/index.html), but these aren't clever enough to rename `IOError` to `IO error` or `NonStandardFileExtension` to `Non-standard file extension`, so for now I've left it at camel-case.