### PR TITLE
Add logging framework and `--verbose/quiet/silent` flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "annotate-snippets"
 version = "0.11.4"
 source = "git+https://github.com/PlasmaFAIR/annotate-snippets-rs.git?branch=level-none#3e1ae5fadf250c5183653dc5d9db2ca79ecffd7d"
@@ -150,7 +165,10 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
  "num-traits",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -241,6 +259,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -369,6 +393,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,8 +439,10 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "bitflags",
+ "chrono",
  "clap",
  "colored",
+ "fern",
  "fortitude_macros",
  "globset",
  "indicatif",
@@ -417,6 +452,7 @@ dependencies = [
  "itertools 0.12.1",
  "lazy-regex",
  "lazy_static",
+ "log",
  "path-absolutize",
  "pathdiff",
  "predicates",
@@ -520,6 +556,29 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -1816,6 +1875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/fortitude/Cargo.toml
+++ b/fortitude/Cargo.toml
@@ -21,6 +21,7 @@ fortitude_macros = { workspace = true }
 annotate-snippets = { git = "https://github.com/PlasmaFAIR/annotate-snippets-rs.git", branch = "level-none" }
 anyhow = { workspace = true }
 bitflags = "2.6.0"
+chrono = { version = "0.4.35", default-features = false, features = ["clock"] }
 clap = { workspace = true }
 colored = { workspace = true }
 is-macro = "0.3.7"
@@ -57,6 +58,8 @@ unicode-width = "0.2.0"
 url = { version = "2.5.0" }
 walkdir = "2.4.0"
 globset = "0.4.15"
+log = "0.4.22"
+fern = "0.7.1"
 
 [build-dependencies]
 shadow-rs = { version = "0.36.0", default-features = false }

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -23,6 +23,7 @@ use colored::Colorize;
 use indicatif::{ParallelProgressIterator, ProgressStyle};
 use itertools::Itertools;
 use lazy_regex::{regex, regex_captures};
+use log::warn;
 use rayon::prelude::*;
 use ruff_diagnostics::Diagnostic;
 use ruff_source_file::{Locator, SourceFile, SourceFileBuilder};
@@ -1000,8 +1001,7 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
                             Diagnostic::new(IoError { message }, TextRange::default()),
                         )]));
                     } else {
-                        // TODO: log::warn
-                        eprintln!(
+                        warn!(
                             "{}{}{} {error}",
                             "Error opening file ".bold(),
                             fs::relativize_path(path).bold(),
@@ -1035,8 +1035,7 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
                             Diagnostic::new(IoError { message }, TextRange::default()),
                         )]))
                     } else {
-                        // TODO: log::warn
-                        eprintln!(
+                        warn!(
                             "{}{}{} {msg}",
                             "Failed to process ".bold(),
                             fs::relativize_path(path).bold(),

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -1067,11 +1067,14 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
         printer_flags |= PrinterFlags::SHOW_FIX_SUMMARY;
     }
 
-    Printer::new(output_format, printer_flags, fix_mode, unsafe_fixes).write_once(
-        files.len(),
-        &all_diagnostics,
-        &mut writer,
-    )?;
+    Printer::new(
+        output_format,
+        global_options.log_level(),
+        printer_flags,
+        fix_mode,
+        unsafe_fixes,
+    )
+    .write_once(files.len(), &all_diagnostics, &mut writer)?;
 
     if total_errors == 0 {
         Ok(ExitCode::SUCCESS)

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -23,7 +23,7 @@ use colored::Colorize;
 use indicatif::{ParallelProgressIterator, ProgressStyle};
 use itertools::Itertools;
 use lazy_regex::{regex, regex_captures};
-use log::warn;
+use log::{debug, warn};
 use rayon::prelude::*;
 use ruff_diagnostics::Diagnostic;
 use ruff_source_file::{Locator, SourceFile, SourceFileBuilder};
@@ -38,6 +38,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::str::FromStr;
+use std::time::Instant;
 use strum::IntoEnumIterator;
 use toml::Table;
 use tree_sitter::{Node, Parser};
@@ -958,7 +959,10 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
     let text_rules = rules_to_text_rules(&rules);
     let ast_entrypoints = ast_entrypoint_map(&rules);
 
+    let start = Instant::now();
     let files = get_files(files, file_extensions, &file_excludes, exclude_mode);
+    debug!("Identified files to lint in: {:?}", start.elapsed());
+
     let file_digits = files.len().to_string().len();
     let progress_bar_style = match progress_bar {
         ProgressBar::Fancy => {
@@ -984,6 +988,7 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
         ProgressBar::Off => ProgressStyle::with_template("").unwrap(),
     };
 
+    let start = Instant::now();
     let diagnostics_per_file = files
         .par_iter()
         .progress_with_style(progress_bar_style)
@@ -1047,13 +1052,22 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
             }
         });
 
-    let mut all_diagnostics = diagnostics_per_file
-        .fold(Diagnostics::default, |all_diagnostics, file_diagnostics| {
-            all_diagnostics + file_diagnostics
-        })
-        .reduce(Diagnostics::default, |a, b| a + b);
+    let (mut all_diagnostics, checked_files) = diagnostics_per_file
+        .fold(
+            || (Diagnostics::default(), 0u64),
+            |(all_diagnostics, checked_files), file_diagnostics| {
+                (all_diagnostics + file_diagnostics, checked_files + 1)
+            },
+        )
+        .reduce(
+            || (Diagnostics::default(), 0u64),
+            |a, b| (a.0 + b.0, a.1 + b.1),
+        );
 
     all_diagnostics.messages.par_sort_unstable();
+
+    let duration = start.elapsed();
+    debug!("Checked {:?} files in: {:?}", checked_files, duration);
 
     let total_errors = all_diagnostics.messages.len();
 

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -3,8 +3,11 @@ use serde::Deserialize;
 use std::path::PathBuf;
 
 use crate::{
-    build, rule_selector::RuleSelector, settings::FilePattern, settings::OutputFormat,
-    settings::PatternPrefixPair, settings::ProgressBar, RuleSelectorParser,
+    build,
+    logging::LogLevel,
+    rule_selector::RuleSelector,
+    settings::{FilePattern, OutputFormat, PatternPrefixPair, ProgressBar},
+    RuleSelectorParser,
 };
 
 #[derive(Debug, Parser)]
@@ -21,9 +24,64 @@ pub struct Cli {
 /// i.e., can be passed to all subcommands
 #[derive(Debug, Default, Clone, clap::Args)]
 pub struct GlobalConfigArgs {
+    #[clap(flatten)]
+    log_level_args: LogLevelArgs,
+
     /// Path to a TOML configuration file
     #[arg(long)]
     pub config_file: Option<PathBuf>,
+}
+
+impl GlobalConfigArgs {
+    pub fn log_level(&self) -> LogLevel {
+        LogLevel::from(&self.log_level_args)
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Default, Clone, clap::Args)]
+pub struct LogLevelArgs {
+    /// Enable verbose logging.
+    #[arg(
+        short,
+        long,
+        global = true,
+        group = "verbosity",
+        help_heading = "Log levels"
+    )]
+    pub verbose: bool,
+    /// Print diagnostics, but nothing else.
+    #[arg(
+        short,
+        long,
+        global = true,
+        group = "verbosity",
+        help_heading = "Log levels"
+    )]
+    pub quiet: bool,
+    /// Disable all logging (but still exit with status code "1" upon detecting diagnostics).
+    #[arg(
+        short,
+        long,
+        global = true,
+        group = "verbosity",
+        help_heading = "Log levels"
+    )]
+    pub silent: bool,
+}
+
+impl From<&LogLevelArgs> for LogLevel {
+    fn from(args: &LogLevelArgs) -> Self {
+        if args.silent {
+            Self::Silent
+        } else if args.quiet {
+            Self::Quiet
+        } else if args.verbose {
+            Self::Verbose
+        } else {
+            Self::Default
+        }
+    }
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -5,6 +5,7 @@ mod diagnostics;
 pub mod explain;
 mod fix;
 mod fs;
+pub mod logging;
 pub mod message;
 mod printer;
 pub mod registry;

--- a/fortitude/src/logging.rs
+++ b/fortitude/src/logging.rs
@@ -145,8 +145,6 @@ pub fn set_up_logging(level: LogLevel) -> Result<()> {
         })
         .level(level.level_filter())
         .level_for("globset", log::LevelFilter::Warn)
-        .level_for("red_knot_python_semantic", log::LevelFilter::Warn)
-        .level_for("salsa", log::LevelFilter::Warn)
         .chain(std::io::stderr())
         .apply()?;
     Ok(())

--- a/fortitude/src/logging.rs
+++ b/fortitude/src/logging.rs
@@ -1,0 +1,167 @@
+// Adapted from ruff
+// Copyright 2022 Charles Marsh
+// SPDX-License-Identifier: MIT
+
+use std::sync::{LazyLock, Mutex};
+
+use anyhow::Result;
+use colored::Colorize;
+use log::Level;
+use rustc_hash::FxHashSet;
+
+pub static IDENTIFIERS: LazyLock<Mutex<Vec<&'static str>>> = LazyLock::new(Mutex::default);
+
+/// Warn a user once, with uniqueness determined by the given ID.
+#[macro_export]
+macro_rules! warn_user_once_by_id {
+    ($id:expr, $($arg:tt)*) => {
+        use colored::Colorize;
+        use log::warn;
+
+        if let Ok(mut states) = $crate::logging::IDENTIFIERS.lock() {
+            if !states.contains(&$id) {
+                let message = format!("{}", format_args!($($arg)*));
+                warn!("{}", message.bold());
+                states.push($id);
+            }
+        }
+    };
+}
+
+pub static MESSAGES: LazyLock<Mutex<FxHashSet<String>>> = LazyLock::new(Mutex::default);
+
+/// Warn a user once, if warnings are enabled, with uniqueness determined by the content of the
+/// message.
+#[macro_export]
+macro_rules! warn_user_once_by_message {
+    ($($arg:tt)*) => {
+        use colored::Colorize;
+        use log::warn;
+
+        if let Ok(mut states) = $crate::logging::MESSAGES.lock() {
+            let message = format!("{}", format_args!($($arg)*));
+            if !states.contains(&message) {
+                warn!("{}", message.bold());
+                states.insert(message);
+            }
+        }
+    };
+}
+
+/// Warn a user once, with uniqueness determined by the calling location itself.
+#[macro_export]
+macro_rules! warn_user_once {
+    ($($arg:tt)*) => {
+        use colored::Colorize;
+        use log::warn;
+
+        static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+        if !WARNED.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            let message = format!("{}", format_args!($($arg)*));
+            warn!("{}", message.bold());
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! warn_user {
+    ($($arg:tt)*) => {{
+        use colored::Colorize;
+        use log::warn;
+
+        let message = format!("{}", format_args!($($arg)*));
+        warn!("{}", message.bold());
+    }};
+}
+
+#[macro_export]
+macro_rules! notify_user {
+    ($($arg:tt)*) => {
+        println!(
+            "[{}] {}",
+            chrono::Local::now()
+                .format("%H:%M:%S %p")
+                .to_string()
+                .dimmed(),
+            format_args!($($arg)*)
+        )
+    }
+}
+
+#[derive(Debug, Default, PartialOrd, Ord, PartialEq, Eq, Copy, Clone)]
+pub enum LogLevel {
+    /// No output ([`log::LevelFilter::Off`]).
+    Silent,
+    /// Only show lint violations, with no decorative output
+    /// ([`log::LevelFilter::Off`]).
+    Quiet,
+    /// All user-facing output ([`log::LevelFilter::Info`]).
+    #[default]
+    Default,
+    /// All user-facing output ([`log::LevelFilter::Debug`]).
+    Verbose,
+}
+
+impl LogLevel {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    const fn level_filter(&self) -> log::LevelFilter {
+        match self {
+            LogLevel::Default => log::LevelFilter::Info,
+            LogLevel::Verbose => log::LevelFilter::Debug,
+            LogLevel::Quiet => log::LevelFilter::Off,
+            LogLevel::Silent => log::LevelFilter::Off,
+        }
+    }
+}
+
+pub fn set_up_logging(level: LogLevel) -> Result<()> {
+    fern::Dispatch::new()
+        .format(|out, message, record| match record.level() {
+            Level::Error => {
+                out.finish(format_args!(
+                    "{}{} {}",
+                    "error".red().bold(),
+                    ":".bold(),
+                    message
+                ));
+            }
+            Level::Warn => {
+                out.finish(format_args!(
+                    "{}{} {}",
+                    "warning".yellow().bold(),
+                    ":".bold(),
+                    message
+                ));
+            }
+            Level::Info | Level::Debug | Level::Trace => {
+                out.finish(format_args!(
+                    "{}[{}][{}] {}",
+                    chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+                    record.target(),
+                    record.level(),
+                    message
+                ));
+            }
+        })
+        .level(level.level_filter())
+        .level_for("globset", log::LevelFilter::Warn)
+        .level_for("red_knot_python_semantic", log::LevelFilter::Warn)
+        .level_for("salsa", log::LevelFilter::Warn)
+        .chain(std::io::stderr())
+        .apply()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::logging::LogLevel;
+
+    #[test]
+    fn ordering() {
+        assert!(LogLevel::Default > LogLevel::Silent);
+        assert!(LogLevel::Default >= LogLevel::Default);
+        assert!(LogLevel::Quiet > LogLevel::Silent);
+        assert!(LogLevel::Verbose > LogLevel::Default);
+        assert!(LogLevel::Verbose > LogLevel::Silent);
+    }
+}

--- a/fortitude/src/main.rs
+++ b/fortitude/src/main.rs
@@ -5,9 +5,13 @@ use clap::Parser;
 use fortitude::check::check;
 use fortitude::cli::{Cli, SubCommands};
 use fortitude::explain::explain;
+use fortitude::logging::set_up_logging;
 
 fn main() -> Result<ExitCode> {
     let args = Cli::parse();
+
+    set_up_logging(args.global_options.log_level())?;
+
     let status = match args.command {
         SubCommands::Check(check_args) => check(check_args, &args.global_options),
         SubCommands::Explain(args) => explain(args),


### PR DESCRIPTION
Logging framework using [log](https://docs.rs/log/latest/log/index.html) and [fern](https://docs.rs/fern/latest/fern/) crates, and setup stolen from ruff, as is traditional.

Also add `--verbose/quiet/silent` flags. As the logging isn't used for much, this doesn't change very much, although we can skip the summary with `--quiet`, and skip printing absolutely everything but still return the exit code with `--silent`.

We can now sprinkle `debug!()` through the code to get some useful insight into internal state, for example some basic profiling:

```
[2025-01-10][17:53:49][fortitude::check][DEBUG] Identified files to lint in: 66.510789ms
[2025-01-10][17:53:50][fortitude::check][DEBUG] Checked 236 files in: 935.848477ms
```