### PR TITLE
Fix README.md installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ It can also be installed as a pure Rust project:
 
 ```bash
 git clone https://github.com/PlasmaFAIR/fortitude
+cd fortitude
 cargo install --path fortitude
 ```
 


### PR DESCRIPTION
add the critical missing step in the installation instructions in the README.

Fixes #272 