### PR TITLE
Add `RuleSet`, `RuleTable` from ruff; allow ignoring `IoError`

### DIFF
--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -925,6 +925,12 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
                         )]));
                     } else {
                         // TODO: log::warn
+                        eprintln!(
+                            "{}{}{} {error}",
+                            "Error opening file ".bold(),
+                            fs::relativize_path(path).bold(),
+                            ":".bold()
+                        );
                         return None;
                     }
                 }
@@ -953,6 +959,12 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
                         )]))
                     } else {
                         // TODO: log::warn
+                        eprintln!(
+                            "{}{}{} {msg}",
+                            "Failed to process ".bold(),
+                            fs::relativize_path(path).bold(),
+                            ":".bold()
+                        );
                         None
                     }
                 }

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -229,7 +229,7 @@ fn parse_config_file(config_file: &Option<PathBuf>) -> Result<CheckSettings> {
 }
 
 /// Get the list of active rules for this session.
-fn ruleset(args: RuleSelection, preview: &PreviewMode) -> anyhow::Result<RuleTable> {
+fn to_rule_table(args: RuleSelection, preview: &PreviewMode) -> anyhow::Result<RuleTable> {
     let preview = PreviewOptions {
         mode: *preview,
         require_explicit: false,
@@ -875,7 +875,7 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
     // At this point, we've assembled all our settings, and we're
     // ready to check the project
 
-    let rules = ruleset(rule_selection, &preview_mode)?;
+    let rules = to_rule_table(rule_selection, &preview_mode)?;
 
     let path_rules = rules_to_path_rules(&rules);
     let text_rules = rules_to_text_rules(&rules);
@@ -1001,7 +1001,7 @@ mod tests {
     use super::*;
 
     fn resolve_rules(args: RuleSelection, preview: &PreviewMode) -> Result<RuleSet> {
-        Ok(ruleset(args, preview)?.iter_enabled().collect())
+        Ok(to_rule_table(args, preview)?.iter_enabled().collect())
     }
 
     #[test]

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -10,6 +10,7 @@ mod printer;
 pub mod registry;
 mod rule_redirects;
 mod rule_selector;
+pub mod rule_table;
 pub mod rules;
 pub mod settings;
 #[cfg(test)]

--- a/fortitude/src/registry.rs
+++ b/fortitude/src/registry.rs
@@ -2,6 +2,9 @@ use fortitude_macros::RuleNamespace;
 use std::str::FromStr; // Needed by strum_macros
 
 pub use crate::rules::Rule;
+pub use rule_set::{RuleSet, RuleSetIterator};
+
+mod rule_set;
 
 // Rule categories and identity codes
 // ----------------------------------

--- a/fortitude/src/registry/rule_set.rs
+++ b/fortitude/src/registry/rule_set.rs
@@ -1,0 +1,425 @@
+// Adapted from from ruff
+// Copyright 2022 Charles Marsh
+// SPDX-License-Identifier: MIT
+
+use std::fmt::{Debug, Display, Formatter};
+use std::iter::FusedIterator;
+
+use ruff_macros::CacheKey;
+
+use crate::registry::Rule;
+
+const RULESET_SIZE: usize = 2;
+
+/// A set of [`Rule`]s.
+///
+/// Uses a bitset where a bit of one signals that the Rule with that [u16] is in this set.
+#[derive(Clone, Default, CacheKey, PartialEq, Eq)]
+pub struct RuleSet([u64; RULESET_SIZE]);
+
+impl RuleSet {
+    const EMPTY: [u64; RULESET_SIZE] = [0; RULESET_SIZE];
+    // 64 fits into a u16 without truncation
+    #[allow(clippy::cast_possible_truncation)]
+    const SLICE_BITS: u16 = u64::BITS as u16;
+
+    /// Returns an empty rule set.
+    pub const fn empty() -> Self {
+        Self(Self::EMPTY)
+    }
+
+    pub fn clear(&mut self) {
+        self.0 = Self::EMPTY;
+    }
+
+    #[inline]
+    pub const fn from_rule(rule: Rule) -> Self {
+        let rule = rule as u16;
+
+        let index = (rule / Self::SLICE_BITS) as usize;
+
+        debug_assert!(
+            index < Self::EMPTY.len(),
+            "Rule index out of bounds. Increase the size of the bitset array."
+        );
+
+        // The bit-position of this specific rule in the slice
+        let shift = rule % Self::SLICE_BITS;
+        // Set the index for that rule to 1
+        let mask = 1 << shift;
+
+        let mut bits = Self::EMPTY;
+        bits[index] = mask;
+
+        Self(bits)
+    }
+
+    #[inline]
+    pub const fn from_rules(rules: &[Rule]) -> Self {
+        let mut set = RuleSet::empty();
+
+        let mut i = 0;
+
+        // Uses a while because for loops are not allowed in const functions.
+        while i < rules.len() {
+            set = set.union(&RuleSet::from_rule(rules[i]));
+            i += 1;
+        }
+
+        set
+    }
+
+    /// Returns the union of the two rule sets `self` and `other`
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use fortitude::registry::{Rule, RuleSet};
+    /// let set_1 = RuleSet::from_rules(&[Rule::MissingIntent, Rule::ImplicitTyping]);
+    /// let set_2 = RuleSet::from_rules(&[
+    ///     Rule::LineTooLong,
+    ///     Rule::ExternalProcedure,
+    /// ]);
+    ///
+    /// let union = set_1.union(&set_2);
+    ///
+    /// assert!(union.contains(Rule::MissingIntent));
+    /// assert!(union.contains(Rule::ImplicitTyping));
+    /// assert!(union.contains(Rule::LineTooLong));
+    /// assert!(union.contains(Rule::ExternalProcedure));
+    /// ```
+    #[must_use]
+    pub const fn union(mut self, other: &Self) -> Self {
+        let mut i = 0;
+
+        while i < self.0.len() {
+            self.0[i] |= other.0[i];
+            i += 1;
+        }
+
+        self
+    }
+
+    /// Returns `self` without any of the rules contained in `other`.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use fortitude::registry::{Rule, RuleSet};
+    /// let set_1 = RuleSet::from_rules(&[Rule::MissingIntent, Rule::ImplicitTyping]);
+    /// let set_2 = RuleSet::from_rules(&[Rule::MissingIntent, Rule::ProcedureNotInModule]);
+    ///
+    /// let subtract = set_1.subtract(&set_2);
+    ///
+    /// assert!(subtract.contains(Rule::ImplicitTyping));
+    /// assert!(!subtract.contains(Rule::MissingIntent));
+    /// ```
+    #[must_use]
+    pub const fn subtract(mut self, other: &Self) -> Self {
+        let mut i = 0;
+
+        while i < self.0.len() {
+            self.0[i] &= !other.0[i];
+            i += 1;
+        }
+
+        self
+    }
+
+    /// Returns true if `self` and `other` contain at least one common rule.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use fortitude::registry::{Rule, RuleSet};
+    /// let set_1 = RuleSet::from_rules(&[Rule::MissingIntent, Rule::ImplicitTyping]);
+    ///
+    /// assert!(set_1.intersects(&RuleSet::from_rules(&[
+    ///     Rule::ImplicitTyping,
+    ///     Rule::LineTooLong
+    /// ])));
+    ///
+    /// assert!(!set_1.intersects(&RuleSet::from_rules(&[
+    ///     Rule::ExternalProcedure,
+    ///     Rule::LineTooLong
+    /// ])));
+    /// ```
+    pub const fn intersects(&self, other: &Self) -> bool {
+        let mut i = 0;
+
+        while i < self.0.len() {
+            if self.0[i] & other.0[i] != 0 {
+                return true;
+            }
+            i += 1;
+        }
+
+        false
+    }
+
+    /// Returns `true` if this set contains no rules, `false` otherwise.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use fortitude::registry::{Rule, RuleSet};
+    /// assert!(RuleSet::empty().is_empty());
+    ///         assert!(
+    ///             !RuleSet::from_rules(&[Rule::MissingIntent, Rule::LineTooLong])
+    ///                 .is_empty()
+    ///         );
+    /// ```
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the number of rules in this set.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use fortitude::registry::{Rule, RuleSet};
+    /// assert_eq!(RuleSet::empty().len(), 0);
+    /// assert_eq!(
+    ///     RuleSet::from_rules(&[Rule::MissingIntent, Rule::LineTooLong]).len(),
+    ///     2
+    /// );
+    pub const fn len(&self) -> usize {
+        let mut len: u32 = 0;
+
+        let mut i = 0;
+
+        while i < self.0.len() {
+            len += self.0[i].count_ones();
+            i += 1;
+        }
+
+        len as usize
+    }
+
+    /// Inserts `rule` into the set.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use fortitude::registry::{Rule, RuleSet};
+    /// let mut set = RuleSet::empty();
+    ///
+    /// assert!(!set.contains(Rule::ImplicitTyping));
+    ///
+    /// set.insert(Rule::ImplicitTyping);
+    ///
+    /// assert!(set.contains(Rule::ImplicitTyping));
+    /// ```
+    pub fn insert(&mut self, rule: Rule) {
+        let set = std::mem::take(self);
+        *self = set.union(&RuleSet::from_rule(rule));
+    }
+
+    #[inline]
+    pub fn set(&mut self, rule: Rule, enabled: bool) {
+        if enabled {
+            self.insert(rule);
+        } else {
+            self.remove(rule);
+        }
+    }
+
+    /// Removes `rule` from the set.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use fortitude::registry::{Rule, RuleSet};
+    /// let mut set = RuleSet::from_rules(&[Rule::MissingIntent, Rule::ImplicitTyping]);
+    ///
+    /// set.remove(Rule::MissingIntent);
+    ///
+    /// assert!(set.contains(Rule::ImplicitTyping));
+    /// assert!(!set.contains(Rule::MissingIntent));
+    /// ```
+    pub fn remove(&mut self, rule: Rule) {
+        let set = std::mem::take(self);
+        *self = set.subtract(&RuleSet::from_rule(rule));
+    }
+
+    /// Returns `true` if `rule` is in this set.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use fortitude::registry::{Rule, RuleSet};
+    /// let set = RuleSet::from_rules(&[Rule::MissingIntent, Rule::ImplicitTyping]);
+    ///
+    /// assert!(set.contains(Rule::MissingIntent));
+    /// assert!(!set.contains(Rule::StarKind));
+    /// ```
+    #[inline]
+    pub const fn contains(&self, rule: Rule) -> bool {
+        let rule = rule as u16;
+        let index = rule as usize / Self::SLICE_BITS as usize;
+        let shift = rule % Self::SLICE_BITS;
+        let mask = 1 << shift;
+
+        self.0[index] & mask != 0
+    }
+
+    /// Returns `true` if any of the rules in `rules` are in this set.
+    #[inline]
+    pub const fn any(&self, rules: &[Rule]) -> bool {
+        let mut any = false;
+        let mut i = 0;
+
+        while i < rules.len() {
+            any |= self.contains(rules[i]);
+            i += 1;
+        }
+
+        any
+    }
+
+    /// Returns an iterator over the rules in this set.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use fortitude::registry::{Rule, RuleSet};
+    /// let set = RuleSet::from_rules(&[Rule::MissingIntent, Rule::ImplicitTyping]);
+    ///
+    /// let iter: Vec<_> = set.iter().collect();
+    ///
+    /// assert_eq!(iter, vec![Rule::ImplicitTyping, Rule::MissingIntent]);
+    /// ```
+    pub fn iter(&self) -> RuleSetIterator {
+        RuleSetIterator {
+            set: self.clone(),
+            index: 0,
+        }
+    }
+}
+
+impl Debug for RuleSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+impl Display for RuleSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.is_empty() {
+            write!(f, "[]")?;
+        } else {
+            writeln!(f, "[")?;
+            for rule in self {
+                let name = rule.as_ref();
+                let code = rule.noqa_code();
+                writeln!(f, "\t{name} ({code}),")?;
+            }
+            write!(f, "]")?;
+        }
+        Ok(())
+    }
+}
+
+impl FromIterator<Rule> for RuleSet {
+    fn from_iter<T: IntoIterator<Item = Rule>>(iter: T) -> Self {
+        let mut set = RuleSet::empty();
+
+        for rule in iter {
+            set.insert(rule);
+        }
+
+        set
+    }
+}
+
+impl Extend<Rule> for RuleSet {
+    fn extend<T: IntoIterator<Item = Rule>>(&mut self, iter: T) {
+        let set = std::mem::take(self);
+        *self = set.union(&RuleSet::from_iter(iter));
+    }
+}
+
+impl IntoIterator for RuleSet {
+    type IntoIter = RuleSetIterator;
+    type Item = Rule;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl IntoIterator for &RuleSet {
+    type IntoIter = RuleSetIterator;
+    type Item = Rule;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+pub struct RuleSetIterator {
+    set: RuleSet,
+    index: u16,
+}
+
+impl Iterator for RuleSetIterator {
+    type Item = Rule;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let slice = self.set.0.get_mut(self.index as usize)?;
+            // `trailing_zeros` is guaranteed to return a value in [0;64]
+            #[allow(clippy::cast_possible_truncation)]
+            let bit = slice.trailing_zeros() as u16;
+
+            if bit < RuleSet::SLICE_BITS {
+                *slice ^= 1 << bit;
+                let rule_value = self.index * RuleSet::SLICE_BITS + bit;
+                // SAFETY: RuleSet guarantees that only valid rules are stored in the set.
+                #[allow(unsafe_code)]
+                return Some(unsafe { std::mem::transmute::<u16, Rule>(rule_value) });
+            }
+
+            self.index += 1;
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.set.len();
+
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for RuleSetIterator {}
+
+impl FusedIterator for RuleSetIterator {}
+
+#[cfg(test)]
+mod tests {
+    use strum::IntoEnumIterator;
+
+    use crate::registry::{Rule, RuleSet};
+
+    /// Tests that the set can contain all rules
+    #[test]
+    fn test_all_rules() {
+        for rule in Rule::iter() {
+            let set = RuleSet::from_rule(rule);
+
+            assert!(set.contains(rule));
+        }
+
+        let all_rules_set: RuleSet = Rule::iter().collect();
+        let all_rules: Vec<_> = all_rules_set.iter().collect();
+        let expected_rules: Vec<_> = Rule::iter().collect();
+        assert_eq!(all_rules, expected_rules);
+    }
+
+    #[test]
+    fn remove_not_existing_rule_from_set() {
+        let mut set = RuleSet::default();
+
+        set.remove(Rule::MissingIntent);
+
+        assert!(!set.contains(Rule::MissingIntent));
+        assert!(set.is_empty());
+        assert_eq!(set.into_iter().collect::<Vec<_>>(), vec![]);
+    }
+}

--- a/fortitude/src/rule_table.rs
+++ b/fortitude/src/rule_table.rs
@@ -1,0 +1,92 @@
+// Taken from ruff
+// Copyright 2022 Charles Marsh
+// SPDX-License-Identifier: MIT
+
+use std::fmt::{Debug, Display, Formatter};
+
+use crate::display_settings;
+use ruff_macros::CacheKey;
+
+use crate::registry::{Rule, RuleSet, RuleSetIterator};
+
+/// A table to keep track of which rules are enabled and whether they should be fixed.
+#[derive(Debug, Clone, CacheKey, Default)]
+pub struct RuleTable {
+    /// Maps rule codes to a boolean indicating if the rule should be fixed.
+    enabled: RuleSet,
+    should_fix: RuleSet,
+}
+
+impl RuleTable {
+    /// Creates a new empty rule table.
+    pub const fn empty() -> Self {
+        Self {
+            enabled: RuleSet::empty(),
+            should_fix: RuleSet::empty(),
+        }
+    }
+
+    /// Returns whether the given rule should be checked.
+    #[inline]
+    pub const fn enabled(&self, rule: Rule) -> bool {
+        self.enabled.contains(rule)
+    }
+
+    /// Returns whether any of the given rules should be checked.
+    #[inline]
+    pub const fn any_enabled(&self, rules: &[Rule]) -> bool {
+        self.enabled.any(rules)
+    }
+
+    /// Returns whether violations of the given rule should be fixed.
+    #[inline]
+    pub const fn should_fix(&self, rule: Rule) -> bool {
+        self.should_fix.contains(rule)
+    }
+
+    /// Returns an iterator over all enabled rules.
+    pub fn iter_enabled(&self) -> RuleSetIterator {
+        self.enabled.iter()
+    }
+
+    /// Enables the given rule.
+    #[inline]
+    pub fn enable(&mut self, rule: Rule, should_fix: bool) {
+        self.enabled.insert(rule);
+
+        if should_fix {
+            self.should_fix.insert(rule);
+        }
+    }
+
+    /// Disables the given rule.
+    #[inline]
+    pub fn disable(&mut self, rule: Rule) {
+        self.enabled.remove(rule);
+        self.should_fix.remove(rule);
+    }
+}
+
+impl Display for RuleTable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        display_settings! {
+            formatter = f,
+            namespace = "linter.rules",
+            fields = [
+                self.enabled,
+                self.should_fix
+            ]
+        }
+        Ok(())
+    }
+}
+
+impl FromIterator<Rule> for RuleTable {
+    fn from_iter<T: IntoIterator<Item = Rule>>(iter: T) -> Self {
+        let rules = RuleSet::from_iter(iter);
+        Self {
+            enabled: rules.clone(),
+            should_fix: rules,
+        }
+    }
+}

--- a/fortitude/src/rules/error/ioerror.rs
+++ b/fortitude/src/rules/error/ioerror.rs
@@ -2,11 +2,7 @@
 // Copyright 2022 Charles Marsh
 // SPDX-License-Identifier: MIT
 
-use crate::settings::Settings;
-use crate::PathRule;
-use std::path::Path;
-
-use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 
 /// ## What it does
@@ -42,12 +38,5 @@ impl Violation for IoError {
     fn message(&self) -> String {
         let IoError { message } = self;
         format!("{message}")
-    }
-}
-
-// Need to implement some kind of rule, although we only raise this manually
-impl PathRule for IoError {
-    fn check(_settings: &Settings, _path: &Path) -> Option<Diagnostic> {
-        None
     }
 }

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -74,7 +74,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
 
     #[rustfmt::skip]
     Some(match (category, code) {
-        (Error, "000") => (RuleGroup::Stable, Path, error::ioerror::IoError),
+        (Error, "000") => (RuleGroup::Stable, None, error::ioerror::IoError),
         (Error, "001") => (RuleGroup::Stable, Ast, error::syntax_error::SyntaxError),
 
         (Filesystem, "001") => (RuleGroup::Stable, Path, filesystem::extensions::NonStandardFileExtension),
@@ -128,28 +128,28 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         // Rules for testing fortitude
         // Couldn't get a separate `Testing` category working for some reason
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9900") => (RuleGroup::Stable, Test, testing::test_rules::StableTestRule),
+        (Error, "9900") => (RuleGroup::Stable, None, testing::test_rules::StableTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9901") => (RuleGroup::Stable, Test, testing::test_rules::StableTestRuleSafeFix),
+        (Error, "9901") => (RuleGroup::Stable, None, testing::test_rules::StableTestRuleSafeFix),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9902") => (RuleGroup::Stable, Test, testing::test_rules::StableTestRuleUnsafeFix),
+        (Error, "9902") => (RuleGroup::Stable, None, testing::test_rules::StableTestRuleUnsafeFix),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9903") => (RuleGroup::Stable, Test, testing::test_rules::StableTestRuleDisplayOnlyFix),
+        (Error, "9903") => (RuleGroup::Stable, None, testing::test_rules::StableTestRuleDisplayOnlyFix),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9904") => (RuleGroup::Preview, Test, testing::test_rules::PreviewTestRule),
+        (Error, "9904") => (RuleGroup::Preview, None, testing::test_rules::PreviewTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9905") => (RuleGroup::Deprecated, Test, testing::test_rules::DeprecatedTestRule),
+        (Error, "9905") => (RuleGroup::Deprecated, None, testing::test_rules::DeprecatedTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9906") => (RuleGroup::Deprecated, Test, testing::test_rules::AnotherDeprecatedTestRule),
+        (Error, "9906") => (RuleGroup::Deprecated, None, testing::test_rules::AnotherDeprecatedTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9907") => (RuleGroup::Removed, Test, testing::test_rules::RemovedTestRule),
+        (Error, "9907") => (RuleGroup::Removed, None, testing::test_rules::RemovedTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9908") => (RuleGroup::Removed, Test, testing::test_rules::AnotherRemovedTestRule),
+        (Error, "9908") => (RuleGroup::Removed, None, testing::test_rules::AnotherRemovedTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9909") => (RuleGroup::Removed, Test, testing::test_rules::RedirectedFromTestRule),
+        (Error, "9909") => (RuleGroup::Removed, None, testing::test_rules::RedirectedFromTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9910") => (RuleGroup::Stable, Test, testing::test_rules::RedirectedToTestRule),
+        (Error, "9910") => (RuleGroup::Stable, None, testing::test_rules::RedirectedToTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9911") => (RuleGroup::Removed, Test, testing::test_rules::RedirectedFromPrefixTestRule),
+        (Error, "9911") => (RuleGroup::Removed, None, testing::test_rules::RedirectedFromPrefixTestRule),
     })
 }

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -1,3 +1,7 @@
+// Some parts adapted from from ruff
+// Copyright 2022 Charles Marsh
+// SPDX-License-Identifier: MIT
+
 /// A collection of user-modifiable settings. Should be expanded as new features are added.
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
@@ -310,4 +314,176 @@ pub enum FixMode {
     Apply,
     #[allow(dead_code)]
     Diff,
+}
+
+/// `display_settings!` is a macro that can display and format struct fields in a readable,
+/// namespaced format. It's particularly useful at generating `Display` implementations
+/// for types used in settings.
+///
+/// # Example
+/// ```
+/// use std::fmt;
+/// use fortitude::display_settings;
+/// #[derive(Default)]
+/// struct Settings {
+///     option_a: bool,
+///     sub_settings: SubSettings,
+///     option_b: String,
+/// }
+///
+/// struct SubSettings {
+///     name: String
+/// }
+///
+/// impl Default for SubSettings {
+///     fn default() -> Self {
+///         Self { name: "Default Name".into() }
+///     }
+///
+/// }
+///
+/// impl fmt::Display for SubSettings {
+///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+///         display_settings! {
+///             formatter = f,
+///             namespace = "sub_settings",
+///             fields = [
+///                 self.name | quoted
+///             ]
+///         }
+///         Ok(())
+///     }
+///
+/// }
+///
+/// impl fmt::Display for Settings {
+///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+///         display_settings! {
+///             formatter = f,
+///             fields = [
+///                 self.option_a,
+///                 self.sub_settings | nested,
+///                 self.option_b | quoted,
+///             ]
+///         }
+///         Ok(())
+///     }
+///
+/// }
+///
+/// const EXPECTED_OUTPUT: &str = r#"option_a = false
+/// sub_settings.name = "Default Name"
+/// option_b = ""
+/// "#;
+///
+/// fn main() {
+///     let settings = Settings::default();
+///     assert_eq!(format!("{settings}"), EXPECTED_OUTPUT);
+/// }
+/// ```
+#[macro_export]
+macro_rules! display_settings {
+    (formatter = $fmt:ident, namespace = $namespace:literal, fields = [$($settings:ident.$field:ident $(| $modifier:tt)?),* $(,)?]) => {
+        {
+            const _PREFIX: &str = concat!($namespace, ".");
+            $(
+                display_settings!(@field $fmt, _PREFIX, $settings.$field $(| $modifier)?);
+            )*
+        }
+    };
+    (formatter = $fmt:ident, fields = [$($settings:ident.$field:ident $(| $modifier:tt)?),* $(,)?]) => {
+        {
+            const _PREFIX: &str = "";
+            $(
+                display_settings!(@field $fmt, _PREFIX, $settings.$field $(| $modifier)?);
+            )*
+        }
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident | debug) => {
+        writeln!($fmt, "{}{} = {:?}", $prefix, stringify!($field), $settings.$field)?;
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident | path) => {
+        writeln!($fmt, "{}{} = \"{}\"", $prefix, stringify!($field), $settings.$field.display())?;
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident | quoted) => {
+        writeln!($fmt, "{}{} = \"{}\"", $prefix, stringify!($field), $settings.$field)?;
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident | globmatcher) => {
+        writeln!($fmt, "{}{} = \"{}\"", $prefix, stringify!($field), $settings.$field.glob())?;
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident | nested) => {
+        write!($fmt, "{}", $settings.$field)?;
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident | optional) => {
+        {
+            write!($fmt, "{}{} = ", $prefix, stringify!($field))?;
+            match &$settings.$field {
+                Some(value) => writeln!($fmt, "{}", value)?,
+                None        => writeln!($fmt, "none")?
+            };
+        }
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident | array) => {
+        {
+            write!($fmt, "{}{} = ", $prefix, stringify!($field))?;
+            if $settings.$field.is_empty() {
+                writeln!($fmt, "[]")?;
+            } else {
+                writeln!($fmt, "[")?;
+                for elem in &$settings.$field {
+                    writeln!($fmt, "\t{elem},")?;
+                }
+                writeln!($fmt, "]")?;
+            }
+        }
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident | map) => {
+        {
+            use itertools::Itertools;
+
+            write!($fmt, "{}{} = ", $prefix, stringify!($field))?;
+            if $settings.$field.is_empty() {
+                writeln!($fmt, "{{}}")?;
+            } else {
+                writeln!($fmt, "{{")?;
+                for (key, value) in $settings.$field.iter().sorted_by(|(left, _), (right, _)| left.cmp(right)) {
+                    writeln!($fmt, "\t{key} = {value},")?;
+                }
+                writeln!($fmt, "}}")?;
+            }
+        }
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident | set) => {
+        {
+            use itertools::Itertools;
+
+            write!($fmt, "{}{} = ", $prefix, stringify!($field))?;
+            if $settings.$field.is_empty() {
+                writeln!($fmt, "[]")?;
+            } else {
+                writeln!($fmt, "[")?;
+                for elem in $settings.$field.iter().sorted_by(|left, right| left.cmp(right)) {
+                    writeln!($fmt, "\t{elem},")?;
+                }
+                writeln!($fmt, "]")?;
+            }
+        }
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident | paths) => {
+        {
+            write!($fmt, "{}{} = ", $prefix, stringify!($field))?;
+            if $settings.$field.is_empty() {
+                writeln!($fmt, "[]")?;
+            } else {
+                writeln!($fmt, "[")?;
+                for elem in &$settings.$field {
+                    writeln!($fmt, "\t\"{}\",", elem.display())?;
+                }
+                writeln!($fmt, "]")?;
+            }
+        }
+    };
+    (@field $fmt:ident, $prefix:ident, $settings:ident.$field:ident) => {
+        writeln!($fmt, "{}{} = {}", $prefix, stringify!($field), $settings.$field)?;
+    };
 }

--- a/fortitude/src/test.rs
+++ b/fortitude/src/test.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     message::{Emitter, TextEmitter},
     rule_selector::CompiledPerFileIgnoreList,
+    rule_table::RuleTable,
     rules::Rule,
     settings::{FixMode, Settings, UnsafeFixes},
 };
@@ -36,9 +37,10 @@ pub(crate) fn test_contents(
     rules: &[Rule],
     settings: &Settings,
 ) -> String {
-    let path_rules = rules_to_path_rules(rules);
-    let text_rules = rules_to_text_rules(rules);
-    let ast_entrypoints = ast_entrypoint_map(rules);
+    let rule_table = RuleTable::from_iter(rules.iter().cloned());
+    let path_rules = rules_to_path_rules(&rule_table);
+    let text_rules = rules_to_text_rules(&rule_table);
+    let ast_entrypoints = ast_entrypoint_map(&rule_table);
     let per_file_ignores = CompiledPerFileIgnoreList::resolve(vec![]).unwrap();
 
     match check_file(

--- a/fortitude_macros/src/map_codes.rs
+++ b/fortitude_macros/src/map_codes.rs
@@ -702,14 +702,14 @@ impl Parse for RuleMeta {
         let kind_is_valid = kind.is_ident("Path")
             || kind.is_ident("Text")
             || kind.is_ident("Ast")
-            || kind.is_ident("Test");
+            || kind.is_ident("None");
         if !kind_is_valid {
             // We better have an ident here, because I don't know what else to do
             let kind = kind.get_ident().unwrap();
             return Err(syn::Error::new(
                 pat_tuple.span(),
                 format!(
-                    "Invalid checker kind '{kind}', expected one of 'Path', 'Text', 'Ast', 'Test'"
+                    "Invalid checker kind '{kind}', expected one of 'Path', 'Text', 'Ast', 'None'"
                 ),
             ));
         }


### PR DESCRIPTION
`RuleSet` and `RuleTable` are massive overkill for just this feature, but this will also allow ignoring allow-comment warnings, properly testing preview/deprecated/removed rules, and converting to the more explicit/verbose ruff checking structure.