### PR TITLE
Add fancy progress bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "rayon",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "cc"
 version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +200,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "unicode-width 0.1.14",
  "windows-sys 0.52.0",
 ]
 
@@ -306,6 +313,7 @@ dependencies = [
  "clap",
  "colored",
  "fortitude_macros",
+ "indicatif",
  "insta",
  "insta-cmd",
  "is-macro",
@@ -389,6 +397,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "rayon",
+ "unicode-width 0.2.0",
+ "web-time",
+]
+
+[[package]]
 name = "insta"
 version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +476,15 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy-regex"
@@ -541,6 +572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +606,12 @@ name = "pathdiff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "predicates"
@@ -1102,6 +1145,71 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/fortitude/Cargo.toml
+++ b/fortitude/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.4.16", features = ["derive", "string", "env"] }
 colored = { workspace = true }
 fortitude_macros = { version = "0.1.0", path = "../fortitude_macros" }
 is-macro = "0.3.7"
-indicatif = { version = "0.17.9", features = ["rayon"] }
+indicatif = { version = "0.17.9", features = ["rayon", "improved_unicode"] }
 itertools = { workspace = true }
 lazy-regex = "3.3.0"
 lazy_static = "1.5.0"

--- a/fortitude/Cargo.toml
+++ b/fortitude/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.4.16", features = ["derive", "string", "env"] }
 colored = { workspace = true }
 fortitude_macros = { version = "0.1.0", path = "../fortitude_macros" }
 is-macro = "0.3.7"
+indicatif = { version = "0.17.9", features = ["rayon"] }
 itertools = { workspace = true }
 lazy-regex = "3.3.0"
 lazy_static = "1.5.0"

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -387,7 +387,7 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
         // Colours use some 8-bit representation
         let file_digits = files.len().to_string().len();
         let style_template = format!(
-            "{{prefix}} {{pos:>{file_digits}}}/{{len}} {{bar:60.51/4}} [{{elapsed_precise}}] ETA: [{{eta_precise}}]"
+            "{{prefix}} {{pos:>{file_digits}}}/{{len}} {{bar:60.51/4}} [{{elapsed_precise}}]"
         );
         ProgressStyle::with_template(style_template.as_str())
             .unwrap()

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -378,11 +378,9 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
     let ast_entrypoints = ast_entrypoint_map(&rules);
 
     let progress_bar_style = if colored::control::SHOULD_COLORIZE.should_colorize() {
-        ProgressStyle::with_template(
-            "[{elapsed_precise}] {bar:60.cyan/blue} {pos:>7}/{len:7} {msg}",
-        )
-        .unwrap()
-        .progress_chars("━━━")
+        ProgressStyle::with_template("[{elapsed_precise}] {bar:60.cyan/blue} {pos:>7}/{len:7}")
+            .unwrap()
+            .progress_chars("━━━")
         // Liam: An alternative I quite like: .progress_chars("▰▰▰")
     } else {
         ProgressStyle::with_template("").unwrap()

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -387,7 +387,7 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
         // Colours use some 8-bit representation
         let file_digits = files.len().to_string().len();
         let style_template = format!(
-            "{{prefix}} {{pos:>{file_digits}}}/{{len}} {{bar:60.51/4}} [{{elapsed_precise}}]"
+            "{{prefix}} {{pos:>{file_digits}}}/{{len}} {{bar:60.51/4}} [{{elapsed_precise}}] ETA: [{{eta_precise}}]"
         );
         ProgressStyle::with_template(style_template.as_str())
             .unwrap()

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -378,11 +378,18 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
     let ast_entrypoints = ast_entrypoint_map(&rules);
 
     let progress_bar_style = if colored::control::SHOULD_COLORIZE.should_colorize() {
-        ProgressStyle::with_template("[{elapsed_precise}] {bar:60.cyan/blue} {pos:>7}/{len:7}")
+        // Make progress bar with:
+        // - 60 char width (60)
+        // - Bright cyan colour for the filled part (51)
+        // - Dark blue colour for the unfilled part (4)
+        // Colours use some 8-bit representation
+        ProgressStyle::with_template("[{elapsed_precise}] {bar:60.51/4} {pos:>7}/{len:7}")
             .unwrap()
             .progress_chars("━━━")
         // Liam: An alternative I quite like: .progress_chars("▰▰▰")
     } else {
+        // Don't make a bar when writing to file
+        // TODO Make a simpler bar when writing to non-colour terminals?
         ProgressStyle::with_template("").unwrap()
     };
 

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -2,7 +2,9 @@ use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use crate::{rule_selector::RuleSelector, settings::OutputFormat, RuleSelectorParser};
+use crate::{
+    rule_selector::RuleSelector, settings::OutputFormat, settings::ProgressBar, RuleSelectorParser,
+};
 
 /// Default extensions to check
 pub const FORTRAN_EXTS: &[&str] = &[
@@ -98,7 +100,8 @@ pub struct CheckArgs {
     #[arg(long, value_enum, env = "FORTITUDE_OUTPUT_FORMAT")]
     pub output_format: Option<OutputFormat>,
 
-    /// Switch off the progress bar.
-    #[arg(long, action = clap::ArgAction::SetTrue)]
-    pub no_progress_bar: Option<bool>,
+    /// Progress bar settings.
+    /// Options are "off" (default), "ascii", and "fancy"
+    #[arg(long, value_enum)]
+    pub progress_bar: Option<ProgressBar>,
 }

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -97,4 +97,8 @@ pub struct CheckArgs {
     /// The default serialization format is "full".
     #[arg(long, value_enum, env = "FORTITUDE_OUTPUT_FORMAT")]
     pub output_format: Option<OutputFormat>,
+
+    /// Switch off the progress bar.
+    #[arg(long, action = clap::ArgAction::SetTrue)]
+    pub no_progress_bar: Option<bool>,
 }

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -91,6 +91,32 @@ impl UnsafeFixes {
     }
 }
 
+/// Toggle for progress bar
+#[derive(
+    Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, Hash, Default, clap::ValueEnum,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProgressBar {
+    #[default]
+    Off,
+    Fancy,
+    Ascii,
+}
+
+impl Display for ProgressBar {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Off => "off",
+                Self::Fancy => "fancy",
+                Self::Ascii => "ascii",
+            }
+        )
+    }
+}
+
 #[derive(
     Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, Hash, Default, clap::ValueEnum,
 )]

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -70,7 +70,7 @@ unknown-key = 1
       |
     2 | unknown-key = 1
       | ^^^^^^^^^^^
-    unknown field `unknown-key`, expected one of `files`, `ignore`, `select`, `extend-select`, `line-length`, `file-extensions`, `output-format`
+    unknown field `unknown-key`, expected one of `files`, `ignore`, `select`, `extend-select`, `line-length`, `file-extensions`, `output-format`, `no-progress-bar`
     ");
     Ok(())
 }

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -70,7 +70,7 @@ unknown-key = 1
       |
     2 | unknown-key = 1
       | ^^^^^^^^^^^
-    unknown field `unknown-key`, expected one of `files`, `ignore`, `select`, `extend-select`, `line-length`, `file-extensions`, `output-format`, `no-progress-bar`
+    unknown field `unknown-key`, expected one of `files`, `ignore`, `select`, `extend-select`, `line-length`, `file-extensions`, `output-format`, `progress-bar`
     ");
     Ok(())
 }


### PR DESCRIPTION
Since https://github.com/PlasmaFAIR/fortitude/pull/127, diagnostics are not printed as they are created, but instead are printed all at once after checking all files. On large projects, this can give the impression that the program is hanging, and gives no indication of when the program might be done.

This adds a fancy progress bar so the user can keep track of how things are going. Uses [indicatif](https://docs.rs/indicatif/latest/indicatif/), and the bar seems to nicely delete itself after completion.