### PR TITLE
Fix clippy warning about redundant `map_or`

### DIFF
--- a/fortitude/src/fix/mod.rs
+++ b/fortitude/src/fix/mod.rs
@@ -43,7 +43,7 @@ pub(crate) fn fix_file(
             diagnostic
                 .fix
                 .as_ref()
-                .map_or(false, |fix| fix.applies(required_applicability))
+                .is_some_and(|fix| fix.applies(required_applicability))
         })
         .peekable();
 


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or