### PR TITLE
Add rules for magic/non-portable IO units

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -62,6 +62,8 @@
 | Code | Name | Message | |
 | ---- | ---- | ------- | ------: |
 | IO001 | [missing-action-specifier](rules/missing-action-specifier.md) | file opened without action specifier | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
+| IO011 | [magic-io-unit](rules/magic-io-unit.md) | Magic unit '{value}' in IO statement | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
+| IO012 | [non-portable-io-unit](rules/non-portable-io-unit.md) | Non-portable unit '{value}' in '{kind}' statement | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 
 ### Filesystem (F)
 

--- a/docs/rules/magic-io-unit.md
+++ b/docs/rules/magic-io-unit.md
@@ -1,0 +1,25 @@
+# magic-io-unit (IO011)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for literal integers as units in IO statements.
+
+## Why is this bad?
+Hardcoding unit numbers makes programs more brittle as it becomes harder to
+verify units have been opened before reading/writing. Instead, units should
+be passed in to procedures as arguments, or the `newunit=` argument used for
+`open` statements.
+
+Bad:
+```f90
+open(10, file="example.txt", action="read")
+read(10, fmt=*) int
+close(10)
+```
+
+Good:
+```f90
+open(newunit=example_unit, file="example.txt", action="read")
+read(example_unit, fmt=*) int
+close(example_unit)
+```

--- a/docs/rules/non-portable-io-unit.md
+++ b/docs/rules/non-portable-io-unit.md
@@ -1,0 +1,10 @@
+# non-portable-io-unit (IO012)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for the literals `5` or `6` as units in `read`/`write` statements.
+
+## Why is this bad?
+The Fortran standard does not specify numeric values for `stdin` or
+`stdout`. Instead, use the named constants `input_unit` and `output_unit`
+from the `iso_fortran_env` module.

--- a/fortitude/resources/test/fixtures/io/IO011.f90
+++ b/fortitude/resources/test/fixtures/io/IO011.f90
@@ -1,0 +1,15 @@
+program test
+  implicit none
+  integer :: i, named_unit
+  open(10, file="test.txt", action="read")
+  read(10, *) i
+  close(10)
+
+  open(file="test_out.txt", action="write", unit=24)
+  write (fmt=*, unit=24) i
+  close(24)
+
+  open(newunit=named_unit, file="test.txt", action="write")
+  write(named_unit, *) "i =", i
+  close(named_unit)
+end program test

--- a/fortitude/resources/test/fixtures/io/IO012.f90
+++ b/fortitude/resources/test/fixtures/io/IO012.f90
@@ -1,0 +1,12 @@
+program test
+  implicit none
+  integer :: i, named_unit
+
+  write (6,*) "enter an integer"
+  read (unit=5,fmt=*) i
+  write(fmt=*, unit=6) "thanks"
+
+  open(newunit=named_unit, file="test.txt", action="write")
+  write(named_unit, *) "i =", i
+  close(named_unit)
+end program test

--- a/fortitude/src/ast.rs
+++ b/fortitude/src/ast.rs
@@ -209,7 +209,7 @@ pub fn dtype_is_plain_number(dtype: &str) -> bool {
     )
 }
 
-/// If `node` is a keyword argument with name `keyword`, return the corresponding value
+/// Returns `true` if `node` is a keyword argument with name `keyword`.
 pub fn is_keyword_argument<S: AsRef<str>>(node: &Node, keyword: S, src: &str) -> bool {
     if node.kind() != "keyword_argument" {
         return false;

--- a/fortitude/src/ast.rs
+++ b/fortitude/src/ast.rs
@@ -208,3 +208,17 @@ pub fn dtype_is_plain_number(dtype: &str) -> bool {
         "integer" | "real" | "logical" | "complex"
     )
 }
+
+/// If `node` is a keyword argument with name `keyword`, return the corresponding value
+pub fn is_keyword_argument<S: AsRef<str>>(node: &Node, keyword: S, src: &str) -> bool {
+    if node.kind() != "keyword_argument" {
+        return false;
+    }
+
+    if let Some(kwarg) = node.child_by_field_name("name") {
+        if let Some(name) = &kwarg.to_text(src) {
+            return name.to_lowercase() == keyword.as_ref();
+        }
+    }
+    false
+}

--- a/fortitude/src/rules/io/magic_io_unit.rs
+++ b/fortitude/src/rules/io/magic_io_unit.rs
@@ -1,0 +1,149 @@
+use crate::ast::{is_keyword_argument, FortitudeNode};
+use crate::settings::Settings;
+use crate::{AstRule, FromAstNode};
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_source_file::SourceFile;
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks for literal integers as units in IO statements.
+///
+/// ## Why is this bad?
+/// Hardcoding unit numbers makes programs more brittle as it becomes harder to
+/// verify units have been opened before reading/writing. Instead, units should
+/// be passed in to procedures as arguments, or the `newunit=` argument used for
+/// `open` statements.
+///
+/// Bad:
+/// ```f90
+/// open(10, file="example.txt", action="read")
+/// read(10, fmt=*) int
+/// close(10)
+/// ```
+///
+/// Good:
+/// ```f90
+/// open(newunit=example_unit, file="example.txt", action="read")
+/// read(example_unit, fmt=*) int
+/// close(example_unit)
+/// ```
+#[violation]
+pub struct MagicIoUnit {
+    value: i32,
+}
+
+impl Violation for MagicIoUnit {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self { value, .. } = self;
+        format!("Magic unit '{value}' in IO statement")
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Replace with named variable".to_string())
+    }
+}
+
+impl AstRule for MagicIoUnit {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        let unit = literal_as_unit(node, src)?;
+
+        let value = unit
+            .to_text(src.source_text())?
+            .parse::<i32>()
+            .unwrap_or_default();
+
+        some_vec!(Diagnostic::from_node(Self { value }, &unit))
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec![
+            "read_statement",
+            "write_statement",
+            "open_statement",
+            "close_statement",
+        ]
+    }
+}
+
+/// ## What it does
+/// Checks for the literals `5` or `6` as units in `read`/`write` statements.
+///
+/// ## Why is this bad?
+/// The Fortran standard does not specify numeric values for `stdin` or
+/// `stdout`. Instead, use the named constants `input_unit` and `output_unit`
+/// from the `iso_fortran_env` module.
+#[violation]
+pub struct NonPortableIoUnit {
+    value: i32,
+    kind: String,
+    replacement: Option<String>,
+}
+
+impl Violation for NonPortableIoUnit {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self { value, kind, .. } = self;
+        format!("Non-portable unit '{value}' in '{kind}' statement")
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        let Self { replacement, .. } = self;
+        replacement
+            .as_ref()
+            .map(|replacement| format!("Use `{replacement}` from `iso_fortran_env`"))
+    }
+}
+
+impl AstRule for NonPortableIoUnit {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        let unit = literal_as_unit(node, src)?;
+
+        let value = unit
+            .to_text(src.source_text())?
+            .parse::<i32>()
+            .unwrap_or_default();
+        let is_read = node.kind() == "read_statement";
+        let is_write = node.kind() == "write_statement";
+
+        let kind = if is_read { "read" } else { "write" }.to_string();
+
+        let replacement = if is_read && value == 5 {
+            Some("input_unit".to_string())
+        } else if is_write && value == 6 {
+            Some("output_unit".to_string())
+        } else {
+            None
+        };
+
+        some_vec!(Diagnostic::from_node(
+            Self {
+                value,
+                kind,
+                replacement
+            },
+            &unit
+        ))
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["read_statement", "write_statement"]
+    }
+}
+
+fn literal_as_unit<'a>(node: &'a Node, src: &SourceFile) -> Option<Node<'a>> {
+    let unit = if let Some(unit) = node.child_with_name("unit_identifier") {
+        unit.child(0)?
+    } else {
+        node.named_children(&mut node.walk())
+            .find(|child| is_keyword_argument(child, "unit", src.source_text()))
+            .map(|node| node.child_by_field_name("value"))??
+    };
+
+    if unit.kind() == "number_literal" {
+        Some(unit)
+    } else {
+        None
+    }
+}

--- a/fortitude/src/rules/io/magic_io_unit.rs
+++ b/fortitude/src/rules/io/magic_io_unit.rs
@@ -13,7 +13,9 @@ use tree_sitter::Node;
 /// Hardcoding unit numbers makes programs more brittle as it becomes harder to
 /// verify units have been opened before reading/writing. Instead, units should
 /// be passed in to procedures as arguments, or the `newunit=` argument used for
-/// `open` statements.
+/// `open` statements. Having a named variable also makes it much clearer what a
+/// given IO statement is for, and allows tools like LSP and IDEs to find all
+/// references.
 ///
 /// Bad:
 /// ```f90

--- a/fortitude/src/rules/io/mod.rs
+++ b/fortitude/src/rules/io/mod.rs
@@ -1,3 +1,4 @@
+pub mod magic_io_unit;
 pub mod missing_specifier;
 
 #[cfg(test)]
@@ -14,6 +15,8 @@ mod tests {
     use crate::test::test_path;
 
     #[test_case(Rule::MissingActionSpecifier, Path::new("IO001.f90"))]
+    #[test_case(Rule::MagicIoUnit, Path::new("IO011.f90"))]
+    #[test_case(Rule::NonPortableIoUnit, Path::new("IO012.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/io/snapshots/fortitude__rules__io__tests__magic-io-unit_IO011.f90.snap
+++ b/fortitude/src/rules/io/snapshots/fortitude__rules__io__tests__magic-io-unit_IO011.f90.snap
@@ -1,0 +1,67 @@
+---
+source: fortitude/src/rules/io/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/io/IO011.f90:4:8: IO011 Magic unit '10' in IO statement
+  |
+2 |   implicit none
+3 |   integer :: i, named_unit
+4 |   open(10, file="test.txt", action="read")
+  |        ^^ IO011
+5 |   read(10, *) i
+6 |   close(10)
+  |
+  = help: Replace with named variable
+
+./resources/test/fixtures/io/IO011.f90:5:8: IO011 Magic unit '10' in IO statement
+  |
+3 |   integer :: i, named_unit
+4 |   open(10, file="test.txt", action="read")
+5 |   read(10, *) i
+  |        ^^ IO011
+6 |   close(10)
+  |
+  = help: Replace with named variable
+
+./resources/test/fixtures/io/IO011.f90:6:9: IO011 Magic unit '10' in IO statement
+  |
+4 |   open(10, file="test.txt", action="read")
+5 |   read(10, *) i
+6 |   close(10)
+  |         ^^ IO011
+7 |
+8 |   open(file="test_out.txt", action="write", unit=24)
+  |
+  = help: Replace with named variable
+
+./resources/test/fixtures/io/IO011.f90:8:50: IO011 Magic unit '24' in IO statement
+   |
+ 6 |   close(10)
+ 7 |
+ 8 |   open(file="test_out.txt", action="write", unit=24)
+   |                                                  ^^ IO011
+ 9 |   write (fmt=*, unit=24) i
+10 |   close(24)
+   |
+   = help: Replace with named variable
+
+./resources/test/fixtures/io/IO011.f90:9:22: IO011 Magic unit '24' in IO statement
+   |
+ 8 |   open(file="test_out.txt", action="write", unit=24)
+ 9 |   write (fmt=*, unit=24) i
+   |                      ^^ IO011
+10 |   close(24)
+   |
+   = help: Replace with named variable
+
+./resources/test/fixtures/io/IO011.f90:10:9: IO011 Magic unit '24' in IO statement
+   |
+ 8 |   open(file="test_out.txt", action="write", unit=24)
+ 9 |   write (fmt=*, unit=24) i
+10 |   close(24)
+   |         ^^ IO011
+11 |
+12 |   open(newunit=named_unit, file="test.txt", action="write")
+   |
+   = help: Replace with named variable

--- a/fortitude/src/rules/io/snapshots/fortitude__rules__io__tests__non-portable-io-unit_IO012.f90.snap
+++ b/fortitude/src/rules/io/snapshots/fortitude__rules__io__tests__non-portable-io-unit_IO012.f90.snap
@@ -1,0 +1,35 @@
+---
+source: fortitude/src/rules/io/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/io/IO012.f90:5:10: IO012 Non-portable unit '6' in 'write' statement
+  |
+3 |   integer :: i, named_unit
+4 |
+5 |   write (6,*) "enter an integer"
+  |          ^ IO012
+6 |   read (unit=5,fmt=*) i
+7 |   write(fmt=*, unit=6) "thanks"
+  |
+  = help: Use `output_unit` from `iso_fortran_env`
+
+./resources/test/fixtures/io/IO012.f90:6:14: IO012 Non-portable unit '5' in 'read' statement
+  |
+5 |   write (6,*) "enter an integer"
+6 |   read (unit=5,fmt=*) i
+  |              ^ IO012
+7 |   write(fmt=*, unit=6) "thanks"
+  |
+  = help: Use `input_unit` from `iso_fortran_env`
+
+./resources/test/fixtures/io/IO012.f90:7:21: IO012 Non-portable unit '6' in 'write' statement
+  |
+5 |   write (6,*) "enter an integer"
+6 |   read (unit=5,fmt=*) i
+7 |   write(fmt=*, unit=6) "thanks"
+  |                     ^ IO012
+8 |
+9 |   open(newunit=named_unit, file="test.txt", action="write")
+  |
+  = help: Use `output_unit` from `iso_fortran_env`

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -113,6 +113,8 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Modules, "022") => (RuleGroup::Preview, Ast, modules::accessibility_statements::DefaultPublicAccessibility),
 
         (Io, "001") => (RuleGroup::Preview, Ast, io::missing_specifier::MissingActionSpecifier),
+        (Io, "011") => (RuleGroup::Preview, Ast, io::magic_io_unit::MagicIoUnit),
+        (Io, "012") => (RuleGroup::Preview, Ast, io::magic_io_unit::NonPortableIoUnit),
 
         // Rules for testing fortitude
         // Couldn't get a separate `Testing` category working for some reason


### PR DESCRIPTION
Closes #206 
Closes #146 

Unfortunately these are overlapping rules, although some projects might have their own equivalent of `input_unit` and so would want `magic-io-unit` but not `non-portable-io-unit`. I think this is one place where ruff's approach of handling check functions would work quite well. We'd have one function that we'd call if either rule was enabled, and it could do the check once and return the apropriate `Violation`.