### PR TITLE
Bugfix: `DiagnosticMessages` were created on pre-transformed file

### DIFF
--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -493,7 +493,7 @@ pub(crate) fn check_and_fix_file<'a>(
         return Ok(FixerResult {
             result: violations
                 .into_iter()
-                .map(|v| DiagnosticMessage::from_ruff(file, v))
+                .map(|v| DiagnosticMessage::from_ruff(&transformed, v))
                 .collect_vec(),
             transformed,
             fixed,

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -416,7 +416,7 @@ end program foo
       |
     2 | program foo
     3 |   implicit none
-    4 |   real i
+    4 |   real :: i
       |   ^^^^ P021
     5 |   i = 4.0
     6 | contains


### PR DESCRIPTION
When applying fixes, any remaining violations were converted to
messages using the _pre-transformed_ file, and so it was possible for
locations to be wrong