### PR TITLE
Select rules by name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +289,7 @@ dependencies = [
 name = "fortitude_macros"
 version = "0.1.0"
 dependencies = [
+ "convert_case",
  "itertools 0.12.1",
  "proc-macro2",
  "quote",

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -2,7 +2,7 @@ use crate::ast::{parse, FortitudeNode};
 use crate::cli::CheckArgs;
 use crate::rule_selector::{PreviewOptions, Specificity};
 use crate::rules::Rule;
-use crate::rules::{error::ioerror::IOError, ASTRuleEnum, PathRuleEnum, TextRuleEnum};
+use crate::rules::{error::ioerror::IoError, AstRuleEnum, PathRuleEnum, TextRuleEnum};
 use crate::settings::{Settings, DEFAULT_SELECTORS};
 use crate::DiagnosticMessage;
 use anyhow::Result;
@@ -92,7 +92,7 @@ fn get_files<S: AsRef<str>>(files_in: &Vec<PathBuf>, extensions: &[S]) -> Vec<Pa
 fn check_file(
     path_rules: &Vec<PathRuleEnum>,
     text_rules: &Vec<TextRuleEnum>,
-    ast_entrypoints: &BTreeMap<&str, Vec<ASTRuleEnum>>,
+    ast_entrypoints: &BTreeMap<&str, Vec<AstRuleEnum>>,
     path: &Path,
     file: &SourceFile,
     settings: &Settings,
@@ -169,8 +169,8 @@ fn rules_to_text_rules(rules: &[Rule]) -> Vec<TextRuleEnum> {
 }
 
 /// Create a mapping of AST entrypoints to lists of the rules and codes that operate on them.
-fn ast_entrypoint_map<'a>(rules: &[Rule]) -> BTreeMap<&'a str, Vec<ASTRuleEnum>> {
-    let ast_rules: Vec<ASTRuleEnum> = rules
+fn ast_entrypoint_map<'a>(rules: &[Rule]) -> BTreeMap<&'a str, Vec<AstRuleEnum>> {
+    let ast_rules: Vec<AstRuleEnum> = rules
         .iter()
         .filter_map(|rule| match TryFrom::try_from(*rule) {
             Ok(ast) => Some(ast),
@@ -216,7 +216,7 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                         let message = format!("Error opening file: {error}");
                         let diagnostic = DiagnosticMessage::from_ruff(
                             &empty_file,
-                            Diagnostic::new(IOError { message }, TextRange::default()),
+                            Diagnostic::new(IoError { message }, TextRange::default()),
                         );
                         println!("{diagnostic}");
                         total_errors += 1;
@@ -249,7 +249,7 @@ pub fn check(args: CheckArgs) -> Result<ExitCode> {
                         let message = format!("Failed to process: {msg}");
                         let diagnostic = DiagnosticMessage::from_ruff(
                             &empty_file,
-                            Diagnostic::new(IOError { message }, TextRange::default()),
+                            Diagnostic::new(IoError { message }, TextRange::default()),
                         );
                         println!("{diagnostic}");
                         total_errors += 1;
@@ -328,7 +328,7 @@ mod tests {
         };
 
         let rules = ruleset(&args)?;
-        let one_rules: Vec<Rule> = vec![Rule::IOError];
+        let one_rules: Vec<Rule> = vec![Rule::IoError];
 
         assert_eq!(rules, one_rules);
 
@@ -347,7 +347,7 @@ mod tests {
         };
 
         let rules = ruleset(&args)?;
-        let one_rules: Vec<Rule> = vec![Rule::IOError, Rule::SyntaxError];
+        let one_rules: Vec<Rule> = vec![Rule::IoError, Rule::SyntaxError];
 
         assert_eq!(rules, one_rules);
 

--- a/fortitude/src/explain.rs
+++ b/fortitude/src/explain.rs
@@ -71,7 +71,7 @@ pub fn explain(args: ExplainArgs) -> Result<ExitCode> {
                 }
 
                 let code = rule.noqa_code().to_string();
-                let name = rule.name();
+                let name = rule.alias();
                 let title = format!("# {code}: {name}\n");
                 outputs.push((title.bright_red(), dedent(body.as_str())));
             }

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -26,11 +26,11 @@ use tree_sitter::Node;
 // Violation type
 // --------------
 
-pub trait FromASTNode {
+pub trait FromAstNode {
     fn from_node<T: Into<DiagnosticKind>>(violation: T, node: &Node) -> Self;
 }
 
-impl FromASTNode for Diagnostic {
+impl FromAstNode for Diagnostic {
     fn from_node<T: Into<DiagnosticKind>>(violation: T, node: &Node) -> Self {
         Self::new(
             violation,
@@ -86,7 +86,7 @@ pub trait TextRule {
 }
 
 /// Implemented by rules that analyse the abstract syntax tree.
-pub trait ASTRule {
+pub trait AstRule {
     fn check(settings: &Settings, node: &Node, source: &SourceFile) -> Option<Vec<Diagnostic>>;
 
     /// Return list of tree-sitter node types on which a rule should trigger.

--- a/fortitude/src/registry.rs
+++ b/fortitude/src/registry.rs
@@ -155,6 +155,14 @@ mod tests {
     }
 
     #[test]
+    fn check_code_from_alias() -> Result<(), String> {
+        for rule in Rule::iter() {
+            assert_eq!(rule, Rule::from_alias(rule.alias())?);
+        }
+        Ok(())
+    }
+
+    #[test]
     fn category_parse_code() {
         for rule in Rule::iter() {
             let code = format!("{}", rule.noqa_code());

--- a/fortitude/src/rule_selector.rs
+++ b/fortitude/src/rule_selector.rs
@@ -65,6 +65,12 @@ impl FromStr for RuleSelector {
                     None => (s, None),
                 };
 
+                // If passed full name of rule, use the equivalent code instead.
+                if let Ok(rule) = Rule::from_alias(s) {
+                    let c = rule.noqa_code().to_string();
+                    return Self::from_str(c.as_str());
+                }
+
                 let (category, code) =
                     Category::parse_code(s).ok_or_else(|| ParseError::Unknown(s.to_string()))?;
 

--- a/fortitude/src/rules/error/ioerror.rs
+++ b/fortitude/src/rules/error/ioerror.rs
@@ -14,7 +14,7 @@ use ruff_macros::{derive_message_formats, violation};
 /// from disk.
 ///
 /// ## Why is this bad?
-/// An `IOError` indicates an error in the development setup. For example, the user may
+/// An `IoError` indicates an error in the development setup. For example, the user may
 /// not have permissions to read a given file, or the filesystem may contain a broken
 /// symlink.
 ///
@@ -32,21 +32,21 @@ use ruff_macros::{derive_message_formats, violation};
 /// - [UNIX Permissions introduction](https://mason.gmu.edu/~montecin/UNIXpermiss.htm)
 /// - [Command Line Basics: Symbolic Links](https://www.digitalocean.com/community/tutorials/workflow-symbolic-links)
 #[violation]
-pub struct IOError {
+pub struct IoError {
     pub message: String,
 }
 
 /// E000
-impl Violation for IOError {
+impl Violation for IoError {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let IOError { message } = self;
+        let IoError { message } = self;
         format!("{message}")
     }
 }
 
 // Need to implement some kind of rule, although we only raise this manually
-impl PathRule for IOError {
+impl PathRule for IoError {
     fn check(_settings: &Settings, _path: &Path) -> Option<Diagnostic> {
         None
     }

--- a/fortitude/src/rules/error/syntax_error.rs
+++ b/fortitude/src/rules/error/syntax_error.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{some_vec, ASTRule, FromASTNode};
+use crate::{some_vec, AstRule, FromAstNode};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -26,7 +26,7 @@ impl Violation for SyntaxError {
     }
 }
 
-impl ASTRule for SyntaxError {
+impl AstRule for SyntaxError {
     fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         some_vec![Diagnostic::from_node(Self {}, node)]
     }

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::useless_format)]
 /// A collection of all rules, and utilities to select a subset at runtime.
-pub(crate) mod error; // Public so we can use `IOError` in other places
+pub(crate) mod error; // Public so we can use `IoError` in other places
 mod filesystem;
 #[macro_use]
 mod macros;
@@ -70,7 +70,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
 
     #[rustfmt::skip]
     Some(match (category, code) {
-        (Error, "000") => (RuleGroup::Stable, Path, error::ioerror::IOError),
+        (Error, "000") => (RuleGroup::Stable, Path, error::ioerror::IoError),
         (Error, "001") => (RuleGroup::Stable, Ast, error::syntax_error::SyntaxError),
 
         (Filesystem, "001") => (RuleGroup::Stable, Path, filesystem::extensions::NonStandardFileExtension),

--- a/fortitude/src/rules/modules/external_functions.rs
+++ b/fortitude/src/rules/modules/external_functions.rs
@@ -1,5 +1,5 @@
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -26,7 +26,7 @@ impl Violation for ExternalFunction {
     }
 }
 
-impl ASTRule for ExternalFunction {
+impl AstRule for ExternalFunction {
     fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if node.parent()?.kind() == "translation_unit" {
             let procedure_stmt = node.child(0)?;

--- a/fortitude/src/rules/modules/use_statements.rs
+++ b/fortitude/src/rules/modules/use_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -37,7 +37,7 @@ impl Violation for UseAll {
     }
 }
 
-impl ASTRule for UseAll {
+impl AstRule for UseAll {
     fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if node.child_with_name("included_items").is_none() {
             return some_vec![Diagnostic::from_node(UseAll {}, node)];

--- a/fortitude/src/rules/precision/double_precision.rs
+++ b/fortitude/src/rules/precision/double_precision.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -56,7 +56,7 @@ impl Violation for DoublePrecision {
     }
 }
 
-impl ASTRule for DoublePrecision {
+impl AstRule for DoublePrecision {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let txt = node.to_text(src.source_text())?.to_lowercase();
         some_vec![Diagnostic::from_node(DoublePrecision::try_new(txt)?, node)]

--- a/fortitude/src/rules/precision/implicit_kinds.rs
+++ b/fortitude/src/rules/precision/implicit_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -26,7 +26,7 @@ impl Violation for ImplicitRealKind {
     }
 }
 
-impl ASTRule for ImplicitRealKind {
+impl AstRule for ImplicitRealKind {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let dtype = node.child(0)?.to_text(src.source_text())?.to_lowercase();
 

--- a/fortitude/src/rules/precision/kind_suffixes.rs
+++ b/fortitude/src/rules/precision/kind_suffixes.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -55,7 +55,7 @@ impl Violation for NoRealSuffix {
     }
 }
 
-impl ASTRule for NoRealSuffix {
+impl AstRule for NoRealSuffix {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         // Given a number literal, match anything with one or more of a decimal place or
         // an exponentiation e or E. There should not be an underscore present.

--- a/fortitude/src/rules/style/end_statements.rs
+++ b/fortitude/src/rules/style/end_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -64,7 +64,7 @@ fn map_declaration(kind: &str) -> (&'static str, &'static str) {
     }
 }
 
-impl ASTRule for UnnamedEndStatement {
+impl AstRule for UnnamedEndStatement {
     fn check<'a>(
         _settings: &Settings,
         node: &'a Node,

--- a/fortitude/src/rules/style/exit_labels.rs
+++ b/fortitude/src/rules/style/exit_labels.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -33,7 +33,7 @@ impl Violation for MissingExitOrCycleLabel {
         format!("'{name}' statement in named 'do' loop missing label '{label}'")
     }
 }
-impl ASTRule for MissingExitOrCycleLabel {
+impl AstRule for MissingExitOrCycleLabel {
     fn check<'a>(
         _settings: &Settings,
         node: &'a Node,

--- a/fortitude/src/rules/style/old_style_array_literal.rs
+++ b/fortitude/src/rules/style/old_style_array_literal.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -22,7 +22,7 @@ impl Violation for OldStyleArrayLiteral {
         format!("Array literal uses old-style syntax: prefer `[...]`")
     }
 }
-impl ASTRule for OldStyleArrayLiteral {
+impl AstRule for OldStyleArrayLiteral {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if node.to_text(src.source_text())?.starts_with("(/") {
             return some_vec!(Diagnostic::from_node(Self {}, node));

--- a/fortitude/src/rules/style/relational_operators.rs
+++ b/fortitude/src/rules/style/relational_operators.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -38,7 +38,7 @@ impl Violation for DeprecatedRelationalOperator {
         format!("deprecated relational operator '{symbol}', prefer '{new_symbol}' instead")
     }
 }
-impl ASTRule for DeprecatedRelationalOperator {
+impl AstRule for DeprecatedRelationalOperator {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let relation = node.child(1)?;
         let symbol = relation

--- a/fortitude/src/rules/typing/assumed_size.rs
+++ b/fortitude/src/rules/typing/assumed_size.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use itertools::Itertools;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -53,7 +53,7 @@ impl Violation for AssumedSize {
         format!("'{name}' has assumed size")
     }
 }
-impl ASTRule for AssumedSize {
+impl AstRule for AssumedSize {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         let declaration = node
@@ -160,7 +160,7 @@ impl Violation for AssumedSizeCharacterIntent {
         format!("character '{name}' has assumed size but does not have `intent(in)`")
     }
 }
-impl ASTRule for AssumedSizeCharacterIntent {
+impl AstRule for AssumedSizeCharacterIntent {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         // TODO: This warning will also catch:
@@ -243,7 +243,7 @@ impl Violation for DeprecatedAssumedSizeCharacter {
         format!("character '{name}' uses deprecated syntax for assumed size")
     }
 }
-impl ASTRule for DeprecatedAssumedSizeCharacter {
+impl AstRule for DeprecatedAssumedSizeCharacter {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         let declaration = node

--- a/fortitude/src/rules/typing/implicit_typing.rs
+++ b/fortitude/src/rules/typing/implicit_typing.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -40,7 +40,7 @@ impl Violation for ImplicitTyping {
         format!("{entity} missing 'implicit none'")
     }
 }
-impl ASTRule for ImplicitTyping {
+impl AstRule for ImplicitTyping {
     fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if !child_is_implicit_none(node) {
             let entity = node.kind().to_string();
@@ -74,7 +74,7 @@ impl Violation for InterfaceImplicitTyping {
     }
 }
 
-impl ASTRule for InterfaceImplicitTyping {
+impl AstRule for InterfaceImplicitTyping {
     fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let parent = node.parent()?;
         if parent.kind() == "interface" && !child_is_implicit_none(node) {
@@ -113,7 +113,7 @@ impl AlwaysFixableViolation for SuperfluousImplicitNone {
     }
 }
 
-impl ASTRule for SuperfluousImplicitNone {
+impl AstRule for SuperfluousImplicitNone {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         if !implicit_statement_is_none(node) {
             return None;

--- a/fortitude/src/rules/typing/init_decls.rs
+++ b/fortitude/src/rules/typing/init_decls.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -78,7 +78,7 @@ impl Violation for InitialisationInDeclaration {
     }
 }
 
-impl ASTRule for InitialisationInDeclaration {
+impl AstRule for InitialisationInDeclaration {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         // Only check in procedures

--- a/fortitude/src/rules/typing/intent.rs
+++ b/fortitude/src/rules/typing/intent.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -38,7 +38,7 @@ impl Violation for MissingIntent {
     }
 }
 
-impl ASTRule for MissingIntent {
+impl AstRule for MissingIntent {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         // Names of all the dummy arguments

--- a/fortitude/src/rules/typing/literal_kinds.rs
+++ b/fortitude/src/rules/typing/literal_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{dtype_is_plain_number, FortitudeNode};
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -76,7 +76,7 @@ impl Violation for LiteralKind {
     }
 }
 
-impl ASTRule for LiteralKind {
+impl AstRule for LiteralKind {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         let dtype = node.child(0)?.to_text(src)?.to_lowercase();
@@ -168,7 +168,7 @@ impl Violation for LiteralKindSuffix {
     }
 }
 
-impl ASTRule for LiteralKindSuffix {
+impl AstRule for LiteralKindSuffix {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         let kind = node.child_by_field_name("kind")?;

--- a/fortitude/src/rules/typing/star_kinds.rs
+++ b/fortitude/src/rules/typing/star_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{dtype_is_plain_number, strip_line_breaks, FortitudeNode};
 use crate::settings::Settings;
-use crate::{ASTRule, FromASTNode};
+use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
@@ -34,7 +34,7 @@ impl Violation for StarKind {
     }
 }
 
-impl ASTRule for StarKind {
+impl AstRule for StarKind {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let src = src.source_text();
         let dtype = node.child(0)?.to_text(src)?.to_lowercase();

--- a/fortitude_macros/Cargo.toml
+++ b/fortitude_macros/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
+convert_case = "0.6.0"
 proc-macro2 = "1.0.89"
 quote = "1.0.37"
 syn = "2.0.86"

--- a/fortitude_macros/src/map_codes.rs
+++ b/fortitude_macros/src/map_codes.rs
@@ -502,7 +502,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
         use ruff_diagnostics::{Diagnostic, Violation};
         use ruff_source_file::SourceFile;
         use tree_sitter::Node;
-        use crate::{ASTRule, PathRule, TextRule};
+        use crate::{AstRule, PathRule, TextRule};
         use crate::settings::Settings;
 
 
@@ -645,20 +645,20 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
         )]
         #[repr(u16)]
         #[strum(serialize_all = "kebab-case")]
-        pub enum ASTRuleEnum { #ast_rule_variants }
+        pub enum AstRuleEnum { #ast_rule_variants }
 
-        impl TryFrom<Rule> for ASTRuleEnum {
+        impl TryFrom<Rule> for AstRuleEnum {
             type Error = &'static str;
 
             fn try_from(rule: Rule) -> Result<Self, Self::Error> {
                 match rule {
                     #ast_rule_from_match_arms
-                    _ => Err("not an ASTRule")
+                    _ => Err("not an AstRule")
                 }
             }
         }
 
-        impl ASTRuleEnum {
+        impl AstRuleEnum {
             pub fn check(&self, settings: &Settings, node: &Node, source: &SourceFile) -> Option<Vec<Diagnostic>> {
                 match self {
                     #ast_rule_check_match_arms

--- a/fortitude_macros/src/rule_namespace.rs
+++ b/fortitude_macros/src/rule_namespace.rs
@@ -95,9 +95,11 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
 
     for (prefix, field) in parsed {
         let ret_str = quote!(rest);
-        if_statements.extend(quote! {if let Some(rest) = code.strip_prefix(#prefix) {
-            return Some((#ident::#field, #ret_str));
-        }});
+        if_statements.extend(quote! {
+            if let Some(rest) = code.strip_prefix(#prefix) {
+                return Some((#ident::#field, #ret_str));
+            }
+        });
     }
 
     Ok(quote! {


### PR DESCRIPTION
Adds a basic implementation for https://github.com/PlasmaFAIR/fortitude/issues/106, so you can now specify the full names of rules:

```
fortitude check --select=implicit-typing
```

Also works in settings files.

Missing some features:

- Can't specify categories by full name, so `--select=typing` doesn't work.
- Human-readable names are mapped 1-to-1 with rule codes. In the future we'll likely need multiple human-readable names and multiple codes mapping to each rule.

Ultimately I think we'll need to add more macro machinery to do it properly, but right now I'm still having issues figuring out how everything fits together.