### PR TITLE
Respect `.gitignore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "colored",
  "fortitude_macros",
  "globset",
+ "ignore",
  "indicatif",
  "insta",
  "insta-cmd",
@@ -445,7 +446,6 @@ dependencies = [
  "tree-sitter-fortran",
  "unicode-width 0.2.0",
  "url",
- "walkdir",
 ]
 
 [[package]]
@@ -658,6 +658,22 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/fortitude/Cargo.toml
+++ b/fortitude/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = { workspace = true }
 bitflags = "2.6.0"
 clap = { workspace = true }
 colored = { workspace = true }
+ignore = "0.4.23"
 is-macro = "0.3.7"
 indicatif = { version = "0.17.9", features = ["rayon", "improved_unicode"] }
 itertools = { workspace = true }
@@ -55,7 +56,6 @@ tree-sitter = "~0.24.0"
 tree-sitter-fortran = "0.3.0"
 unicode-width = "0.2.0"
 url = { version = "2.5.0" }
-walkdir = "2.4.0"
 globset = "0.4.15"
 
 [build-dependencies]

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -14,12 +14,13 @@ use crate::rules::error::allow_comments::InvalidRuleCodeOrName;
 use crate::rules::Rule;
 use crate::rules::{error::ioerror::IoError, AstRuleEnum, PathRuleEnum, TextRuleEnum};
 use crate::settings::{
-    ExcludeMode, FilePattern, FilePatternSet, FixMode, OutputFormat, PatternPrefixPair,
-    PreviewMode, ProgressBar, Settings, UnsafeFixes, DEFAULT_SELECTORS,
+    ExcludeMode, FilePattern, FilePatternSet, FixMode, GitignoreMode, OutputFormat,
+    PatternPrefixPair, PreviewMode, ProgressBar, Settings, UnsafeFixes, DEFAULT_SELECTORS,
 };
 
 use anyhow::{anyhow, Context, Result};
 use colored::Colorize;
+use ignore::WalkBuilder;
 use indicatif::{ParallelProgressIterator, ProgressStyle};
 use itertools::Itertools;
 use lazy_regex::{regex, regex_captures};
@@ -40,7 +41,6 @@ use std::str::FromStr;
 use strum::IntoEnumIterator;
 use toml::Table;
 use tree_sitter::{Node, Parser};
-use walkdir::WalkDir;
 
 /// Default extensions to check
 const FORTRAN_EXTS: &[&str] = &[
@@ -185,6 +185,7 @@ pub struct CheckSettings {
     pub exclude: Option<Vec<FilePattern>>,
     pub extend_exclude: Vec<FilePattern>,
     pub exclude_mode: ExcludeMode,
+    pub gitignore_mode: GitignoreMode,
 }
 
 impl Default for CheckSettings {
@@ -197,7 +198,7 @@ impl Default for CheckSettings {
             per_file_ignores: Default::default(),
             extend_per_file_ignores: Default::default(),
             line_length: Settings::default().line_length,
-            file_extensions: Default::default(),
+            file_extensions: FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect(),
             fix: Default::default(),
             fix_only: Default::default(),
             show_fixes: Default::default(),
@@ -208,6 +209,7 @@ impl Default for CheckSettings {
             exclude: Default::default(),
             extend_exclude: Default::default(),
             exclude_mode: Default::default(),
+            gitignore_mode: Default::default(),
         }
     }
 }
@@ -252,6 +254,9 @@ fn parse_config_file(config_file: &Option<PathBuf>) -> Result<CheckSettings> {
             extend_exclude: value.extend_exclude.unwrap_or_default(),
             exclude_mode: resolve_bool_arg(value.force_exclude, value.no_force_exclude)
                 .map(ExcludeMode::from)
+                .unwrap_or_default(),
+            gitignore_mode: resolve_bool_arg(value.respect_gitignore, value.no_respect_gitignore)
+                .map(GitignoreMode::from)
                 .unwrap_or_default(),
         },
         None => CheckSettings::default(),
@@ -323,6 +328,7 @@ fn get_files<P: AsRef<Path>, S: AsRef<str>>(
     extensions: &[S],
     excludes: &FilePatternSet,
     exclude_mode: ExcludeMode,
+    gitignore_mode: GitignoreMode,
 ) -> Vec<PathBuf> {
     paths
         .iter()
@@ -330,10 +336,13 @@ fn get_files<P: AsRef<Path>, S: AsRef<str>>(
             if matches!(exclude_mode, ExcludeMode::Force) && excludes.matches(path) {
                 vec![]
             } else if path.as_ref().is_dir() {
-                WalkDir::new(path)
-                    .min_depth(1)
-                    .into_iter()
-                    .filter_entry(|e| !excludes.matches(e.path()))
+                let excludes = excludes.clone(); // Needed to get around lifetime issues
+                let mut builder = WalkBuilder::new(path);
+                builder.standard_filters(gitignore_mode.into());
+                builder.hidden(false);
+                builder.filter_entry(move |e| !excludes.matches(e.path()));
+                builder
+                    .build()
                     .filter_map(|p| p.ok()) // skip dirs if user doesn't have permission
                     .filter(|p| is_valid_extension(p.path(), extensions))
                     .map(|p| fs::normalize_path(p.path()))
@@ -912,6 +921,9 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
     let exclude_mode = resolve_bool_arg(args.force_exclude, args.no_force_exclude)
         .map(ExcludeMode::from)
         .unwrap_or(file_settings.exclude_mode);
+    let gitignore_mode = resolve_bool_arg(args.respect_gitignore, args.no_respect_gitignore)
+        .map(GitignoreMode::from)
+        .unwrap_or(file_settings.gitignore_mode);
 
     let output_format = args.output_format.unwrap_or(file_settings.output_format);
     let preview_mode = resolve_bool_arg(args.preview, args.no_preview)
@@ -957,7 +969,13 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
     let text_rules = rules_to_text_rules(&rules);
     let ast_entrypoints = ast_entrypoint_map(&rules);
 
-    let files = get_files(files, file_extensions, &file_excludes, exclude_mode);
+    let files = get_files(
+        files,
+        file_extensions,
+        &file_excludes,
+        exclude_mode,
+        gitignore_mode,
+    );
     let file_digits = files.len().to_string().len();
     let progress_bar_style = match progress_bar {
         ProgressBar::Fancy => {

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -189,6 +189,13 @@ pub struct CheckArgs {
     #[clap(long, overrides_with("force_exclude"), hide = true, action = SetTrue)]
     pub no_force_exclude: Option<bool>,
 
+    /// Respect `.gitignore`` files when determining which files to check.
+    /// Use `--no-respect-gitignore` to disable.
+    #[arg(long, overrides_with("no_respect_gitignore"), help_heading = "File selection", action = SetTrue)]
+    pub respect_gitignore: Option<bool>,
+    #[clap(long, overrides_with("respect_gitignore"), hide = true, action = SetTrue)]
+    pub no_respect_gitignore: Option<bool>,
+
     // Options for individual rules
     /// Set the maximum allowable line length.
     #[arg(long, help_heading = "Per-Rule Options")]

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -243,6 +243,33 @@ impl From<bool> for ExcludeMode {
     }
 }
 
+/// Toggle for respecting .gitignore files
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, CacheKey, is_macro::Is)]
+pub enum GitignoreMode {
+    #[default]
+    RespectGitignore,
+    NoRespectGitignore,
+}
+
+impl From<bool> for GitignoreMode {
+    fn from(value: bool) -> Self {
+        if value {
+            GitignoreMode::RespectGitignore
+        } else {
+            GitignoreMode::NoRespectGitignore
+        }
+    }
+}
+
+impl From<GitignoreMode> for bool {
+    fn from(value: GitignoreMode) -> Self {
+        match value {
+            GitignoreMode::RespectGitignore => true,
+            GitignoreMode::NoRespectGitignore => false,
+        }
+    }
+}
+
 /// Toggle for progress bar
 #[derive(
     Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, Hash, Default, clap::ValueEnum,


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/231

I spent a while trying to get Ruff's implementation of this working, but it required pulling in a lot of additional infrastructure that I didn't fully understand, so this seemed the safer option.

The use of the `WalkBuilder` seems messy, but when I tried building and using it from a function chain I got all kinds of lifetime issues. Making it `mut` and modifying it one line at a time seemed to do the trick.