### PR TITLE
Fix reading config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,21 +150,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size",
-]
-
-[[package]]
-name = "clap_config"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46efb9cbf691f5505d0b7b2c8055aec0c9a770eaac8a06834b6d84b5be93279a"
-dependencies = [
- "clap",
- "heck",
- "proc-macro2",
- "quote",
- "serde",
- "syn",
 ]
 
 [[package]]
@@ -294,7 +279,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
- "clap_config",
  "colored",
  "fortitude_macros",
  "insta",
@@ -851,16 +835,6 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
-dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]

--- a/fortitude/Cargo.toml
+++ b/fortitude/Cargo.toml
@@ -18,7 +18,6 @@ exclude = [".*", "test.f90"]
 annotate-snippets = "0.11.4"
 anyhow = "1.0.79"
 clap = { version = "4.4.16", features = ["derive", "string"] }
-clap_config = "0.1.1"
 colored = "2.1.0"
 fortitude_macros = { version = "0.1.0", path = "../fortitude_macros" }
 is-macro = "0.3.7"

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -1,36 +1,40 @@
-use anyhow::{Context, Result};
-use clap::{CommandFactory, Parser, Subcommand};
-use clap_config::ClapConfig;
+use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
-use toml::Table;
+use std::path::PathBuf;
 
 use crate::{rule_selector::RuleSelector, RuleSelectorParser};
 
 /// Default extensions to check
-const FORTRAN_EXTS: &[&str] = &[
+pub const FORTRAN_EXTS: &[&str] = &[
     "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "f18", "F18", "f23", "F23",
 ];
 
-#[derive(Debug, Parser, ClapConfig)]
+#[derive(Debug, Parser)]
 #[command(version, about)]
 pub struct Cli {
     #[clap(subcommand)]
     pub command: SubCommands,
+    #[clap(flatten)]
+    pub global_options: GlobalConfigArgs,
+}
 
+/// All configuration options that can be passed "globally",
+/// i.e., can be passed to all subcommands
+#[derive(Debug, Default, Clone, clap::Args)]
+pub struct GlobalConfigArgs {
     /// Path to a TOML configuration file
     #[arg(long)]
     pub config_file: Option<PathBuf>,
 }
 
-#[derive(Debug, Subcommand, ClapConfig, Clone, PartialEq)]
+#[derive(Debug, Subcommand, Clone, PartialEq)]
 pub enum SubCommands {
     Check(CheckArgs),
     Explain(ExplainArgs),
 }
 
 /// Get descriptions, rationales, and solutions for each rule.
-#[derive(Debug, clap::Parser, ClapConfig, Clone, PartialEq)]
+#[derive(Debug, clap::Parser, Clone, PartialEq)]
 pub struct ExplainArgs {
     /// List of rules to explain. If omitted, explains all rules.
     #[arg(
@@ -44,11 +48,12 @@ pub struct ExplainArgs {
 }
 
 /// Perform static analysis on files and report issues.
-#[derive(Debug, clap::Parser, Deserialize, Serialize, ClapConfig, Clone, PartialEq)]
+#[derive(Debug, clap::Parser, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct CheckArgs {
     /// List of files to analyze
     #[arg(default_value = ".")]
-    pub files: Vec<PathBuf>,
+    pub files: Option<Vec<PathBuf>>,
     /// Comma-separated list of rules to ignore.
     #[arg(
         long,
@@ -58,7 +63,7 @@ pub struct CheckArgs {
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
-    pub ignore: Vec<RuleSelector>,
+    pub ignore: Option<Vec<RuleSelector>>,
     /// Comma-separated list of rule codes to enable (or ALL, to enable all rules).
     #[arg(
         long,
@@ -68,7 +73,7 @@ pub struct CheckArgs {
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
-    pub select: Vec<RuleSelector>,
+    pub select: Option<Vec<RuleSelector>>,
     /// Like --select, but adds additional rule codes on top of those already specified.
     #[arg(
         long,
@@ -78,143 +83,11 @@ pub struct CheckArgs {
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
-    pub extend_select: Vec<RuleSelector>,
+    pub extend_select: Option<Vec<RuleSelector>>,
     /// Set the maximum allowable line length.
     #[arg(long, default_value = "100")]
-    pub line_length: usize,
+    pub line_length: Option<usize>,
     /// File extensions to check
     #[arg(long, value_delimiter = ',', default_values = FORTRAN_EXTS)]
-    pub file_extensions: Vec<String>,
-}
-
-// These are just helper structs to let us quickly work out if there's
-// a fortitude section in an fpm.toml file
-#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
-struct Fpm {
-    extra: Option<Extra>,
-}
-
-#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
-struct Extra {
-    fortitude: Option<EmptyConfig>,
-}
-
-#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
-struct EmptyConfig {}
-
-// Adapted from ruff
-fn parse_fpm_toml<P: AsRef<Path>>(path: P) -> Result<Fpm> {
-    let contents = std::fs::read_to_string(path.as_ref())
-        .with_context(|| format!("Failed to read {}", path.as_ref().display()))?;
-    toml::from_str(&contents)
-        .with_context(|| format!("Failed to parse {}", path.as_ref().display()))
-}
-
-pub fn fortitude_enabled<P: AsRef<Path>>(path: P) -> Result<bool> {
-    let fpm = parse_fpm_toml(path)?;
-    Ok(fpm.extra.and_then(|extra| extra.fortitude).is_some())
-}
-
-/// Return the path to the `fpm.toml` or `fortitude.toml` file in a given
-/// directory. Adapated from ruff
-pub fn settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
-    // Check for `.fortitude.toml`.
-    let fortitude_toml = path.as_ref().join(".fortitude.toml");
-    if fortitude_toml.is_file() {
-        return Ok(Some(fortitude_toml));
-    }
-
-    // Check for `fortitude.toml`.
-    let fortitude_toml = path.as_ref().join("fortitude.toml");
-    if fortitude_toml.is_file() {
-        return Ok(Some(fortitude_toml));
-    }
-
-    // Check for `fpm.toml`.
-    let fpm_toml = path.as_ref().join("fpm.toml");
-    if fpm_toml.is_file() && fortitude_enabled(&fpm_toml)? {
-        return Ok(Some(fpm_toml));
-    }
-
-    Ok(None)
-}
-
-/// Find the path to the `fpm.toml` or `fortitude.toml` file, if such a file
-/// exists. Adapated from ruff
-pub fn find_settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
-    for directory in path.as_ref().ancestors() {
-        if let Some(settings) = settings_toml(directory)? {
-            return Ok(Some(settings));
-        }
-    }
-    Ok(None)
-}
-
-fn from_clap_config_subsection<P: AsRef<Path>>(path: P) -> Result<Cli> {
-    let matches = <Cli as CommandFactory>::command().get_matches();
-
-    let config_str = if path.as_ref().ends_with("fpm.toml") {
-        let config = std::fs::read_to_string(path)?.parse::<Table>()?;
-
-        // Unwrap should be ok here because we've already checked this
-        // file has these tables
-        let extra = &config["extra"].as_table().unwrap();
-        let fortitude = &extra["fortitude"].as_table().unwrap();
-        fortitude.to_string()
-    } else {
-        std::fs::read_to_string(path)?
-    };
-
-    let config: CliConfig = toml::from_str(&config_str)?;
-
-    Ok(Cli::from_merged(matches, Some(config)))
-}
-
-pub fn parse_args() -> Result<Cli> {
-    let args = Cli::parse();
-
-    if args.config_file.is_some() {
-        return from_clap_config_subsection(args.config_file.unwrap());
-    }
-
-    if let Some(toml_file) = find_settings_toml(".")? {
-        from_clap_config_subsection(toml_file)
-    } else {
-        Ok(args)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::fs;
-
-    use anyhow::{Context, Result};
-    use tempfile::TempDir;
-    use textwrap::dedent;
-
-    use super::*;
-
-    #[test]
-    fn find_and_check_fpm_toml() -> Result<()> {
-        let tempdir = TempDir::new()?;
-        let fpm_toml = tempdir.path().join("fpm.toml");
-        fs::write(
-            fpm_toml,
-            dedent(
-                r#"
-                some-stuff = 1
-                other-things = "hello"
-
-                [extra.fortitude.check]
-                ignore = ["T001"]
-                "#,
-            ),
-        )?;
-
-        let fpm = find_settings_toml(tempdir.path())?.context("Failed to find fpm.toml")?;
-        let enabled = fortitude_enabled(fpm)?;
-        assert!(enabled);
-
-        Ok(())
-    }
+    pub file_extensions: Option<Vec<String>>,
 }

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -18,7 +18,7 @@ use colored::{ColoredString, Colorize};
 use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
 use ruff_source_file::{OneIndexed, SourceFile, SourceLocation};
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use settings::{Settings};
+use settings::Settings;
 use std::cmp::Ordering;
 use std::fmt;
 use std::path::Path;

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -18,7 +18,7 @@ use colored::{ColoredString, Colorize};
 use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
 use ruff_source_file::{OneIndexed, SourceFile, SourceLocation};
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use settings::{default_settings, Settings};
+use settings::{Settings};
 use std::cmp::Ordering;
 use std::fmt;
 use std::path::Path;
@@ -96,12 +96,11 @@ pub trait AstRule {
     /// Apply a rule over some text, generating all violations raised as a result.
     fn apply(source: &SourceFile) -> anyhow::Result<Vec<Diagnostic>> {
         let entrypoints = Self::entrypoints();
-        let default_settings = default_settings();
         Ok(parse(source.source_text())?
             .root_node()
             .named_descendants()
             .filter(|x| entrypoints.contains(&x.kind()))
-            .filter_map(|x| Self::check(&default_settings, &x, source))
+            .filter_map(|x| Self::check(&Settings::default(), &x, source))
             .flatten()
             .collect())
     }

--- a/fortitude/src/main.rs
+++ b/fortitude/src/main.rs
@@ -1,20 +1,19 @@
 use std::process::ExitCode;
 
+use anyhow::Result;
+use clap::Parser;
 use fortitude::check::check;
-use fortitude::cli::{parse_args, SubCommands};
+use fortitude::cli::{Cli, SubCommands};
 use fortitude::explain::explain;
 
-fn main() -> ExitCode {
-    let args = match parse_args() {
-        Ok(args) => args,
-        Err(_) => return ExitCode::FAILURE,
-    };
+fn main() -> Result<ExitCode> {
+    let args = Cli::parse();
     let status = match args.command {
-        SubCommands::Check(args) => check(args),
+        SubCommands::Check(check_args) => check(check_args, &args.global_options),
         SubCommands::Explain(args) => explain(args),
     };
     match status {
-        Ok(code) => code,
-        Err(_) => ExitCode::FAILURE,
+        Ok(code) => Ok(code),
+        Err(_) => status,
     }
 }

--- a/fortitude/src/rules/filesystem/extensions.rs
+++ b/fortitude/src/rules/filesystem/extensions.rs
@@ -42,13 +42,12 @@ impl PathRule for NonStandardFileExtension {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::default_settings;
 
     #[test]
     fn test_bad_file_extension() {
         let path = Path::new("my/dir/to/file.f95");
         assert_eq!(
-            NonStandardFileExtension::check(&default_settings(), path),
+            NonStandardFileExtension::check(&Settings::default(), path),
             Some(Diagnostic::new(
                 NonStandardFileExtension {},
                 TextRange::default()
@@ -60,7 +59,7 @@ mod tests {
     fn test_missing_file_extension() {
         let path = Path::new("my/dir/to/file");
         assert_eq!(
-            NonStandardFileExtension::check(&default_settings(), path),
+            NonStandardFileExtension::check(&Settings::default(), path),
             Some(Diagnostic::new(
                 NonStandardFileExtension {},
                 TextRange::default()
@@ -73,11 +72,11 @@ mod tests {
         let path1 = Path::new("my/dir/to/file.f90");
         let path2 = Path::new("my/dir/to/file.F90");
         assert_eq!(
-            NonStandardFileExtension::check(&default_settings(), path1),
+            NonStandardFileExtension::check(&Settings::default(), path1),
             None
         );
         assert_eq!(
-            NonStandardFileExtension::check(&default_settings(), path2),
+            NonStandardFileExtension::check(&Settings::default(), path2),
             None
         );
     }

--- a/fortitude/src/rules/modules/mod.rs
+++ b/fortitude/src/rules/modules/mod.rs
@@ -15,7 +15,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::registry::Rule;
-    use crate::settings::default_settings;
+    use crate::settings::Settings;
     use crate::test::test_path;
 
     #[test_case(Rule::ExternalFunction, Path::new("M001.f90"))]
@@ -25,7 +25,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("modules").join(path).as_path(),
             &[rule_code],
-            &default_settings(),
+            &Settings::default(),
         )?;
         assert_snapshot!(snapshot, diagnostics);
         Ok(())

--- a/fortitude/src/rules/precision/mod.rs
+++ b/fortitude/src/rules/precision/mod.rs
@@ -12,7 +12,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::registry::Rule;
-    use crate::settings::default_settings;
+    use crate::settings::Settings;
     use crate::test::test_path;
 
     #[test_case(Rule::NoRealSuffix, Path::new("P001.f90"))]
@@ -23,7 +23,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("precision").join(path).as_path(),
             &[rule_code],
-            &default_settings(),
+            &Settings::default(),
         )?;
         assert_snapshot!(snapshot, diagnostics);
         Ok(())

--- a/fortitude/src/rules/style/mod.rs
+++ b/fortitude/src/rules/style/mod.rs
@@ -15,7 +15,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::registry::Rule;
-    use crate::settings::{default_settings, Settings};
+    use crate::settings::Settings;
     use crate::test::test_path;
 
     #[test_case(Rule::LineTooLong, Path::new("S001.f90"))]
@@ -29,7 +29,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("style").join(path).as_path(),
             &[rule_code],
-            &default_settings(),
+            &Settings::default(),
         )?;
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
@@ -41,7 +41,7 @@ mod tests {
         #[allow(clippy::needless_update)]
         let settings = Settings {
             line_length: 20,
-            ..default_settings()
+            ..Settings::default()
         };
         let diagnostics = test_path(
             Path::new("style").join(path).as_path(),

--- a/fortitude/src/rules/typing/mod.rs
+++ b/fortitude/src/rules/typing/mod.rs
@@ -15,7 +15,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::registry::Rule;
-    use crate::settings::default_settings;
+    use crate::settings::Settings;
     use crate::test::test_path;
 
     #[test_case(Rule::ImplicitTyping, Path::new("T001.f90"))]
@@ -34,7 +34,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("typing").join(path).as_path(),
             &[rule_code],
-            &default_settings(),
+            &Settings::default(),
         )?;
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
@@ -47,7 +47,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("typing").join(path).as_path(),
             &[rule_code],
-            &default_settings(),
+            &Settings::default(),
         )?;
         assert!(
             diagnostics.is_empty(),

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -10,9 +10,7 @@ pub struct Settings {
 
 impl Default for Settings {
     fn default() -> Self {
-        Self {
-            line_length: 100,
-        }
+        Self { line_length: 100 }
     }
 }
 

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -8,9 +8,12 @@ pub struct Settings {
     pub line_length: usize,
 }
 
-#[allow(dead_code)]
-pub fn default_settings() -> Settings {
-    Settings { line_length: 100 }
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            line_length: 100,
+        }
+    }
 }
 
 /// Toggle for rules still in preview


### PR DESCRIPTION
Also make sure we bubble up errors from the TOML parser

Fixes #118

The two main problems with the previous solution were:

- no control of case normalisation (we want kebab-case)
- surprising error handling with problems in config file

Easiest solution is less clever, but seems to work better.

Part of the verboseness is because we may or may not have a config
file, which may or may not have any/all options set, which means many
paths to check when overriding from the CLI or falling back to the
default value.

So to solve that particular pain, we have an intermediate type with
all fields set and make a concrete instance (that is, not an
`Option`).

This means we end up with some duplication all over the place, but at
least it works!
