### PR TITLE
maint: Move `profile.dev.package` block to top-level `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ itertools = "0.12.0"
 serde_json = { version = "1.0.113" }
 strum = { version = "0.26.0", features = ["strum_macros"] }
 strum_macros = { version = "0.26.0" }
+
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3

--- a/fortitude/Cargo.toml
+++ b/fortitude/Cargo.toml
@@ -70,10 +70,6 @@ pretty_assertions = "1.4.1"
 tempfile = "3.13.0"
 test-case = "3.3.1"
 
-[profile.dev.package]
-insta.opt-level = 3
-similar.opt-level = 3
-
 [features]
 # Enables rules for internal integration tests
 test-rules = []


### PR DESCRIPTION
It seems this config was being ignored, and needs to be at the
workspace level