### PR TITLE
Handle broken pipes

### DIFF
--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -66,6 +66,7 @@ unknown-key = 1
     ----- stdout -----
 
     ----- stderr -----
+    fortitude failed
     Error: TOML parse error at line 2, column 1
       |
     2 | unknown-key = 1


### PR DESCRIPTION
Previously, piping the output of fortitude into `head`, for example,
would result in output like:

```console
$ fortitude check | head -n1
fortitude/resources/test/fixtures/bugprone/B001.f90:10:1: S101 [*] trailing whitespace
Error: Broken pipe (os error 32)
```

It seems the rust stdlib doesn't handle broken pipes very well, so
some manual handling must be done.

Ruff additionally allows reporting of multiple errors, but that isn't
done here, as we probably need to switch to bubbling up their `ExitStatus`