### PR TITLE
Add rule for obsolescent `entry` statement

### DIFF
--- a/fortitude/resources/test/fixtures/obsolescent/OB021.f90
+++ b/fortitude/resources/test/fixtures/obsolescent/OB021.f90
@@ -1,0 +1,12 @@
+       SUBROUTINE SUB(A, B, C)
+       INTEGER A, B
+       CHARACTER C*4
+
+       RETURN
+
+       ENTRY SUB2(A, B, C)
+       RETURN
+
+       ENTRY SUB3
+       RETURN
+       END

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -96,6 +96,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
 
         (Obsolescent, "001") => (RuleGroup::Preview, Ast, obsolescent::statement_functions::StatementFunction),
         (Obsolescent, "011") => (RuleGroup::Preview, Ast, obsolescent::common_blocks::CommonBlock),
+        (Obsolescent, "021") => (RuleGroup::Preview, Ast, obsolescent::entry_statement::EntryStatement),
 
         (Precision, "001") => (RuleGroup::Stable, Ast, precision::kind_suffixes::NoRealSuffix),
         (Precision, "011") => (RuleGroup::Stable, Ast, precision::double_precision::DoublePrecision),

--- a/fortitude/src/rules/obsolescent/entry_statement.rs
+++ b/fortitude/src/rules/obsolescent/entry_statement.rs
@@ -1,0 +1,42 @@
+use crate::settings::Settings;
+use crate::{AstRule, FromAstNode};
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_source_file::SourceFile;
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks for `entry` statements.
+///
+/// ## Why is this bad?
+/// `entry` statements are an obsolescent feature allowing more than entry point
+/// into a procedure, enabling reuse of variables and executable
+/// statements. However, they make the code much harder to follow and are prone
+/// to bugs.
+///
+/// Multiple entry procedures can be replaced with modules to share data, and
+/// private module procedures to reuse code.
+///
+/// ## References
+/// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
+///   Incorporating Fortran 2018, Oxford University Press, Appendix B
+///   'Obsolescent and Deleted Features'
+#[violation]
+pub struct EntryStatement {}
+
+impl Violation for EntryStatement {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("entry statements are obsolescent, use module procedures with generic interface")
+    }
+}
+
+impl AstRule for EntryStatement {
+    fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        some_vec![Diagnostic::from_node(EntryStatement {}, node)]
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["entry_statement"]
+    }
+}

--- a/fortitude/src/rules/obsolescent/mod.rs
+++ b/fortitude/src/rules/obsolescent/mod.rs
@@ -1,4 +1,5 @@
 pub mod common_blocks;
+pub mod entry_statement;
 pub mod statement_functions;
 
 #[cfg(test)]
@@ -16,6 +17,7 @@ mod tests {
 
     #[test_case(Rule::StatementFunction, Path::new("OB001.f90"))]
     #[test_case(Rule::CommonBlock, Path::new("OB011.f90"))]
+    #[test_case(Rule::EntryStatement, Path::new("OB021.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/obsolescent/snapshots/fortitude__rules__obsolescent__tests__entry-statement_OB021.f90.snap
+++ b/fortitude/src/rules/obsolescent/snapshots/fortitude__rules__obsolescent__tests__entry-statement_OB021.f90.snap
@@ -1,0 +1,23 @@
+---
+source: fortitude/src/rules/obsolescent/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/obsolescent/OB021.f90:7:8: OB021 entry statements are obsolescent, use module procedures with generic interface
+  |
+5 |        RETURN
+6 |
+7 |        ENTRY SUB2(A, B, C)
+  |        ^^^^^^^^^^^^^^^^^^^ OB021
+8 |        RETURN
+  |
+
+./resources/test/fixtures/obsolescent/OB021.f90:10:8: OB021 entry statements are obsolescent, use module procedures with generic interface
+   |
+ 8 |        RETURN
+ 9 |
+10 |        ENTRY SUB3
+   |        ^^^^^^^^^^ OB021
+11 |        RETURN
+12 |        END
+   |


### PR DESCRIPTION
Includes #167 as it requires the updated grammar