### PR TITLE
Add rules for multiple modules/programs in same file; Add rule for `include` statements

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -50,6 +50,8 @@
 | M021 | [missing-accessibility-statement](rules/missing-accessibility-statement.md) | module '{}' missing default accessibility statement | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 | M022 | [default-public-accessibility](rules/default-public-accessibility.md) | module '{}' has default `public` accessibility | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 | M031 | [include-statement](rules/include-statement.md) | Include statement is deprecated, use modules instead | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
+| M041 | [multiple-modules](rules/multiple-modules.md) | Multiple modules in one file, split into one module per file | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
+| M042 | [program-with-module](rules/program-with-module.md) | Program and module in one file, split into their own files | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 
 ### Precision (P)
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -49,6 +49,7 @@
 | M012 | [missing-intrinsic](rules/missing-intrinsic.md) | 'use' for intrinsic module missing 'intrinsic' modifier | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 | M021 | [missing-accessibility-statement](rules/missing-accessibility-statement.md) | module '{}' missing default accessibility statement | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 | M022 | [default-public-accessibility](rules/default-public-accessibility.md) | module '{}' has default `public` accessibility | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
+| M031 | [include-statement](rules/include-statement.md) | Include statement is deprecated, use modules instead | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 
 ### Precision (P)
 

--- a/docs/rules/include-statement.md
+++ b/docs/rules/include-statement.md
@@ -1,0 +1,19 @@
+# include-statement (M031)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for any include statements
+
+## Why is this bad?
+Include statements allow for pasting the contents of other files into
+the current scope, which could be used for sharing COMMON blocks, procedures
+or declaring variables. This can hide details from the programmer, increase
+the maintenance burden and can be bug-prone. Avoided including files in
+others and instead use modules.
+
+## References
+- Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
+  Incorporating Fortran 2018_, Oxford University Press, Appendix A
+  'Deprecated Features'
+- _Difference between INCLUDE and modules in Fortran_, 2013,
+  https://stackoverflow.com/a/15668209

--- a/docs/rules/multiple-modules.md
+++ b/docs/rules/multiple-modules.md
@@ -1,0 +1,10 @@
+# multiple-modules (M041)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for multiple modules in one file
+
+## Why is this bad?
+Placing each module into its own file improves maintainability
+by making each module easier to locate for developers, and also
+making dependency generation in build systems easier.

--- a/docs/rules/program-with-module.md
+++ b/docs/rules/program-with-module.md
@@ -1,0 +1,10 @@
+# program-with-module (M042)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for programs and modules in one file
+
+## Why is this bad?
+Separating top-level constructs into their own files improves
+maintainability by making each easier to locate for developers,
+and also making dependency generation in build systems easier.

--- a/fortitude/resources/test/fixtures/modules/M031.f90
+++ b/fortitude/resources/test/fixtures/modules/M031.f90
@@ -1,0 +1,13 @@
+module test
+
+include "common_variables"
+
+contains
+
+integer function func1()
+    include "variable_declaration"
+
+    func1 = i + 3
+end function
+
+end module test

--- a/fortitude/resources/test/fixtures/modules/M041.f90
+++ b/fortitude/resources/test/fixtures/modules/M041.f90
@@ -1,0 +1,15 @@
+module mod1
+
+contains
+    subroutine test1()
+    end subroutine test1
+end module mod1
+
+
+module mod2
+    use :: mod1, only: test1
+
+contains
+    subroutine test2()
+    end subroutine test2
+end module mod2

--- a/fortitude/resources/test/fixtures/modules/M042.f90
+++ b/fortitude/resources/test/fixtures/modules/M042.f90
@@ -1,0 +1,11 @@
+module mod1
+
+contains
+    subroutine test1()
+    end subroutine test1
+end module mod1
+
+program main
+    use :: mod1, only: test1
+
+end program main

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -33,6 +33,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io;
 use std::io::Write;
+use std::iter::once;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::str::FromStr;
@@ -520,18 +521,8 @@ pub(crate) fn check_only_file(
         .parse(file.source_text(), None)
         .context("Failed to parse")?;
 
-    let root_node = tree.root_node();
-    if let Some(rules) = ast_entrypoints.get(root_node.kind()) {
-        for rule in rules {
-            if let Some(violation) = rule.check(settings, &root_node, file) {
-                for v in violation {
-                    violations.push(v);
-                }
-            }
-        }
-    }
-
-    for node in tree.root_node().named_descendants() {
+    let root = tree.root_node();
+    for node in once(root).chain(root.named_descendants()) {
         if let Some(rules) = ast_entrypoints.get(node.kind()) {
             for rule in rules {
                 if let Some(violation) = rule.check(settings, &node, file) {

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -606,19 +606,8 @@ pub(crate) fn check_and_fix_file<'a>(
             .parse(transformed.source_text(), None)
             .context("Failed to parse")?;
 
-        // Perform AST analysis, starting with root-level rules
-        let root_node = tree.root_node();
-        if let Some(rules) = ast_entrypoints.get(root_node.kind()) {
-            for rule in rules {
-                if let Some(violation) = rule.check(settings, &root_node, &transformed) {
-                    for v in violation {
-                        violations.push(v);
-                    }
-                }
-            }
-        }
-
-        for node in tree.root_node().named_descendants() {
+        let root = tree.root_node();
+        for node in once(root).chain(root.named_descendants()) {
             if let Some(rules) = ast_entrypoints.get(node.kind()) {
                 for rule in rules {
                     if let Some(violation) = rule.check(settings, &node, &transformed) {

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -118,6 +118,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Modules, "021") => (RuleGroup::Preview, Ast, modules::accessibility_statements::MissingAccessibilityStatement),
         (Modules, "022") => (RuleGroup::Preview, Ast, modules::accessibility_statements::DefaultPublicAccessibility),
         (Modules, "031") => (RuleGroup::Preview, Ast, modules::include_statement::IncludeStatement),
+        (Modules, "041") => (RuleGroup::Preview, Ast, modules::file_contents::MultipleModules),
 
         (Io, "001") => (RuleGroup::Preview, Ast, io::missing_specifier::MissingActionSpecifier),
         (Io, "011") => (RuleGroup::Preview, Ast, io::magic_io_unit::MagicIoUnit),

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -117,6 +117,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Modules, "012") => (RuleGroup::Preview, Ast, modules::use_statements::MissingIntrinsic),
         (Modules, "021") => (RuleGroup::Preview, Ast, modules::accessibility_statements::MissingAccessibilityStatement),
         (Modules, "022") => (RuleGroup::Preview, Ast, modules::accessibility_statements::DefaultPublicAccessibility),
+        (Modules, "031") => (RuleGroup::Preview, Ast, modules::include_statement::IncludeStatement),
 
         (Io, "001") => (RuleGroup::Preview, Ast, io::missing_specifier::MissingActionSpecifier),
         (Io, "011") => (RuleGroup::Preview, Ast, io::magic_io_unit::MagicIoUnit),

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -119,6 +119,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Modules, "022") => (RuleGroup::Preview, Ast, modules::accessibility_statements::DefaultPublicAccessibility),
         (Modules, "031") => (RuleGroup::Preview, Ast, modules::include_statement::IncludeStatement),
         (Modules, "041") => (RuleGroup::Preview, Ast, modules::file_contents::MultipleModules),
+        (Modules, "042") => (RuleGroup::Preview, Ast, modules::file_contents::ProgramWithModule),
 
         (Io, "001") => (RuleGroup::Preview, Ast, io::missing_specifier::MissingActionSpecifier),
         (Io, "011") => (RuleGroup::Preview, Ast, io::magic_io_unit::MagicIoUnit),

--- a/fortitude/src/rules/modules/file_contents.rs
+++ b/fortitude/src/rules/modules/file_contents.rs
@@ -1,0 +1,45 @@
+use crate::settings::Settings;
+use crate::{AstRule, FromAstNode};
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_source_file::SourceFile;
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks for multiple modules in one file
+///
+/// ## Why is this bad?
+/// Placing each module into its own file improves maintainability
+/// by making each module easier to locate for developers, and also
+/// making dependency generation in build systems easier.
+#[violation]
+pub struct MultipleModules {}
+
+impl Violation for MultipleModules {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Multiple modules in one file, split into one module per file")
+    }
+}
+
+impl AstRule for MultipleModules {
+    fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        let violations: Vec<Diagnostic> = node
+            .children(&mut node.walk())
+            .filter(|node| node.kind() == "module")
+            .map(|m| -> Diagnostic {
+                let m_first = m.child(0).unwrap_or(m);
+                Diagnostic::from_node(MultipleModules {}, &m_first)
+            })
+            .collect();
+
+        if violations.len() > 1 {
+            return Some(violations);
+        }
+        None
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["translation_unit"]
+    }
+}

--- a/fortitude/src/rules/modules/file_contents.rs
+++ b/fortitude/src/rules/modules/file_contents.rs
@@ -61,6 +61,14 @@ impl Violation for ProgramWithModule {
 
 impl AstRule for ProgramWithModule {
     fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        // There must be a program statement to trigger this rule
+        if !node
+            .children(&mut node.walk())
+            .any(|node| node.kind() == "program")
+        {
+            return None;
+        }
+
         // Mark the violation on the second, and subsequent, occurences
         let violations: Vec<Diagnostic> = node
             .children(&mut node.walk())

--- a/fortitude/src/rules/modules/file_contents.rs
+++ b/fortitude/src/rules/modules/file_contents.rs
@@ -27,16 +27,14 @@ impl AstRule for MultipleModules {
         let violations: Vec<Diagnostic> = node
             .children(&mut node.walk())
             .filter(|node| node.kind() == "module")
+            .skip(1)
             .map(|m| -> Diagnostic {
                 let m_first = m.child(0).unwrap_or(m);
                 Diagnostic::from_node(MultipleModules {}, &m_first)
             })
             .collect();
 
-        if violations.len() > 1 {
-            return Some(violations);
-        }
-        None
+        Some(violations)
     }
 
     fn entrypoints() -> Vec<&'static str> {
@@ -63,19 +61,18 @@ impl Violation for ProgramWithModule {
 
 impl AstRule for ProgramWithModule {
     fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        // Mark the violation on the second, and subsequent, occurences
         let violations: Vec<Diagnostic> = node
             .children(&mut node.walk())
             .filter(|node| node.kind() == "module" || node.kind() == "program")
+            .skip(1)
             .map(|m| -> Diagnostic {
                 let m_first = m.child(0).unwrap_or(m);
                 Diagnostic::from_node(ProgramWithModule {}, &m_first)
             })
             .collect();
 
-        if violations.len() > 1 {
-            return Some(violations);
-        }
-        None
+        Some(violations)
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/fortitude/src/rules/modules/include_statement.rs
+++ b/fortitude/src/rules/modules/include_statement.rs
@@ -1,0 +1,42 @@
+use crate::settings::Settings;
+use crate::{AstRule, FromAstNode};
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_source_file::SourceFile;
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks for any include statements
+///
+/// ## Why is this bad?
+/// Include statements allow for pasting the contents of other files into
+/// the current scope, which could be used for sharing COMMON blocks, procedures
+/// or declaring variables. This can hide details from the programmer, increase
+/// the maintenance burden and can be bug-prone. Avoided including files in
+/// others and instead use modules.
+///
+/// ## References
+/// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
+///   Incorporating Fortran 2018_, Oxford University Press, Appendix A
+///   'Deprecated Features'
+/// - _Difference between INCLUDE and modules in Fortran_, 2013,
+///   https://stackoverflow.com/a/15668209
+#[violation]
+pub struct IncludeStatement {}
+
+impl Violation for IncludeStatement {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Include statement is deprecated, use modules instead")
+    }
+}
+
+impl AstRule for IncludeStatement {
+    fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        some_vec![Diagnostic::from_node(IncludeStatement {}, node)]
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["include_statement"]
+    }
+}

--- a/fortitude/src/rules/modules/mod.rs
+++ b/fortitude/src/rules/modules/mod.rs
@@ -1,5 +1,6 @@
 pub mod accessibility_statements;
 pub mod external_functions;
+pub mod file_contents;
 pub mod include_statement;
 pub mod use_statements;
 
@@ -22,6 +23,7 @@ mod tests {
     #[test_case(Rule::MissingAccessibilityStatement, Path::new("M021.f90"))]
     #[test_case(Rule::DefaultPublicAccessibility, Path::new("M022.f90"))]
     #[test_case(Rule::IncludeStatement, Path::new("M031.f90"))]
+    #[test_case(Rule::MultipleModules, Path::new("M041.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/modules/mod.rs
+++ b/fortitude/src/rules/modules/mod.rs
@@ -24,6 +24,7 @@ mod tests {
     #[test_case(Rule::DefaultPublicAccessibility, Path::new("M022.f90"))]
     #[test_case(Rule::IncludeStatement, Path::new("M031.f90"))]
     #[test_case(Rule::MultipleModules, Path::new("M041.f90"))]
+    #[test_case(Rule::ProgramWithModule, Path::new("M042.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/modules/mod.rs
+++ b/fortitude/src/rules/modules/mod.rs
@@ -1,5 +1,6 @@
 pub mod accessibility_statements;
 pub mod external_functions;
+pub mod include_statement;
 pub mod use_statements;
 
 #[cfg(test)]
@@ -20,6 +21,7 @@ mod tests {
     #[test_case(Rule::MissingIntrinsic, Path::new("M012.f90"))]
     #[test_case(Rule::MissingAccessibilityStatement, Path::new("M021.f90"))]
     #[test_case(Rule::DefaultPublicAccessibility, Path::new("M022.f90"))]
+    #[test_case(Rule::IncludeStatement, Path::new("M031.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/modules/snapshots/fortitude__rules__modules__tests__include-statement_M031.f90.snap
+++ b/fortitude/src/rules/modules/snapshots/fortitude__rules__modules__tests__include-statement_M031.f90.snap
@@ -1,0 +1,22 @@
+---
+source: fortitude/src/rules/modules/mod.rs
+expression: diagnostics
+---
+./resources/test/fixtures/modules/M031.f90:3:1: M031 Include statement is deprecated, use modules instead
+  |
+1 | module test
+2 |
+3 | include "common_variables"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ M031
+4 |
+5 | contains
+  |
+
+./resources/test/fixtures/modules/M031.f90:8:5: M031 Include statement is deprecated, use modules instead
+   |
+ 7 | integer function func1()
+ 8 |     include "variable_declaration"
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ M031
+ 9 |
+10 |     func1 = i + 3
+   |

--- a/fortitude/src/rules/modules/snapshots/fortitude__rules__modules__tests__multiple-modules_M041.f90.snap
+++ b/fortitude/src/rules/modules/snapshots/fortitude__rules__modules__tests__multiple-modules_M041.f90.snap
@@ -2,14 +2,6 @@
 source: fortitude/src/rules/modules/mod.rs
 expression: diagnostics
 ---
-./resources/test/fixtures/modules/M041.f90:1:1: M041 Multiple modules in one file, split into one module per file
-  |
-1 | module mod1
-  | ^^^^^^^^^^^ M041
-2 |
-3 | contains
-  |
-
 ./resources/test/fixtures/modules/M041.f90:9:1: M041 Multiple modules in one file, split into one module per file
    |
  9 | module mod2

--- a/fortitude/src/rules/modules/snapshots/fortitude__rules__modules__tests__multiple-modules_M041.f90.snap
+++ b/fortitude/src/rules/modules/snapshots/fortitude__rules__modules__tests__multiple-modules_M041.f90.snap
@@ -1,0 +1,18 @@
+---
+source: fortitude/src/rules/modules/mod.rs
+expression: diagnostics
+---
+./resources/test/fixtures/modules/M041.f90:1:1: M041 Multiple modules in one file, split into one module per file
+  |
+1 | module mod1
+  | ^^^^^^^^^^^ M041
+2 |
+3 | contains
+  |
+
+./resources/test/fixtures/modules/M041.f90:9:1: M041 Multiple modules in one file, split into one module per file
+   |
+ 9 | module mod2
+   | ^^^^^^^^^^^ M041
+10 |     use :: mod1, only: test1
+   |

--- a/fortitude/src/rules/modules/snapshots/fortitude__rules__modules__tests__program-with-module_M042.f90.snap
+++ b/fortitude/src/rules/modules/snapshots/fortitude__rules__modules__tests__program-with-module_M042.f90.snap
@@ -1,0 +1,20 @@
+---
+source: fortitude/src/rules/modules/mod.rs
+expression: diagnostics
+---
+./resources/test/fixtures/modules/M042.f90:1:1: M042 Program and module in one file, split into their own files
+  |
+1 | module mod1
+  | ^^^^^^^^^^^ M042
+2 |
+3 | contains
+  |
+
+./resources/test/fixtures/modules/M042.f90:8:1: M042 Program and module in one file, split into their own files
+  |
+6 | end module mod1
+7 |
+8 | program main
+  | ^^^^^^^^^^^^ M042
+9 |     use :: mod1, only: test1
+  |

--- a/fortitude/src/rules/modules/snapshots/fortitude__rules__modules__tests__program-with-module_M042.f90.snap
+++ b/fortitude/src/rules/modules/snapshots/fortitude__rules__modules__tests__program-with-module_M042.f90.snap
@@ -2,14 +2,6 @@
 source: fortitude/src/rules/modules/mod.rs
 expression: diagnostics
 ---
-./resources/test/fixtures/modules/M042.f90:1:1: M042 Program and module in one file, split into their own files
-  |
-1 | module mod1
-  | ^^^^^^^^^^^ M042
-2 |
-3 | contains
-  |
-
 ./resources/test/fixtures/modules/M042.f90:8:1: M042 Program and module in one file, split into their own files
   |
 6 | end module mod1


### PR DESCRIPTION
This implements three new rules in the module category:
* Warn on include statements (https://github.com/PlasmaFAIR/fortitude/issues/163)
* Warn if two or more modules are in the same file (https://github.com/PlasmaFAIR/fortitude/issues/257)
* Warn if a program and a module (or multiple) are in the same file (https://github.com/PlasmaFAIR/fortitude/issues/257)

The last two rules required a change to the check driver to also run the AST rules on the root node, since before it was only on the children of the root node. I also decided that instead of placing the violation diagnostic on the main module/program node, it would be better placed on just the opening statement's node - that way the display wouldn't try to print the entire module to the output.

One thing that could be improved still is the handling of the allow comments for the last two rules. Ideally there would be only one comment needed on one of the violations, and it would silence it for the entire file, but right now the way the allow comments are built and rules are defined, you have to use one comment on each violation.

CC @Beliavsky

(Fixes https://github.com/PlasmaFAIR/fortitude/issues/163, Fixes https://github.com/PlasmaFAIR/fortitude/issues/257 )