### PR TITLE
Update precision explanations

### DIFF
--- a/fortitude/src/rules/modules/use_statements.rs
+++ b/fortitude/src/rules/modules/use_statements.rs
@@ -16,7 +16,7 @@ use tree_sitter::Node;
 /// components you intend to use:
 ///
 /// ## Example
-/// ```fortran
+/// ```f90
 /// ! Not recommended
 /// use, intrinsic :: iso_fortran_env
 ///

--- a/fortitude/src/rules/precision/double_precision.rs
+++ b/fortitude/src/rules/precision/double_precision.rs
@@ -24,12 +24,6 @@ use tree_sitter::Node;
 /// - `use, intrinsic :: iso_fortran_env, only: dp => real64`
 /// - `integer, parameter :: dp = selected_real_kind(15, 307)`
 ///
-/// To select a `real` with the same precision as `double precision`, the kind
-/// may be set from a floating point literal constant using `d` or `D` to denote
-/// the exponent:
-///
-/// - `integer, parameter :: dp = kind(0.0d0)
-///
 /// For code that should be compatible with C, you should instead use
 /// `real(c_double)`, which may be found in the intrinsic module `iso_c_binding`.
 ///

--- a/fortitude/src/rules/precision/double_precision.rs
+++ b/fortitude/src/rules/precision/double_precision.rs
@@ -9,20 +9,34 @@ use tree_sitter::Node;
 // TODO rule to prefer 1.23e4_sp over 1.23e4, and 1.23e4_dp over 1.23d4
 
 /// ## What it does
-/// Checks for use of 'double precision' and 'double complex' types.
+/// Checks for use of `double precision` and `double complex` types.
 ///
 /// ## Why is this bad?
-/// The 'double precision' type does not guarantee a 64-bit floating point number
-/// as one might expect. It is instead required to be twice the size of a default
-/// 'real', which may vary depending on your system and can be modified by compiler
-/// arguments. For portability, it is recommended to use `real(dp)`, with `dp` set
-/// in one of the following ways:
+/// The `double precision` type does not guarantee a 64-bit floating point number
+/// as one might expect, and instead is only required to have a higher decimal
+/// precision than the default `real`, which may vary depending on your system
+/// and can be modified by compiler arguments.
+///
+/// In modern Fortran, it is preferred to use `real` and `complex` and instead set
+/// the required precision using 'kinds'. For portability, it is recommended to use
+/// `real(dp)`, with `dp` set in one of the following ways:
 ///
 /// - `use, intrinsic :: iso_fortran_env, only: dp => real64`
 /// - `integer, parameter :: dp = selected_real_kind(15, 307)`
 ///
+/// To select a `real` with the same precision as `double precision`, the kind
+/// may be set from a floating point literal constant using `d` or `D` to denote
+/// the exponent:
+///
+/// - `integer, parameter :: dp = kind(0.0d0)
+///
 /// For code that should be compatible with C, you should instead use
 /// `real(c_double)`, which may be found in the intrinsic module `iso_c_binding`.
+///
+/// ## References
+/// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained: Incorporating Fortran
+///   2018_, Oxford University Press, Appendix A 'Deprecated Features'
+/// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
 #[violation]
 pub struct DoublePrecision {
     original: String, // TODO: could be &'static str

--- a/fortitude/src/rules/precision/implicit_kinds.rs
+++ b/fortitude/src/rules/precision/implicit_kinds.rs
@@ -7,12 +7,38 @@ use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
-/// Checks that `real` variables have their kind explicitly specified
+/// Checks for `real` variables that don't have their kind explicitly specified.
 ///
 /// ## Why is this bad?
 /// Real variable declarations without an explicit kind will have a compiler/platform
 /// dependent precision, which hurts portability and may lead to surprising loss of
-/// precision in some cases.
+/// precision in some cases. Although the default `real` will map to a 32-bit floating
+/// point number on most systems, this is not guaranteed.
+///
+/// It is recommended to always be explicit about the precision required by `real`
+/// variables. This can be done by setting their 'kinds' using integer parameters
+/// chosen in one of the following ways:
+///
+/// ```f90
+/// ! Set using iso_fortran_env
+/// use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
+/// ! Using selected_real_kind
+/// integer, parameter :: sp = selected_real_kind(6, 37)
+/// integer, parameter :: dp = selected_real_kind(15, 307)
+/// ! For C-compatibility:
+/// use, intrinsic :: iso_c_binding, only: sp => c_float, dp => c_double
+///
+/// ! Declaring real variables:
+/// real(sp) :: single
+/// real(dp) :: double
+/// ```
+///
+/// It is also common for Fortran developers to set a 'working precision' `wp`,
+/// which is set to either `sp` or `dp` and used throughout a project. This can
+/// then be easily toggled depending on the user's needs.
+///
+/// ## References
+/// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
 #[violation]
 pub struct ImplicitRealKind {
     dtype: String,

--- a/fortitude/src/rules/precision/kind_suffixes.rs
+++ b/fortitude/src/rules/precision/kind_suffixes.rs
@@ -7,11 +7,15 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
-/// Defines rule to ensure real precision is explicit, as this avoids accidental loss of precision.
+/// ## What it does
+/// Checks for floating point literal constants that don't have their kinds
+/// explicitly specified.
+///
+/// ## Why is this bad?
 /// Floating point literals use the default 'real' kind unless given an explicit
 /// kind suffix. This can cause surprising loss of precision:
 ///
-/// ```fortran
+/// ```f90
 /// use, intrinsic :: iso_fortran_env, only: dp => real64
 ///
 /// real(dp), parameter :: pi_1 = 3.14159265358979
@@ -24,7 +28,7 @@ use tree_sitter::Node;
 /// There are many cases where the difference in precision doesn't matter, such
 /// as the following operations:
 ///
-/// ```fortran
+/// ```f90
 /// real(dp) :: x, y
 ///
 /// x = 1.0
@@ -34,14 +38,17 @@ use tree_sitter::Node;
 /// However, even for 'nice' numbers, it's possible to accidentally lose
 /// precision in surprising ways:
 ///
-/// ```fortran
+/// ```f90
 /// x = y * sqrt(2.0)
 /// ```
 ///
-/// Ideally this rule should check how the number is used in a local expression
+/// Ideally, this rule should check how the number is used in a local expression
 /// and determine whether precision loss is a real risk, but in its current
 /// implementation it instead requires all real literals to have an explicit
 /// kind suffix.
+///
+/// ## References
+/// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
 #[violation]
 pub struct NoRealSuffix {
     literal: String,

--- a/fortitude/src/rules/style/end_statements.rs
+++ b/fortitude/src/rules/style/end_statements.rs
@@ -13,7 +13,7 @@ use tree_sitter::Node;
 /// End statements should specify what kind of construct they're ending, and the
 /// name of that construct. For example, prefer this:
 ///
-/// ```fortran
+/// ```f90
 /// module mymodule
 ///   ...
 /// end module mymodule
@@ -21,7 +21,7 @@ use tree_sitter::Node;
 ///
 /// To this:
 ///
-/// ```fortran
+/// ```f90
 /// module mymodule
 ///   ...
 /// end
@@ -29,7 +29,7 @@ use tree_sitter::Node;
 ///
 /// Or this:
 ///
-/// ```fortran
+/// ```f90
 /// module mymodule
 ///   ...
 /// end module

--- a/fortitude/src/rules/style/exit_labels.rs
+++ b/fortitude/src/rules/style/exit_labels.rs
@@ -11,7 +11,7 @@ use tree_sitter::Node;
 /// should use the loop name
 ///
 /// ## Example
-/// ```fortran
+/// ```f90
 /// name: do
 ///   exit name
 /// end do name

--- a/fortitude/src/rules/typing/assumed_size.rs
+++ b/fortitude/src/rules/typing/assumed_size.rs
@@ -24,7 +24,7 @@ use tree_sitter::Node;
 ///
 /// Instead of:
 ///
-/// ```fortran
+/// ```f90
 /// subroutine process_array(array)
 ///     integer, dimension(*), intent(in) :: array
 ///     ...
@@ -32,7 +32,7 @@ use tree_sitter::Node;
 ///
 /// use:
 ///
-/// ```fortran
+/// ```f90
 /// subroutine process_array(array)
 ///     integer, dimension(:), intent(in) :: array
 ///     ...
@@ -119,7 +119,7 @@ impl AstRule for AssumedSize {
 /// Character dummy arguments with an assumed size should only have `intent(in)`, as
 /// this can cause data loss with `intent([in]out)`. For example:
 ///
-/// ```fortran
+/// ```f90
 /// program example
 ///   character(len=3) :: short_text
 ///   call set_text(short_text)
@@ -136,7 +136,7 @@ impl AstRule for AssumedSize {
 ///
 /// To handle dynamically setting `character` sizes, use `allocatable` instead:
 ///
-/// ```fortran
+/// ```f90
 /// program example
 ///   character(len=3) :: short_text
 ///   call set_text(short_text)

--- a/fortitude/src/rules/typing/init_decls.rs
+++ b/fortitude/src/rules/typing/init_decls.rs
@@ -17,7 +17,7 @@ use tree_sitter::Node;
 /// ## Examples
 /// For example, this subroutine:
 ///
-/// ```fortran
+/// ```f90
 /// subroutine example()
 ///   integer :: var = 1
 ///   print*, var
@@ -27,7 +27,7 @@ use tree_sitter::Node;
 ///
 /// when called twice:
 ///
-/// ```fortran
+/// ```f90
 /// call example()
 /// call example()
 /// ```
@@ -36,7 +36,7 @@ use tree_sitter::Node;
 ///
 /// Adding the `save` attribute makes it clear that this is the intention:
 ///
-/// ```fortran
+/// ```f90
 /// subroutine example()
 ///   integer, save :: var = 1
 ///   print*, var
@@ -47,7 +47,7 @@ use tree_sitter::Node;
 /// Unfortunately, in Fortran there is no way to disable this behaviour, and so if it
 /// is not intended, it's necessary to have a separate assignment statement:
 ///
-/// ```fortran
+/// ```f90
 /// subroutine example()
 ///   integer :: var
 ///   var = 1
@@ -59,7 +59,7 @@ use tree_sitter::Node;
 /// If the variable's value is intended to be constant, then use the `parameter`
 /// attribute instead:
 ///
-/// ```fortran
+/// ```f90
 /// subroutine example()
 ///   integer, parameter :: var = 1
 ///   print*, var

--- a/fortitude/src/rules/typing/literal_kinds.rs
+++ b/fortitude/src/rules/typing/literal_kinds.rs
@@ -28,7 +28,7 @@ use tree_sitter::Node;
 /// precision), `real(dp)` (double precision), and `real(qp)` (quadruple precision),
 /// using:
 ///
-/// ```fortran
+/// ```f90
 /// use, intrinsic :: iso_fortran_env, only: sp => real32, &
 ///                                          dp => real64, &
 ///                                          qp => real128
@@ -36,7 +36,7 @@ use tree_sitter::Node;
 ///
 /// Or alternatively:
 ///
-/// ```fortran
+/// ```f90
 /// integer, parameter :: sp = selected_real_kind(6, 37)
 /// integer, parameter :: dp = selected_real_kind(15, 307)
 /// integer, parameter :: qp = selected_real_kind(33, 4931)
@@ -47,7 +47,7 @@ use tree_sitter::Node;
 ///
 /// Integer sizes may be set similarly:
 ///
-/// ```fortran
+/// ```f90
 /// integer, parameter :: i1 = selected_int_kind(2)  ! 8 bits
 /// integer, parameter :: i2 = selected_int_kind(4)  ! 16 bits
 /// integer, parameter :: i4 = selected_int_kind(9)  ! 32 bits
@@ -56,7 +56,7 @@ use tree_sitter::Node;
 ///
 /// Or:
 ///
-/// ```fortran
+/// ```f90
 /// use, intrinsic :: iso_fortran_env, only: i1 => int8, &
 ///                                          i2 => int16, &
 ///                                          i4 => int32, &
@@ -137,20 +137,20 @@ fn integer_literal_kind<'a>(node: &'a Node, src: &str) -> Option<Node<'a>> {
 /// precision of the type, as kind numbers are not specified in the Fortran
 /// standards. It is recommended to use parameter types from `iso_fortran_env`:
 ///
-/// ```fortran
+/// ```f90
 /// use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
 /// ```
 ///
 /// or alternatively:
 ///
-/// ```fortran
+/// ```f90
 /// integer, parameter :: sp => selected_real_kind(6, 37)
 /// integer, parameter :: dp => selected_real_kind(15, 307)
 /// ```
 ///
 /// Floating point constants can then be specified as follows:
 ///
-/// ```fortran
+/// ```f90
 /// real(sp), parameter :: sqrt2 = 1.41421_sp
 /// real(dp), parameter :: pi = 3.14159265358979_dp
 /// ```


### PR DESCRIPTION
Following feedback on [Fortran Discourse](https://fortran-lang.discourse.group/t/fortitude-a-fortran-linter/8834), updates the explanations given for 'precision' rules.

I based these rules on advice given on Fortran-Lang's [best practices pages](https://fortran-lang.org/en/learn/best_practices/floating_point/), so I'm strongly in favour of keeping them around, but it's clearly a controversial topic, so we may have to exclude these rules from the default set in a future version.

Also updated markdown code snippets to use `f90` over `fortran`, as `fortran` can cause incorrect syntax highlighting:

```fortran
! fortran
real, allocatable, intent(in) :: hello_world
```

```f90
! f90
real, allocatable, intent(in) :: hello_world
```