### PR TITLE
Bugfix: report number of files scanned

### DIFF
--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -483,7 +483,7 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
 
     let flags = PrinterFlags::SHOW_VIOLATIONS | PrinterFlags::SHOW_FIX_SUMMARY;
 
-    Printer::new(output_format, flags).write_once(&diagnostics, &mut writer)?;
+    Printer::new(output_format, flags).write_once(files.len(), &diagnostics, &mut writer)?;
 
     if total_errors == 0 {
         Ok(ExitCode::SUCCESS)

--- a/fortitude/src/message/mod.rs
+++ b/fortitude/src/message/mod.rs
@@ -49,7 +49,6 @@ impl DiagnosticMessage {
     }
 
     /// Returns the name used to represent the diagnostic.
-    #[allow(dead_code)]
     pub fn name(&self) -> &str {
         &self.kind.name
     }

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -31,7 +31,7 @@ fn check_file_doesnt_exist() -> anyhow::Result<()> {
     ----- stdout -----
     test/file/doesnt/exist.f90:1:1: E000 Error opening file: No such file or directory (os error 2)
 
-    fortitude: 1 files scanned.
+    fortitude: 0 files scanned, 1 could not be read.
     Number of errors: 1
 
     For more information about specific rules, run:


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/155

Correctly prints the number of files scanned, and I've added some extra output to report the number of files that _weren't_ scanned (although only if IO errors occurred). This might be a little superfluous, so I'd be happy to revert this to only print the number successfully processed.