### PR TITLE
Add per-file-ignores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,8 @@ dependencies = [
  "clap",
  "colored",
  "fortitude_macros",
+ "glob",
+ "globset",
  "indicatif",
  "insta",
  "insta-cmd",

--- a/fortitude/Cargo.toml
+++ b/fortitude/Cargo.toml
@@ -56,6 +56,8 @@ tree-sitter-fortran = "0.3.0"
 unicode-width = "0.2.0"
 url = { version = "2.5.0" }
 walkdir = "2.4.0"
+globset = "0.4.15"
+glob = "0.3.1"
 
 [build-dependencies]
 shadow-rs = { version = "0.36.0", default-features = false }

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -660,18 +660,19 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
         extend_select: args.extend_select.unwrap_or(file_settings.extend_select),
     };
 
-    let mut per_file_ignores = args
-        .per_file_ignores
-        .or(file_settings.per_file_ignores)
-        .unwrap_or_default();
-    per_file_ignores.extend(
-        args.extend_per_file_ignores
+    let per_file_ignores = CompiledPerFileIgnoreList::resolve(collect_per_file_ignores(
+        args.per_file_ignores
+            .or(file_settings.per_file_ignores)
             .unwrap_or_default()
             .into_iter()
-            .chain(file_settings.extend_per_file_ignores),
-    );
-    let per_file_ignores =
-        CompiledPerFileIgnoreList::resolve(collect_per_file_ignores(per_file_ignores))?;
+            .chain(
+                args.extend_per_file_ignores
+                    .unwrap_or_default()
+                    .into_iter()
+                    .chain(file_settings.extend_per_file_ignores),
+            )
+            .collect::<Vec<_>>(),
+    ))?;
 
     let output_format = args.output_format.unwrap_or(file_settings.output_format);
     let preview_mode = resolve_bool_arg(args.preview, args.no_preview)

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -350,8 +350,13 @@ pub(crate) fn check_file(
         vec![]
     };
     if !per_file_ignores.is_empty() {
-        // (liam): unwrap used as I don't think a DiagnosticMessage's rule can ever be None
-        messages.retain(|message| !per_file_ignores.contains(&message.rule().unwrap()));
+        messages.retain(|message| {
+            if let Some(rule) = message.rule() {
+                !per_file_ignores.contains(&rule)
+            } else {
+                true
+            }
+        });
     }
 
     Ok(Diagnostics {

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -269,7 +269,7 @@ fn get_files<P: AsRef<Path>, S: AsRef<str>>(
                     .map(|x| std::path::absolute(x.path()))
                     .collect::<Vec<_>>()
             } else {
-                std::iter::once(std::path::absolute(path)).collect::<Vec<_>>()
+                vec![std::path::absolute(path)]
             }
         })
         .collect::<Result<Vec<_>, _>>()

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -1,10 +1,10 @@
 use clap::{ArgAction::SetTrue, Parser, Subcommand};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::path::PathBuf;
 
 use crate::{
-    build, rule_selector::RuleSelector, settings::OutputFormat, settings::ProgressBar,
-    RuleSelectorParser,
+    build, rule_selector::RuleSelector, settings::OutputFormat, settings::PatternPrefixPair,
+    settings::ProgressBar, RuleSelectorParser,
 };
 
 /// Default extensions to check
@@ -52,7 +52,7 @@ pub struct ExplainArgs {
 }
 
 /// Perform static analysis on files and report issues.
-#[derive(Debug, clap::Parser, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, clap::Parser, Deserialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct CheckArgs {
     /// List of files or directories to check. Directories are searched recursively for
@@ -90,6 +90,13 @@ pub struct CheckArgs {
         hide_possible_values = true
     )]
     pub extend_select: Option<Vec<RuleSelector>>,
+    /// List of mappings from file pattern to code to exclude.
+    #[arg(long, value_delimiter = ',', help_heading = "Rule selection")]
+    pub per_file_ignores: Option<Vec<PatternPrefixPair>>,
+    /// Like `--per-file-ignores`, but adds additional ignores on top of those already specified.
+    #[arg(long, value_delimiter = ',', help_heading = "Rule selection")]
+    pub extend_per_file_ignores: Option<Vec<PatternPrefixPair>>,
+
     /// Set the maximum allowable line length.
     #[arg(long, default_value = "100")]
     pub line_length: Option<usize>,

--- a/fortitude/src/fs.rs
+++ b/fortitude/src/fs.rs
@@ -2,9 +2,34 @@ use std::path::{Path, PathBuf};
 
 use path_absolutize::Absolutize;
 
+use crate::registry::Rule;
+use crate::rule_selector::CompiledPerFileIgnoreList;
+
+/// Create a set with codes matching the pattern/code pairs.
+pub(crate) fn ignores_from_path(path: &Path, ignore_list: &CompiledPerFileIgnoreList) -> Vec<Rule> {
+    let file_name = path.file_name().expect("Unable to parse filename");
+    ignore_list
+        .iter()
+        .filter_map(|entry| {
+            if entry.basename_matcher.is_match(file_name) || entry.absolute_matcher.is_match(path) {
+                if entry.negated {
+                    None
+                } else {
+                    Some(&entry.rules)
+                }
+            } else if entry.negated {
+                Some(&entry.rules)
+            } else {
+                None
+            }
+        })
+        .flatten()
+        .copied()
+        .collect()
+}
+
 /// Convert any path to an absolute path (based on the current working
 /// directory).
-#[allow(dead_code)]
 pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
     let path = path.as_ref();
     if let Ok(path) = path.absolutize() {
@@ -14,7 +39,6 @@ pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
 }
 
 /// Convert any path to an absolute path (based on the specified project root).
-#[allow(dead_code)]
 pub fn normalize_path_to<P: AsRef<Path>, R: AsRef<Path>>(path: P, project_root: R) -> PathBuf {
     let path = path.as_ref();
     if let Ok(path) = path.absolutize_from(project_root.as_ref()) {

--- a/fortitude/src/test.rs
+++ b/fortitude/src/test.rs
@@ -8,6 +8,7 @@ use crate::{
         ast_entrypoint_map, check_file, read_to_string, rules_to_path_rules, rules_to_text_rules,
     },
     message::{Emitter, TextEmitter},
+    rule_selector::CompiledPerFileIgnoreList,
     rules::Rule,
     settings::{FixMode, Settings, UnsafeFixes},
 };
@@ -38,6 +39,7 @@ pub(crate) fn test_contents(
     let path_rules = rules_to_path_rules(rules);
     let text_rules = rules_to_text_rules(rules);
     let ast_entrypoints = ast_entrypoint_map(rules);
+    let per_file_ignores = CompiledPerFileIgnoreList::resolve(vec![]).unwrap();
 
     match check_file(
         &path_rules,
@@ -48,6 +50,7 @@ pub(crate) fn test_contents(
         settings,
         FixMode::Generate,
         UnsafeFixes::Hint,
+        &per_file_ignores,
     ) {
         Ok(violations) => {
             if violations.messages.is_empty() {

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -686,21 +686,17 @@ per-file-ignores = [
     // - Overwrite per-file-ignores in the config file
     // - Files of foo, bar, and baz
     // - No files with index 2
-    let ignores = format!(
-        "--per-file-ignores={}/**/double_nested/*.f90:implicit-typing",
-        path.display()
-    );
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
-                         .args(["--config-file", config_file.as_os_str().to_string_lossy().as_ref()])
                          .arg("check")
                          .arg("--select=typing")
-                         .arg(ignores)
-                         .arg(path),
+                         .arg("--per-file-ignores=**/double_nested/*.f90:implicit-typing")
+                         .arg(path)
+                         .current_dir(path),
                          @r"
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] T001 module missing 'implicit none'
+    bar0.f90:2:1: T001 module missing 'implicit none'
       |
     2 | module bar0
       | ^^^^^^^^^^^ T001
@@ -708,7 +704,7 @@ per-file-ignores = [
     4 | contains
       |
 
-    [TEMP_FILE] T001 module missing 'implicit none'
+    baz0.f90:2:1: T001 module missing 'implicit none'
       |
     2 | module baz0
       | ^^^^^^^^^^^ T001
@@ -716,7 +712,7 @@ per-file-ignores = [
     4 | contains
       |
 
-    [TEMP_FILE] T001 module missing 'implicit none'
+    foo0.f90:2:1: T001 module missing 'implicit none'
       |
     2 | module foo0
       | ^^^^^^^^^^^ T001
@@ -724,7 +720,7 @@ per-file-ignores = [
     4 | contains
       |
 
-    [TEMP_FILE] T001 module missing 'implicit none'
+    nested/bar1.f90:2:1: T001 module missing 'implicit none'
       |
     2 | module bar1
       | ^^^^^^^^^^^ T001
@@ -732,7 +728,7 @@ per-file-ignores = [
     4 | contains
       |
 
-    [TEMP_FILE] T001 module missing 'implicit none'
+    nested/baz1.f90:2:1: T001 module missing 'implicit none'
       |
     2 | module baz1
       | ^^^^^^^^^^^ T001
@@ -740,7 +736,7 @@ per-file-ignores = [
     4 | contains
       |
 
-    [TEMP_FILE] T001 module missing 'implicit none'
+    nested/foo1.f90:2:1: T001 module missing 'implicit none'
       |
     2 | module foo1
       | ^^^^^^^^^^^ T001
@@ -795,27 +791,22 @@ per-file-ignores = [
 ]
 "#;
     fs::write(&config_file, config)?;
-    let ignores = format!(
-        "--extend-per-file-ignores={}/**/double_nested/*.f90:implicit-typing",
-        path.display()
-    );
-
     apply_common_filters!();
     // Expect:
     // - Don't overwrite config file
     // - File types of foo and baz but no bar
     // - No files with index 2
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
-                         .args(["--config-file", config_file.as_os_str().to_string_lossy().as_ref()])
                          .arg("check")
                          .arg("--select=typing")
-                         .arg(ignores)
-                         .arg(path),
+                         .arg("--extend-per-file-ignores=**/double_nested/*.f90:implicit-typing")
+                         .arg(path)
+                         .current_dir(path),
                          @r"
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] T001 module missing 'implicit none'
+    baz0.f90:2:1: T001 module missing 'implicit none'
       |
     2 | module baz0
       | ^^^^^^^^^^^ T001
@@ -823,7 +814,7 @@ per-file-ignores = [
     4 | contains
       |
 
-    [TEMP_FILE] T001 module missing 'implicit none'
+    foo0.f90:2:1: T001 module missing 'implicit none'
       |
     2 | module foo0
       | ^^^^^^^^^^^ T001
@@ -831,7 +822,7 @@ per-file-ignores = [
     4 | contains
       |
 
-    [TEMP_FILE] T001 module missing 'implicit none'
+    nested/baz1.f90:2:1: T001 module missing 'implicit none'
       |
     2 | module baz1
       | ^^^^^^^^^^^ T001
@@ -839,7 +830,7 @@ per-file-ignores = [
     4 | contains
       |
 
-    [TEMP_FILE] T001 module missing 'implicit none'
+    nested/foo1.f90:2:1: T001 module missing 'implicit none'
       |
     2 | module foo1
       | ^^^^^^^^^^^ T001

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -69,7 +69,7 @@ unknown-key = 1
       |
     2 | unknown-key = 1
       | ^^^^^^^^^^^
-    unknown field `unknown-key`, expected one of `files`, `ignore`, `select`, `extend-select`, `line-length`, `file-extensions`, `fix`, `no-fix`, `unsafe-fixes`, `no-unsafe-fixes`, `show-fixes`, `no-show-fixes`, `fix-only`, `no-fix-only`, `output-format`, `preview`, `no-preview`, `progress-bar`
+    unknown field `unknown-key`, expected one of `files`, `ignore`, `select`, `extend-select`, `per-file-ignores`, `extend-per-file-ignores`, `line-length`, `file-extensions`, `fix`, `no-fix`, `unsafe-fixes`, `no-unsafe-fixes`, `show-fixes`, `no-show-fixes`, `fix-only`, `no-fix-only`, `output-format`, `preview`, `no-preview`, `progress-bar`
     ");
     Ok(())
 }

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -681,20 +681,20 @@ per-file-ignores = [
 ]
 "#;
     fs::write(&config_file, config)?;
-    let double_nested_ignore = format!(
-        "--per-file-ignores={}/*:implicit-typing",
-        double_nested.canonicalize()?.display()
-    );
     apply_common_filters!();
     // Expect:
     // - Overwrite per-file-ignores in the config file
     // - Files of foo, bar, and baz
     // - No files with index 2
+    let ignores = format!(
+        "--per-file-ignores={}/**/double_nested/*.f90:implicit-typing",
+        path.display()
+    );
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
                          .args(["--config-file", config_file.as_os_str().to_string_lossy().as_ref()])
                          .arg("check")
                          .arg("--select=typing")
-                         .arg(double_nested_ignore)
+                         .arg(ignores)
                          .arg(path),
                          @r"
     success: false
@@ -795,10 +795,11 @@ per-file-ignores = [
 ]
 "#;
     fs::write(&config_file, config)?;
-    let double_nested_ignore = format!(
-        "--extend-per-file-ignores={}/*:implicit-typing",
-        double_nested.canonicalize()?.display()
+    let ignores = format!(
+        "--extend-per-file-ignores={}/**/double_nested/*.f90:implicit-typing",
+        path.display()
     );
+
     apply_common_filters!();
     // Expect:
     // - Don't overwrite config file
@@ -808,7 +809,7 @@ per-file-ignores = [
                          .args(["--config-file", config_file.as_os_str().to_string_lossy().as_ref()])
                          .arg("check")
                          .arg("--select=typing")
-                         .arg(double_nested_ignore)
+                         .arg(ignores)
                          .arg(path),
                          @r"
     success: false


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/6

Allows the user to specify `--per-file-ignores` and `--extend-per-file-ignores` to switch off rules/categories for specific files:

```bash
fortitude check --per-file-ignores=myfile.f90:typing,myotherfile.f90:S001
```

Using `--extend-per-file-ignores` on the command line adds to the list in the config file, while `--per-file-ignores` overwrites it.

As we're just using `serde` to handle the config file vs CLI problem, the `.toml` interface is a bit clunky:

```toml
[check]
per-file-ignores = [
  "myfile.f90:typing",
  "myotherfile.f90:S001",
]
```

Ideally we would have a separate interface like:

```toml
[check.per-file-ignores]
"myfile.f90" = ["typing"]
"myotherfile.f90" = ["S001"] 
```

I'd suggest raising a new issue for this if this PR is merged.

---

I had to copy quite a lot of new Ruff machinery over to get this working, and while I've tried it out on some local files, I haven't written any tests yet. I'll leave this as a draft until those are done.