### PR TITLE
Warn about invalid rules in allow-comments

### DIFF
--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -593,6 +593,7 @@ pub struct FixerResult<'a> {
     pub fixed: FixTable,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn check_and_fix_file<'a>(
     rules: &RuleTable,
     path_rules: &Vec<PathRuleEnum>,

--- a/fortitude/src/rules/error/allow_comments.rs
+++ b/fortitude/src/rules/error/allow_comments.rs
@@ -1,0 +1,29 @@
+use ruff_diagnostics::Violation;
+use ruff_macros::{derive_message_formats, violation};
+
+/// ## What it does
+/// Checks for invalid rules in allow comments.
+///
+/// ## Why is this bad?
+/// Invalid rules in allow comments are likely typos or mistakes.
+///
+/// ## Example
+/// The user meant `implicit-typing` but made a mistake:
+/// ```f90
+/// ! allow(implicit-typos)
+/// program test
+/// end program test
+/// ```
+#[violation]
+pub struct InvalidRuleCodeOrName {
+    pub message: String,
+}
+
+/// E011
+impl Violation for InvalidRuleCodeOrName {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self { message } = self;
+        format!("{message}")
+    }
+}

--- a/fortitude/src/rules/error/mod.rs
+++ b/fortitude/src/rules/error/mod.rs
@@ -1,2 +1,3 @@
+pub mod allow_comments;
 pub mod ioerror;
 pub mod syntax_error;

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -76,6 +76,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
     Some(match (category, code) {
         (Error, "000") => (RuleGroup::Stable, None, error::ioerror::IoError),
         (Error, "001") => (RuleGroup::Stable, Ast, error::syntax_error::SyntaxError),
+        (Error, "011") => (RuleGroup::Stable, None, error::allow_comments::InvalidRuleCodeOrName),
 
         (Filesystem, "001") => (RuleGroup::Stable, Path, filesystem::extensions::NonStandardFileExtension),
 

--- a/fortitude/src/test.rs
+++ b/fortitude/src/test.rs
@@ -44,6 +44,7 @@ pub(crate) fn test_contents(
     let per_file_ignores = CompiledPerFileIgnoreList::resolve(vec![]).unwrap();
 
     match check_file(
+        &rule_table,
         &path_rules,
         &text_rules,
         &ast_entrypoints,

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -1170,7 +1170,7 @@ end program test
     [TEMP_FILE] E011 Unknown rule selector: `badbad`
       |
     2 | ! allow(badbad, notgood)
-      | ^^^^^^^^^^^^^^^^^^^^^^^^ E011
+      |         ^^^^^^ E011
     3 | program test
     4 | end program test
       |
@@ -1178,7 +1178,7 @@ end program test
     [TEMP_FILE] E011 Unknown rule selector: `notgood`
       |
     2 | ! allow(badbad, notgood)
-      | ^^^^^^^^^^^^^^^^^^^^^^^^ E011
+      |                 ^^^^^^^ E011
     3 | program test
     4 | end program test
       |


### PR DESCRIPTION
~~Includes #265~~

Partial fix for #252 -- could still add a check for unused allow-comments