### PR TITLE
Add fix for `trailing-whitespace`

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,7 +8,7 @@ echo "Running Fortitude pre-commit hook..."
 caveat="If you really know what you're doing, commit again with --no-verify"
 
 echo "Testing Rust..."
-cargo test
+cargo test --all-targets --all-features
 if [ $? != "0" ]; then
   echo "Rust tests are failing, fix all reported by 'cargo test' and try again"
   echo $caveat

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-targets --all-features --verbose
 
   cargo-install:
     name: Test cargo installation

--- a/fortitude/src/rules/style/snapshots/fortitude__rules__style__tests__trailing-whitespace_S101.f90.snap
+++ b/fortitude/src/rules/style/snapshots/fortitude__rules__style__tests__trailing-whitespace_S101.f90.snap
@@ -3,15 +3,23 @@ source: fortitude/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
-./resources/test/fixtures/style/S101.f90:1:13: S101 trailing whitespace
+./resources/test/fixtures/style/S101.f90:1:13: S101 [*] trailing whitespace
   |
 1 | program test  
   |             ^^ S101
 2 |   implicit none
 3 |   integer :: a(3) = [ & 
   |
+  = help: Remove trailing whitespace
 
-./resources/test/fixtures/style/S101.f90:3:24: S101 trailing whitespace
+ℹ Safe fix
+1   |-program test  
+  1 |+program test
+2 2 |   implicit none
+3 3 |   integer :: a(3) = [ & 
+4 4 |     1, &
+
+./resources/test/fixtures/style/S101.f90:3:24: S101 [*] trailing whitespace
   |
 1 | program test  
 2 |   implicit none
@@ -20,8 +28,18 @@ snapshot_kind: text
 4 |     1, &
 5 |     2, &
   |
+  = help: Remove trailing whitespace
 
-./resources/test/fixtures/style/S101.f90:7:4: S101 trailing whitespace
+ℹ Safe fix
+1 1 | program test  
+2 2 |   implicit none
+3   |-  integer :: a(3) = [ & 
+  3 |+  integer :: a(3) = [ &
+4 4 |     1, &
+5 5 |     2, &
+6 6 |     3 &
+
+./resources/test/fixtures/style/S101.f90:7:4: S101 [*] trailing whitespace
   |
 5 |     2, &
 6 |     3 &
@@ -30,8 +48,18 @@ snapshot_kind: text
 8 |    
 9 | end program test
   |
+  = help: Remove trailing whitespace
 
-./resources/test/fixtures/style/S101.f90:8:1: S101 trailing whitespace
+ℹ Safe fix
+4 4 |     1, &
+5 5 |     2, &
+6 6 |     3 &
+7   |-  ]    
+  7 |+  ]
+8 8 |    
+9 9 | end program test
+
+./resources/test/fixtures/style/S101.f90:8:1: S101 [*] trailing whitespace
   |
 6 |     3 &
 7 |   ]    
@@ -39,3 +67,12 @@ snapshot_kind: text
   | ^^^ S101
 9 | end program test
   |
+  = help: Remove trailing whitespace
+
+ℹ Safe fix
+5 5 |     2, &
+6 6 |     3 &
+7 7 |   ]    
+8   |-   
+  8 |+
+9 9 | end program test

--- a/fortitude/src/rules/style/whitespace.rs
+++ b/fortitude/src/rules/style/whitespace.rs
@@ -5,7 +5,7 @@ use ruff_source_file::{OneIndexed, SourceFile};
 use ruff_text_size::{TextLen, TextRange, TextSize};
 
 use crate::settings::Settings;
-use crate::{FromStartEndLineCol, TextRule};
+use crate::TextRule;
 
 /// ## What does it do?
 /// Checks for tailing whitespace
@@ -40,21 +40,9 @@ impl TextRule for TrailingWhitespace {
                 .sum();
             if whitespace_bytes > 0.into() {
                 let line_end_byte = source.line_end_exclusive(OneIndexed::from_zero_indexed(idx));
-                let edit = Edit::range_deletion(TextRange::new(
-                    line_end_byte - whitespace_bytes,
-                    line_end_byte,
-                ));
-                violations.push(
-                    Diagnostic::from_start_end_line_col(
-                        Self {},
-                        source_file,
-                        idx,
-                        line.trim_end().len(),
-                        idx,
-                        line.len(),
-                    )
-                    .with_fix(Fix::safe_edit(edit)),
-                );
+                let range = TextRange::new(line_end_byte - whitespace_bytes, line_end_byte);
+                let edit = Edit::range_deletion(range);
+                violations.push(Diagnostic::new(Self {}, range).with_fix(Fix::safe_edit(edit)));
             }
         }
         violations

--- a/fortitude/src/rules/style/whitespace.rs
+++ b/fortitude/src/rules/style/whitespace.rs
@@ -1,7 +1,8 @@
 /// Defines rules that enforce widely accepted whitespace rules.
-use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_source_file::SourceFile;
+use ruff_source_file::{OneIndexed, SourceFile};
+use ruff_text_size::{TextLen, TextRange, TextSize};
 
 use crate::settings::Settings;
 use crate::{FromStartEndLineCol, TextRule};
@@ -16,25 +17,44 @@ use crate::{FromStartEndLineCol, TextRule};
 #[violation]
 pub struct TrailingWhitespace {}
 
-impl Violation for TrailingWhitespace {
+impl AlwaysFixableViolation for TrailingWhitespace {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("trailing whitespace")
     }
+
+    fn fix_title(&self) -> String {
+        format!("Remove trailing whitespace")
+    }
 }
 impl TextRule for TrailingWhitespace {
-    fn check(_settings: &Settings, source: &SourceFile) -> Vec<Diagnostic> {
+    fn check(_settings: &Settings, source_file: &SourceFile) -> Vec<Diagnostic> {
+        let source = source_file.to_source_code();
         let mut violations = Vec::new();
-        for (idx, line) in source.source_text().split('\n').enumerate() {
-            if line.ends_with([' ', '\t']) {
-                violations.push(Diagnostic::from_start_end_line_col(
-                    Self {},
-                    source,
-                    idx,
-                    line.trim_end().len(),
-                    idx,
-                    line.len(),
+        for (idx, line) in source.text().lines().enumerate() {
+            let whitespace_bytes: TextSize = line
+                .chars()
+                .rev()
+                .take_while(|c| c.is_whitespace())
+                .map(TextLen::text_len)
+                .sum();
+            if whitespace_bytes > 0.into() {
+                let line_end_byte = source.line_end_exclusive(OneIndexed::from_zero_indexed(idx));
+                let edit = Edit::range_deletion(TextRange::new(
+                    line_end_byte - whitespace_bytes,
+                    line_end_byte,
                 ));
+                violations.push(
+                    Diagnostic::from_start_end_line_col(
+                        Self {},
+                        source_file,
+                        idx,
+                        line.trim_end().len(),
+                        idx,
+                        line.len(),
+                    )
+                    .with_fix(Fix::safe_edit(edit)),
+                );
             }
         }
         violations

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -136,6 +136,7 @@ end program
 
         fortitude explain X001,Y002,...
 
+    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
     ");

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -136,7 +136,7 @@ end program
 
         fortitude explain X001,Y002,...
 
-    [*] 1 fixable with the `--fix` option.
+    [*] 2 fixable with the `--fix` option.
 
     ----- stderr -----
     ");
@@ -189,6 +189,7 @@ end program
 
         fortitude explain X001,Y002,...
 
+    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
     ");
@@ -250,6 +251,7 @@ select = ["T001", "style"]
 
         fortitude explain X001,Y002,...
 
+    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
     ");
@@ -313,6 +315,7 @@ select = ["T001"]
 
         fortitude explain X001,Y002,...
 
+    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
     ");
@@ -374,6 +377,7 @@ select = ["T001", "style"]
 
         fortitude explain X001,Y002,...
 
+    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
     ");


### PR DESCRIPTION
I spent far too long figuring this out from scratch before it occurred to me that Ruff implements the exact same rule and I could just steal most of it. To my credit, I came up with basically the same solution, and barely had to change anything after realising. For example, I had this to get the number of bytes to remove:

```rust
let whitespace_bytes = line
    .chars()
    .rev()
    .take_while(|c| c.is_whitespace())
    .map(|c| c.len_utf8())
    .sum();
```

It's eerily similar to the solution in Ruff, which just switches out `usize` for `TextSize`.

The Ruff version isn't always a safe fix, as trailing whitespace in multiline strings needs to be preserved. Am I correct in thinking this will never be a problem in Fortran, as a line continuation character is always needed?