### PR TITLE
Refactor: Use `strum_macros` to get rule and category names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,15 +192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,7 +280,6 @@ dependencies = [
 name = "fortitude_macros"
 version = "0.1.0"
 dependencies = [
- "convert_case",
  "itertools 0.12.1",
  "proc-macro2",
  "quote",

--- a/fortitude/src/explain.rs
+++ b/fortitude/src/explain.rs
@@ -71,7 +71,7 @@ pub fn explain(args: ExplainArgs) -> Result<ExitCode> {
                 }
 
                 let code = rule.noqa_code().to_string();
-                let name = rule.alias();
+                let name = rule.as_ref();
                 let title = format!("# {code}: {name}\n");
                 outputs.push((title.bright_red(), dedent(body.as_str())));
             }

--- a/fortitude/src/registry.rs
+++ b/fortitude/src/registry.rs
@@ -1,5 +1,5 @@
 use fortitude_macros::RuleNamespace;
-use strum_macros::EnumIter;
+use std::str::FromStr; // Needed by strum_macros
 
 pub use crate::rules::Rule;
 
@@ -29,7 +29,23 @@ pub enum FromCodeError {
 }
 
 /// The category of each rule defines the sort of problem it intends to solve.
-#[derive(EnumIter, Debug, PartialEq, Eq, Clone, Hash, RuleNamespace)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Hash,
+    PartialOrd,
+    Ord,
+    strum_macros::AsRefStr,
+    strum_macros::Display,
+    strum_macros::EnumIter,
+    strum_macros::EnumString,
+    strum_macros::IntoStaticStr,
+    RuleNamespace,
+)]
+#[repr(u16)]
+#[strum(serialize_all = "kebab-case")]
 pub enum Category {
     /// Failure to parse a file.
     #[prefix = "E"]
@@ -66,11 +82,6 @@ pub trait RuleNamespace: Sized {
 
     #[allow(dead_code)]
     fn description(&self) -> &'static str;
-
-    /// Try to build a category from a string. These should match the category
-    /// names within the enum, though are converted to lower-kebab-case.
-    #[allow(dead_code)]
-    fn from_alias(s: &str) -> Result<Self, String>;
 }
 
 pub mod clap_completion {
@@ -157,14 +168,6 @@ mod tests {
                 "{rule:?} could not be round-trip serialized."
             );
         }
-    }
-
-    #[test]
-    fn check_code_from_alias() -> Result<(), String> {
-        for rule in Rule::iter() {
-            assert_eq!(rule, Rule::from_alias(rule.alias())?);
-        }
-        Ok(())
     }
 
     #[test]

--- a/fortitude/src/rule_selector.rs
+++ b/fortitude/src/rule_selector.rs
@@ -66,7 +66,7 @@ impl FromStr for RuleSelector {
                 };
 
                 // If passed full name of rule, use the equivalent code instead.
-                if let Ok(rule) = Rule::from_alias(s) {
+                if let Ok(rule) = Rule::from_str(s) {
                     let c = rule.noqa_code().to_string();
                     return Self::from_str(c.as_str());
                 }

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -10,8 +10,6 @@ mod style;
 mod typing;
 use crate::registry::{AsRule, Category};
 
-use strum_macros::{AsRefStr, EnumIter};
-
 use std::fmt::Formatter;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]

--- a/fortitude_macros/Cargo.toml
+++ b/fortitude_macros/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-convert_case = "0.6.0"
 proc-macro2 = "1.0.89"
 quote = "1.0.37"
 syn = "2.0.86"


### PR DESCRIPTION
After looking into how ruff handles conversion to-and-from human-readable names for rules, I realised that most of the machinery needed to do so was already in the code: the line `#[strum(serialize_all="kebab-case")]` was already generating nice names for each rule, and the derive macro `strum_macros::AsRefStr` was adding `.to_ref()`, which converts the rule to `&'a str`. By adding the macro `strum_macros::EnumString` I was able to also gain the string-to-enum mapping, and `strum_macros::Display` adds `.to_string()`. I also added `strum_macros::IntoStaticStr` for the sake of completing the set.

This PR adds extra strum functionality and removes the extra functions added in https://github.com/PlasmaFAIR/fortitude/pull/111 and https://github.com/PlasmaFAIR/fortitude/pull/112, but leaves the functionality to select rules and categories by name on the command line and in settings files. It also cleans up a few imports.