### PR TITLE
Add rule for missing double-colon in variable decls

### DIFF
--- a/fortitude/resources/test/fixtures/style/S071.f90
+++ b/fortitude/resources/test/fixtures/style/S071.f90
@@ -1,0 +1,6 @@
+program test
+  implicit none
+  real these, are
+  type(real(kind=kind(1.0d0))) all, bad
+  integer :: but, these_ones, are_fine
+end program test

--- a/fortitude/resources/test/fixtures/style/S071.f90
+++ b/fortitude/resources/test/fixtures/style/S071.f90
@@ -1,6 +1,6 @@
 program test
   implicit none
   real these, are
-  type(real(kind=kind(1.0d0))) all, bad
+  type(real(kind=kind(1.0d0))) all(42), bad
   integer :: but, these_ones, are_fine
 end program test

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -80,6 +80,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Style, "041") => (RuleGroup::Stable, Ast, style::old_style_array_literal::OldStyleArrayLiteral),
         (Style, "051") => (RuleGroup::Stable, Ast, style::relational_operators::DeprecatedRelationalOperator),
         (Style, "061") => (RuleGroup::Stable, Ast, style::end_statements::UnnamedEndStatement),
+        (Style, "071") => (RuleGroup::Preview, Ast, style::double_colon_in_decl::MissingDoubleColon),
         (Style, "101") => (RuleGroup::Stable, Text, style::whitespace::TrailingWhitespace),
 
         (Typing, "001") => (RuleGroup::Stable, Ast, typing::implicit_typing::ImplicitTyping),

--- a/fortitude/src/rules/style/double_colon_in_decl.rs
+++ b/fortitude/src/rules/style/double_colon_in_decl.rs
@@ -1,0 +1,40 @@
+use crate::ast::FortitudeNode;
+use crate::settings::Settings;
+use crate::{AstRule, FromAstNode};
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_source_file::SourceFile;
+use tree_sitter::Node;
+
+/// ## What does it do?
+/// Checks for missing double-colon separator in variable declarations.
+///
+/// ## Why is this bad?
+/// The double-colon separator is required when declaring variables with
+/// attributes, so for consistency, all variable declarations should use it.
+#[violation]
+pub struct MissingDoubleColon {}
+
+impl Violation for MissingDoubleColon {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("variable declaration missing '::'")
+    }
+}
+impl AstRule for MissingDoubleColon {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        if node
+            .children(&mut node.walk())
+            .filter_map(|child| child.to_text(src.source_text()))
+            .all(|child| child != "::")
+        {
+            some_vec!(Diagnostic::from_node(Self {}, node))
+        } else {
+            None
+        }
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["variable_declaration"]
+    }
+}

--- a/fortitude/src/rules/style/mod.rs
+++ b/fortitude/src/rules/style/mod.rs
@@ -1,3 +1,4 @@
+pub mod double_colon_in_decl;
 pub mod end_statements;
 pub mod exit_labels;
 pub mod line_length;
@@ -23,6 +24,7 @@ mod tests {
     #[test_case(Rule::OldStyleArrayLiteral, Path::new("S041.f90"))]
     #[test_case(Rule::DeprecatedRelationalOperator, Path::new("S051.f90"))]
     #[test_case(Rule::UnnamedEndStatement, Path::new("S061.f90"))]
+    #[test_case(Rule::MissingDoubleColon, Path::new("S071.f90"))]
     #[test_case(Rule::TrailingWhitespace, Path::new("S101.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());

--- a/fortitude/src/rules/style/snapshots/fortitude__rules__style__tests__missing-double-colon_S071.f90.snap
+++ b/fortitude/src/rules/style/snapshots/fortitude__rules__style__tests__missing-double-colon_S071.f90.snap
@@ -3,22 +3,24 @@ source: fortitude/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
-./resources/test/fixtures/style/S071.f90:3:3: S071 variable declaration missing '::'
+./resources/test/fixtures/style/S071.f90:3:3: S071 [*] variable declaration missing '::'
   |
 1 | program test
 2 |   implicit none
 3 |   real these, are
   |   ^^^^^^^^^^^^^^^ S071
-4 |   type(real(kind=kind(1.0d0))) all, bad
+4 |   type(real(kind=kind(1.0d0))) all(42), bad
 5 |   integer :: but, these_ones, are_fine
   |
+  = help: Add '::'
 
-./resources/test/fixtures/style/S071.f90:4:3: S071 variable declaration missing '::'
+./resources/test/fixtures/style/S071.f90:4:3: S071 [*] variable declaration missing '::'
   |
 2 |   implicit none
 3 |   real these, are
-4 |   type(real(kind=kind(1.0d0))) all, bad
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S071
+4 |   type(real(kind=kind(1.0d0))) all(42), bad
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S071
 5 |   integer :: but, these_ones, are_fine
 6 | end program test
   |
+  = help: Add '::'

--- a/fortitude/src/rules/style/snapshots/fortitude__rules__style__tests__missing-double-colon_S071.f90.snap
+++ b/fortitude/src/rules/style/snapshots/fortitude__rules__style__tests__missing-double-colon_S071.f90.snap
@@ -1,0 +1,24 @@
+---
+source: fortitude/src/rules/style/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/style/S071.f90:3:3: S071 variable declaration missing '::'
+  |
+1 | program test
+2 |   implicit none
+3 |   real these, are
+  |   ^^^^^^^^^^^^^^^ S071
+4 |   type(real(kind=kind(1.0d0))) all, bad
+5 |   integer :: but, these_ones, are_fine
+  |
+
+./resources/test/fixtures/style/S071.f90:4:3: S071 variable declaration missing '::'
+  |
+2 |   implicit none
+3 |   real these, are
+4 |   type(real(kind=kind(1.0d0))) all, bad
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S071
+5 |   integer :: but, these_ones, are_fine
+6 | end program test
+  |


### PR DESCRIPTION
Bad:

``` f90
real foo, bar
```

Good:

``` f90
real :: foo, bar
```

I _think_ this is a safe, always available fix.