### PR TITLE
Suggest `iso_fortran_env` parameters for literal kinds

### DIFF
--- a/fortitude/resources/test/fixtures/typing/T012.f90
+++ b/fortitude/resources/test/fixtures/typing/T012.f90
@@ -1,9 +1,21 @@
 program test
-  use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
+  use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64, qp => real128, int8, int16, int32, int64
+
+  integer(int8), parameter :: i1 = 1_1
+  integer(int16), parameter :: i2 = -1_2
+  integer(int32), parameter :: i3 = 2_4
+  integer(int64), parameter :: i4 = -2_8
+  integer(int8), parameter :: i5 = 1_int8
+  integer(int16), parameter :: i6 = -1_int16
+  integer(int32), parameter :: i7 = 2_int32
+  integer(int64), parameter :: i8 = -2_int64
 
   real(sp), parameter :: x1 = 1.234567_4
   real(dp), parameter :: x2 = 1.234567_dp
   real(dp), parameter :: x3 = 1.789d3
   real(dp), parameter :: x4 = 9.876_8
-  real(sp), parameter :: x5 = 2.468_sp
+  real(sp), parameter :: x5 = 2.468e-1_sp
+  real(qp), parameter :: x6 = 9.876_16
+  real(qp), parameter :: x7 = 9.876e12_sp
+  real(qp), parameter :: x8 = 9.876e-12_16
 end program

--- a/fortitude/src/rules/typing/snapshots/fortitude__rules__typing__tests__literal-kind-suffix_T012.f90.snap
+++ b/fortitude/src/rules/typing/snapshots/fortitude__rules__typing__tests__literal-kind-suffix_T012.f90.snap
@@ -3,22 +3,88 @@ source: fortitude/src/rules/typing/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
-./resources/test/fixtures/typing/T012.f90:4:40: T012 '1.234567_4' has literal suffix '4', use 'iso_fortran_env' parameter
+./resources/test/fixtures/typing/T012.f90:4:38: T012 '1_1' has literal kind suffix '1'
   |
-2 |   use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
+2 |   use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64, qp => real128, int8, int16, int32, int64
 3 |
-4 |   real(sp), parameter :: x1 = 1.234567_4
-  |                                        ^ T012
-5 |   real(dp), parameter :: x2 = 1.234567_dp
-6 |   real(dp), parameter :: x3 = 1.789d3
+4 |   integer(int8), parameter :: i1 = 1_1
+  |                                      ^ T012
+5 |   integer(int16), parameter :: i2 = -1_2
+6 |   integer(int32), parameter :: i3 = 2_4
   |
+  = help: Use the parameter 'int8' from 'iso_fortran_env'
 
-./resources/test/fixtures/typing/T012.f90:7:37: T012 '9.876_8' has literal suffix '8', use 'iso_fortran_env' parameter
+./resources/test/fixtures/typing/T012.f90:5:40: T012 '1_2' has literal kind suffix '2'
   |
-5 |   real(dp), parameter :: x2 = 1.234567_dp
-6 |   real(dp), parameter :: x3 = 1.789d3
-7 |   real(dp), parameter :: x4 = 9.876_8
-  |                                     ^ T012
-8 |   real(sp), parameter :: x5 = 2.468_sp
-9 | end program
+4 |   integer(int8), parameter :: i1 = 1_1
+5 |   integer(int16), parameter :: i2 = -1_2
+  |                                        ^ T012
+6 |   integer(int32), parameter :: i3 = 2_4
+7 |   integer(int64), parameter :: i4 = -2_8
   |
+  = help: Use the parameter 'int16' from 'iso_fortran_env'
+
+./resources/test/fixtures/typing/T012.f90:6:39: T012 '2_4' has literal kind suffix '4'
+  |
+4 |   integer(int8), parameter :: i1 = 1_1
+5 |   integer(int16), parameter :: i2 = -1_2
+6 |   integer(int32), parameter :: i3 = 2_4
+  |                                       ^ T012
+7 |   integer(int64), parameter :: i4 = -2_8
+8 |   integer(int8), parameter :: i5 = 1_int8
+  |
+  = help: Use the parameter 'int32' from 'iso_fortran_env'
+
+./resources/test/fixtures/typing/T012.f90:7:40: T012 '2_8' has literal kind suffix '8'
+  |
+5 |   integer(int16), parameter :: i2 = -1_2
+6 |   integer(int32), parameter :: i3 = 2_4
+7 |   integer(int64), parameter :: i4 = -2_8
+  |                                        ^ T012
+8 |   integer(int8), parameter :: i5 = 1_int8
+9 |   integer(int16), parameter :: i6 = -1_int16
+  |
+  = help: Use the parameter 'int64' from 'iso_fortran_env'
+
+./resources/test/fixtures/typing/T012.f90:13:40: T012 '1.234567_4' has literal kind suffix '4'
+   |
+11 |   integer(int64), parameter :: i8 = -2_int64
+12 |
+13 |   real(sp), parameter :: x1 = 1.234567_4
+   |                                        ^ T012
+14 |   real(dp), parameter :: x2 = 1.234567_dp
+15 |   real(dp), parameter :: x3 = 1.789d3
+   |
+   = help: Use the parameter 'real32' from 'iso_fortran_env'
+
+./resources/test/fixtures/typing/T012.f90:16:37: T012 '9.876_8' has literal kind suffix '8'
+   |
+14 |   real(dp), parameter :: x2 = 1.234567_dp
+15 |   real(dp), parameter :: x3 = 1.789d3
+16 |   real(dp), parameter :: x4 = 9.876_8
+   |                                     ^ T012
+17 |   real(sp), parameter :: x5 = 2.468e-1_sp
+18 |   real(qp), parameter :: x6 = 9.876_16
+   |
+   = help: Use the parameter 'real64' from 'iso_fortran_env'
+
+./resources/test/fixtures/typing/T012.f90:18:37: T012 '9.876_16' has literal kind suffix '16'
+   |
+16 |   real(dp), parameter :: x4 = 9.876_8
+17 |   real(sp), parameter :: x5 = 2.468e-1_sp
+18 |   real(qp), parameter :: x6 = 9.876_16
+   |                                     ^^ T012
+19 |   real(qp), parameter :: x7 = 9.876e12_sp
+20 |   real(qp), parameter :: x8 = 9.876e-12_16
+   |
+   = help: Use the parameter 'real128' from 'iso_fortran_env'
+
+./resources/test/fixtures/typing/T012.f90:20:41: T012 '9.876e-12_16' has literal kind suffix '16'
+   |
+18 |   real(qp), parameter :: x6 = 9.876_16
+19 |   real(qp), parameter :: x7 = 9.876e12_sp
+20 |   real(qp), parameter :: x8 = 9.876e-12_16
+   |                                         ^^ T012
+21 | end program
+   |
+   = help: Use the parameter 'real128' from 'iso_fortran_env'

--- a/fortitude/src/rules/typing/snapshots/fortitude__rules__typing__tests__literal-kind_T011.f90.snap
+++ b/fortitude/src/rules/typing/snapshots/fortitude__rules__typing__tests__literal-kind_T011.f90.snap
@@ -3,15 +3,16 @@ source: fortitude/src/rules/typing/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
-./resources/test/fixtures/typing/T011.f90:1:9: T011 integer kind set with number literal '8', use 'iso_fortran_env' parameter
+./resources/test/fixtures/typing/T011.f90:1:9: T011 integer kind set with number literal '8'
   |
 1 | integer(8) function add_if(x, y, z)
   |         ^ T011
 2 |   integer :: w
 3 |   integer(kind=2), intent(in) :: x
   |
+  = help: Use the parameter 'int64' from 'iso_fortran_env'
 
-./resources/test/fixtures/typing/T011.f90:3:16: T011 integer kind set with number literal '2', use 'iso_fortran_env' parameter
+./resources/test/fixtures/typing/T011.f90:3:16: T011 integer kind set with number literal '2'
   |
 1 | integer(8) function add_if(x, y, z)
 2 |   integer :: w
@@ -20,8 +21,9 @@ snapshot_kind: text
 4 |   integer(i32), intent(in) :: y
 5 |   logical(kind=4), intent(in) :: z
   |
+  = help: Use the parameter 'int16' from 'iso_fortran_env'
 
-./resources/test/fixtures/typing/T011.f90:5:16: T011 logical kind set with number literal '4', use 'iso_fortran_env' parameter
+./resources/test/fixtures/typing/T011.f90:5:16: T011 logical kind set with number literal '4'
   |
 3 |   integer(kind=2), intent(in) :: x
 4 |   integer(i32), intent(in) :: y
@@ -30,8 +32,9 @@ snapshot_kind: text
 6 |
 7 |   if (x) then
   |
+  = help: Use the parameter 'int32' from 'iso_fortran_env'
 
-./resources/test/fixtures/typing/T011.f90:15:8: T011 real kind set with number literal '8', use 'iso_fortran_env' parameter
+./resources/test/fixtures/typing/T011.f90:15:8: T011 real kind set with number literal '8'
    |
 14 | subroutine complex_mul(x, y)
 15 |   real(8), intent(in) :: x
@@ -39,8 +42,9 @@ snapshot_kind: text
 16 |   complex(4), intent(inout) :: y
 17 |   real :: z = 0.5
    |
+   = help: Use the parameter 'real64' from 'iso_fortran_env'
 
-./resources/test/fixtures/typing/T011.f90:16:11: T011 complex kind set with number literal '4', use 'iso_fortran_env' parameter
+./resources/test/fixtures/typing/T011.f90:16:11: T011 complex kind set with number literal '4'
    |
 14 | subroutine complex_mul(x, y)
 15 |   real(8), intent(in) :: x
@@ -49,8 +53,9 @@ snapshot_kind: text
 17 |   real :: z = 0.5
 18 |   y = y * x
    |
+   = help: Use the parameter 'real32' from 'iso_fortran_env'
 
-./resources/test/fixtures/typing/T011.f90:23:16: T011 complex kind set with number literal '4', use 'iso_fortran_env' parameter
+./resources/test/fixtures/typing/T011.f90:23:16: T011 complex kind set with number literal '4'
    |
 21 | complex(real64) function complex_add(x, y)
 22 |   real(real64), intent(in) :: x
@@ -59,3 +64,4 @@ snapshot_kind: text
 24 |   complex_add = y + x
 25 | end function complex_add
    |
+   = help: Use the parameter 'real32' from 'iso_fortran_env'

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -112,13 +112,14 @@ end program
       |
       = help: Replace with 'logical(4)'
 
-    [TEMP_FILE] T011 logical kind set with number literal '4', use 'iso_fortran_env' parameter
+    [TEMP_FILE] T011 logical kind set with number literal '4'
       |
     2 | program test
     3 |   logical*4, parameter :: true = .true.
       |           ^ T011
     4 | end program
       |
+      = help: Use the parameter 'int32' from 'iso_fortran_env'
 
     [TEMP_FILE] S061 [*] end statement should be named.
       |


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/159

Only suggestions for now, as we don't yet have the infrastructure to add/edit `use` statements. An unsafe fix could then follow.