### PR TITLE
Select categories by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,28 @@ You can select or ignore individual rules or whole groups with
 ```bash
 # Just check for missing `implicit none`
 fortitude check --select=T001
+# Also check for missing `implicit none` in interfaces
+fortitude check --select=T001,T002
 # Ignore all styling rules
 fortitude check --ignore=S
 # Only check for typing rules, but ignore superfluous implicit none
 fortitude check --select=T --ignore=T003
+# Rules and categories can also be referred to by name
+fortitude check --select=typing --ignore=superfluous-implicit-none
 ```
 
 The `explain` command can be used to get extra information about any rules:
 
 ```bash
-fortitude explain --rules=T001,T011,...
+# Print extra information for all rules
+fortitude explain
+# Only get information for selected rules
+fortitude explain --rules=T001,T011
+# Print information on all style rules
+fortitude explain --rules=S
+# Rules and categories can also be referred to by name
+fortitude explain --rules=style,superfluous-implicit-none
 ```
-
-If `--rules` is not provided, this will print all rule descriptions to the terminal.
 
 To see further commands and optional arguments, try using `--help`:
 

--- a/fortitude/src/registry.rs
+++ b/fortitude/src/registry.rs
@@ -66,6 +66,11 @@ pub trait RuleNamespace: Sized {
 
     #[allow(dead_code)]
     fn description(&self) -> &'static str;
+
+    /// Try to build a category from a string. These should match the category
+    /// names within the enum, though are converted to lower-kebab-case.
+    #[allow(dead_code)]
+    fn from_alias(s: &str) -> Result<Self, String>;
 }
 
 pub mod clap_completion {

--- a/fortitude_macros/src/rule_namespace.rs
+++ b/fortitude_macros/src/rule_namespace.rs
@@ -5,6 +5,7 @@
 use std::cmp::Reverse;
 use std::collections::HashSet;
 
+use convert_case::{Case, Casing};
 use quote::quote;
 use syn::spanned::Spanned;
 use syn::{Data, DataEnum, DeriveInput, Error, ExprLit, Lit, Meta, MetaNameValue};
@@ -26,6 +27,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
 
     let mut common_prefix_match_arms = quote!();
     let mut name_match_arms = quote!();
+    let mut alias_match_arms = quote!();
     let mut description_match_arms = quote!();
 
     let mut all_prefixes = HashSet::new();
@@ -71,9 +73,11 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
         };
 
         let variant_ident = variant.ident;
-        description_match_arms.extend(quote! { Self::#variant_ident => stringify!(#doc_attr), });
+        let variant_alias = variant_ident.to_string().to_case(Case::Kebab);
 
+        description_match_arms.extend(quote! { Self::#variant_ident => stringify!(#doc_attr),});
         name_match_arms.extend(quote! {Self::#variant_ident => stringify!(#variant_ident),});
+        alias_match_arms.extend(quote! {#variant_alias => Ok(Self::#variant_ident),});
 
         for lit in &prefixes {
             parsed.push((lit.clone(), variant_ident.clone()));
@@ -106,6 +110,9 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
         #[automatically_derived]
         impl crate::registry::RuleNamespace for #ident {
             fn parse_code(code: &str) -> Option<(Self, &str)> {
+                if let Ok(variant) = Self::from_alias(code) {
+                    return Some((variant, ""));
+                }
                 #if_statements
                 None
             }
@@ -120,6 +127,13 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
 
             fn description(&self) -> &'static str {
                 match self { #description_match_arms }
+            }
+
+            fn from_alias(s: &str) -> Result<Self, String> {
+                match s {
+                    #alias_match_arms
+                    _ => Err(format!("Unknown rule namespace: {s}"))
+                }
             }
         }
     })


### PR DESCRIPTION
Extends https://github.com/PlasmaFAIR/fortitude/pull/111, rule categories can also be selected by name, allowing things like:

```
fortitude check --select=typing,S --ignore=unnamed-end-statement,T001
```

I'd argue that this mostly resolves https://github.com/PlasmaFAIR/fortitude/issues/106, but we're still lacking the ability to map multiple aliases to one rule.