### PR TITLE
Add "allow" comments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,30 @@ files using `--per-file-ignores`:
 fortitude check --per-file-ignores=**/*.f95:non-standard-file-extension
 ```
 
+as well as for individual statements through "allow" comments of the
+form:
+
+```f90
+! allow(rule-or-category)
+```
+
+Multiple rules or categories can be given as a comma-separated
+list. Allow comments apply to the next statement and its contents. So
+in the example below, we allow all of the `style` rules and
+`superfluous-implicit-none` throughout the whole module, and `use-all`
+on the `iso_fortran_env` `use` statement specifically, while
+`some_other_module` will still generate a warning.
+
+```f90
+! allow(style, superfluous-implicit-none)
+module example
+    ! allow(use-all)
+    use, intrinsic :: iso_fortran_env
+    use some_other_module
+    implicit none (type, external)
+...
+```
+
 ### Filtering Files
 
 Fortitude will automatically ignore files in some directories (`build/`, `.git/`,

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -20,10 +20,11 @@ use anyhow::{anyhow, Context, Result};
 use colored::Colorize;
 use indicatif::{ParallelProgressIterator, ProgressStyle};
 use itertools::Itertools;
+use lazy_regex::regex_captures;
 use rayon::prelude::*;
 use ruff_diagnostics::Diagnostic;
 use ruff_source_file::{Locator, SourceFile, SourceFileBuilder};
-use ruff_text_size::TextRange;
+use ruff_text_size::{TextRange, TextSize};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -33,9 +34,10 @@ use std::io;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::str::FromStr;
 use strum::IntoEnumIterator;
 use toml::Table;
-use tree_sitter::Parser;
+use tree_sitter::{Node, Parser};
 use walkdir::WalkDir;
 
 // These are just helper structs to let us quickly work out if there's
@@ -395,6 +397,61 @@ pub(crate) fn check_file(
     })
 }
 
+/// A single allowed rule and the range it applies to
+struct AllowComment {
+    pub rule: Rule,
+    pub range: TextRange,
+}
+
+/// If this node is an `allow` comment, get all the rules allowed on the next line
+fn gather_allow_comments(node: &Node, allow_comments: &mut Vec<AllowComment>, file: &SourceFile) {
+    if node.kind() != "comment" {
+        return;
+    }
+    if let Some((_, allow_comment)) = regex_captures!(
+        r#"! allow\((.*)\)\s*"#,
+        node.to_text(file.source_text()).unwrap()
+    ) {
+        let preview = PreviewOptions {
+            mode: PreviewMode::Enabled,
+            require_explicit: false,
+        };
+        let allow_rules = allow_comment
+            .split(',')
+            .map(|rule| RuleSelector::from_str(rule.trim()).expect("valid rule"))
+            .collect_vec();
+
+        if let Some(next_node) = node.next_named_sibling() {
+            let start_byte = TextSize::try_from(next_node.start_byte()).unwrap();
+            let end_byte = TextSize::try_from(next_node.end_byte()).unwrap();
+
+            // This covers the next statement _upto_ the end of the
+            // line that it _ends_ on -- i.e. including trailing
+            // whitespace and other statements. This might have weird
+            // edge cases.
+            let src = file.to_source_code();
+            let start_index = src.line_index(start_byte);
+            let end_index = src.line_index(end_byte);
+            let start_line = src.line_start(start_index);
+            let end_line = src.line_end(end_index);
+
+            let range = TextRange::new(start_line, end_line);
+            for rule_selector in allow_rules {
+                for rule in rule_selector.rules(&preview) {
+                    allow_comments.push(AllowComment { rule, range });
+                }
+            }
+        };
+    }
+}
+
+/// Filter out allowed rules
+fn filter_allowed_rules(diagnostic: &Diagnostic, allow_comments: &[AllowComment]) -> bool {
+    allow_comments.iter().all(|allow| {
+        !(allow.rule == diagnostic.kind.rule() && allow.range.contains_range(diagnostic.range))
+    })
+}
+
 /// Parse a file, check it for issues, and return the report.
 pub(crate) fn check_only_file(
     path_rules: &Vec<PathRuleEnum>,
@@ -405,6 +462,7 @@ pub(crate) fn check_only_file(
     settings: &Settings,
 ) -> anyhow::Result<Vec<DiagnosticMessage>> {
     let mut violations = Vec::new();
+    let mut allow_comments = Vec::new();
 
     for rule in path_rules {
         if let Some(violation) = rule.check(settings, path) {
@@ -435,10 +493,12 @@ pub(crate) fn check_only_file(
                 }
             }
         }
+        gather_allow_comments(&node, &mut allow_comments, file);
     }
 
     Ok(violations
         .into_iter()
+        .filter(|diagnostic| filter_allowed_rules(diagnostic, &allow_comments))
         .map(|v| DiagnosticMessage::from_ruff(file, v))
         .collect_vec())
 }
@@ -484,6 +544,7 @@ pub(crate) fn check_and_fix_file<'a>(
     // Continuously fix until the source code stabilizes.
     loop {
         let mut violations = Vec::new();
+        let mut allow_comments = Vec::new();
 
         // Map row and column locations to byte slices (lazily).
         let locator = Locator::new(transformed.source_text());
@@ -517,6 +578,7 @@ pub(crate) fn check_and_fix_file<'a>(
                     }
                 }
             }
+            gather_allow_comments(&node, &mut allow_comments, file);
         }
 
         if iterations == 0 {
@@ -525,6 +587,11 @@ pub(crate) fn check_and_fix_file<'a>(
             report_fix_syntax_error(path, transformed.source_text(), fixed.keys().copied());
             return Err(anyhow!("Fix introduced a syntax error"));
         }
+
+        let violations = violations
+            .into_iter()
+            .filter(|diagnostic| filter_allowed_rules(diagnostic, &allow_comments))
+            .collect_vec();
 
         // Apply fix
         if let Some(FixResult {


### PR DESCRIPTION
Closes #209

Comments are of the form:

    ! allow(rule)

Usual rule selection applies, list of comma separated selectors

Comments apply to the whole of the next statement, including
constructs, procedures, modules, etc

Needs some proper docs, but I'm not sure where it belongs. Maybe we
need to add a whole tutorial section?