### PR TITLE
Fix link to rules table in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ fortitude check --extend-select=M
 
 ## Documentation
 
-See [table of rules](https://fortitude.readthedocs.io/en/rules/) for a list of all rules.
+See [table of rules](https://fortitude.readthedocs.io/en/stable/rules/) for a list of all rules.
 
 ## Contributing
 


### PR DESCRIPTION
The current link doesn't work because it needs to have the version specifier in the URL.