### PR TITLE
Add rule `missing-action-specifier` and `Io` rule category

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -57,6 +57,12 @@
 | P011 | [double-precision](rules/double-precision.md) | prefer '{preferred}' to '{original}' (see 'iso_fortran_env') | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 | P021 | [implicit-real-kind](rules/implicit-real-kind.md) | {dtype} has implicit kind | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 
+### Io (IO)
+
+| Code | Name | Message | |
+| ---- | ---- | ------- | ------: |
+| IO001 | [missing-action-specifier](rules/missing-action-specifier.md) | file opened without action specifier | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
+
 ### Filesystem (F)
 
 | Code | Name | Message | |

--- a/docs/rules/missing-action-specifier.md
+++ b/docs/rules/missing-action-specifier.md
@@ -1,0 +1,11 @@
+# missing-action-specifier (IO001)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for missing action specifier when opening files.
+
+## Why is this bad?
+By default, files are opened in `readwrite` mode, but this may not be the
+programmer's intent. Explicitly specifying `read`, `write` or `readwrite`
+makes it clear how the file is intended to be used, and prevents the
+accidental overwriting of input data.

--- a/fortitude/resources/test/fixtures/io/IO001.f90
+++ b/fortitude/resources/test/fixtures/io/IO001.f90
@@ -1,0 +1,13 @@
+program p
+  implicit none
+  integer :: file_unit
+  integer :: stat
+
+  open(123, file="test0", action="read")
+  open(unit=234, file="test1")
+  open(unit=345, file="test2", iostat=stat)
+  open(unit=456, file="test3", access="append")
+  open(unit=567, file="test4", action="write", iostat=stat, access="append")
+  open(newunit=file_unit, file="test5", action="readwrite")
+
+end program p

--- a/fortitude/src/registry.rs
+++ b/fortitude/src/registry.rs
@@ -62,6 +62,9 @@ pub enum Category {
     /// Best practices for setting floating point precision.
     #[prefix = "P"]
     Precision,
+    /// Best practices when reading and writing to file or other IO streams.
+    #[prefix = "IO"]
+    Io,
     /// Check path names, directory structures, etc.
     #[prefix = "F"]
     Filesystem,

--- a/fortitude/src/rules/io/missing_specifier.rs
+++ b/fortitude/src/rules/io/missing_specifier.rs
@@ -1,0 +1,49 @@
+use crate::ast::FortitudeNode;
+use crate::settings::Settings;
+use crate::{AstRule, FromAstNode};
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_source_file::SourceFile;
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks for missing action specifier when opening files.
+///
+/// ## Why is this bad?
+/// By default, files are opened in `readwrite` mode, but this may not be the
+/// programmer's intent. Explicitly specifying `read`, `write` or `readwrite`
+/// makes it clear how the file is intended to be used, and prevents the
+/// accidental overwriting of input data.
+#[violation]
+pub struct MissingActionSpecifier {}
+
+impl Violation for MissingActionSpecifier {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("file opened without action specifier")
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Add 'action=read', 'action=write', or 'action=readwrite'".to_string())
+    }
+}
+
+impl AstRule for MissingActionSpecifier {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        let txt = src.source_text();
+        for arg in node.named_children(&mut node.walk()) {
+            if arg.kind() == "keyword_argument" {
+                if let Some(key) = arg.child_by_field_name("name") {
+                    if let Some("action") = key.to_text(txt) {
+                        return None;
+                    }
+                }
+            }
+        }
+        some_vec![Diagnostic::from_node(Self {}, node)]
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["open_statement"]
+    }
+}

--- a/fortitude/src/rules/io/mod.rs
+++ b/fortitude/src/rules/io/mod.rs
@@ -1,0 +1,27 @@
+pub mod missing_specifier;
+
+#[cfg(test)]
+mod tests {
+    use std::convert::AsRef;
+    use std::path::Path;
+
+    use anyhow::Result;
+    use insta::assert_snapshot;
+    use test_case::test_case;
+
+    use crate::registry::Rule;
+    use crate::settings::Settings;
+    use crate::test::test_path;
+
+    #[test_case(Rule::MissingActionSpecifier, Path::new("IO001.f90"))]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("io").join(path).as_path(),
+            &[rule_code],
+            &Settings::default(),
+        )?;
+        assert_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+}

--- a/fortitude/src/rules/io/snapshots/fortitude__rules__io__tests__missing-action-specifier_IO001.f90.snap
+++ b/fortitude/src/rules/io/snapshots/fortitude__rules__io__tests__missing-action-specifier_IO001.f90.snap
@@ -1,0 +1,36 @@
+---
+source: fortitude/src/rules/io/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/io/IO001.f90:7:3: IO001 file opened without action specifier
+  |
+6 |   open(123, file="test0", action="read")
+7 |   open(unit=234, file="test1")
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IO001
+8 |   open(unit=345, file="test2", iostat=stat)
+9 |   open(unit=456, file="test3", access="append")
+  |
+  = help: Add 'action=read', 'action=write', or 'action=readwrite'
+
+./resources/test/fixtures/io/IO001.f90:8:3: IO001 file opened without action specifier
+   |
+ 6 |   open(123, file="test0", action="read")
+ 7 |   open(unit=234, file="test1")
+ 8 |   open(unit=345, file="test2", iostat=stat)
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IO001
+ 9 |   open(unit=456, file="test3", access="append")
+10 |   open(unit=567, file="test4", action="write", iostat=stat, access="append")
+   |
+   = help: Add 'action=read', 'action=write', or 'action=readwrite'
+
+./resources/test/fixtures/io/IO001.f90:9:3: IO001 file opened without action specifier
+   |
+ 7 |   open(unit=234, file="test1")
+ 8 |   open(unit=345, file="test2", iostat=stat)
+ 9 |   open(unit=456, file="test3", access="append")
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IO001
+10 |   open(unit=567, file="test4", action="write", iostat=stat, access="append")
+11 |   open(newunit=file_unit, file="test5", action="readwrite")
+   |
+   = help: Add 'action=read', 'action=write', or 'action=readwrite'

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::useless_format)]
 /// A collection of all rules, and utilities to select a subset at runtime.
-pub(crate) mod error;
-pub(crate) mod filesystem;
 #[macro_use]
 mod macros;
+pub(crate) mod error;
+pub(crate) mod filesystem;
+pub(crate) mod io;
 pub(crate) mod modules;
 pub(crate) mod obsolescent;
 pub(crate) mod precision;
@@ -110,6 +111,8 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Modules, "011") => (RuleGroup::Stable, Ast, modules::use_statements::UseAll),
         (Modules, "021") => (RuleGroup::Preview, Ast, modules::accessibility_statements::MissingAccessibilityStatement),
         (Modules, "022") => (RuleGroup::Preview, Ast, modules::accessibility_statements::DefaultPublicAccessibility),
+
+        (Io, "001") => (RuleGroup::Preview, Ast, io::missing_specifier::MissingActionSpecifier),
 
         // Rules for testing fortitude
         // Couldn't get a separate `Testing` category working for some reason

--- a/fortitude/src/rules/modules/mod.rs
+++ b/fortitude/src/rules/modules/mod.rs
@@ -2,10 +2,6 @@ pub mod accessibility_statements;
 pub mod external_functions;
 pub mod use_statements;
 
-// TODO should be private by default, with explicit public interface
-// TODO prefer 'end module {name}'
-// TODO function is not used within a module and is not public
-
 #[cfg(test)]
 mod tests {
     use std::convert::AsRef;


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/205

Other entries to this category would follow the advice in https://fortran-lang.org/en/learn/best_practices/file_io/, e.g. catch `action=read` without `status=old` (Edit: or maybe just catch missing `status` in general)