### PR TITLE
Bugfix: fix `get_files` force excluding with directories

### DIFF
--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -3,6 +3,7 @@ use crate::cli::{CheckArgs, GlobalConfigArgs};
 use crate::diagnostics::{Diagnostics, FixMap};
 use crate::fix::{fix_file, FixResult};
 use crate::fs;
+use crate::fs::{get_files, FilePattern, FilePatternSet, EXCLUDE_BUILTINS, FORTRAN_EXTS};
 use crate::message::DiagnosticMessage;
 use crate::printer::{Flags as PrinterFlags, Printer};
 use crate::registry::AsRule;
@@ -14,13 +15,12 @@ use crate::rules::error::allow_comments::InvalidRuleCodeOrName;
 use crate::rules::Rule;
 use crate::rules::{error::ioerror::IoError, AstRuleEnum, PathRuleEnum, TextRuleEnum};
 use crate::settings::{
-    ExcludeMode, FilePattern, FilePatternSet, FixMode, GitignoreMode, OutputFormat,
-    PatternPrefixPair, PreviewMode, ProgressBar, Settings, UnsafeFixes, DEFAULT_SELECTORS,
+    ExcludeMode, FixMode, GitignoreMode, OutputFormat, PatternPrefixPair, PreviewMode, ProgressBar,
+    Settings, UnsafeFixes, DEFAULT_SELECTORS,
 };
 
 use anyhow::{anyhow, Context, Result};
 use colored::Colorize;
-use ignore::{types::TypesBuilder, WalkBuilder};
 use indicatif::{ParallelProgressIterator, ProgressStyle};
 use itertools::Itertools;
 use lazy_regex::{regex, regex_captures};
@@ -44,11 +44,6 @@ use strum::IntoEnumIterator;
 use toml::Table;
 use tree_sitter::{Node, Parser};
 
-/// Default extensions to check
-const FORTRAN_EXTS: &[&str] = &[
-    "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "f18", "F18", "f23", "F23",
-];
-
 // These are just helper structs to let us quickly work out if there's
 // a fortitude section in an fpm.toml file
 #[derive(Debug, PartialEq, Eq, Default, Deserialize)]
@@ -65,25 +60,6 @@ struct Extra {
 struct CheckSection {
     check: Option<CheckArgs>,
 }
-
-// Default paths to exclude when searching paths
-pub(crate) static EXCLUDE_BUILTINS: &[FilePattern] = &[
-    FilePattern::Builtin(".git"),
-    FilePattern::Builtin(".git-rewrite"),
-    FilePattern::Builtin(".hg"),
-    FilePattern::Builtin(".svn"),
-    FilePattern::Builtin("venv"),
-    FilePattern::Builtin(".venv"),
-    FilePattern::Builtin("pyenv"),
-    FilePattern::Builtin(".pyenv"),
-    FilePattern::Builtin(".eggs"),
-    FilePattern::Builtin("site-packages"),
-    FilePattern::Builtin(".vscode"),
-    FilePattern::Builtin("build"),
-    FilePattern::Builtin("_build"),
-    FilePattern::Builtin("dist"),
-    FilePattern::Builtin("_dist"),
-];
 
 // Adapted from ruff
 fn parse_fpm_toml<P: AsRef<Path>>(path: P) -> Result<Fpm> {
@@ -312,64 +288,6 @@ fn to_rule_table(args: RuleSelection, preview: &PreviewMode) -> anyhow::Result<R
     }
 
     Ok(rules)
-}
-
-/// Expand the input list of files to include all Fortran files.
-fn get_files<P: AsRef<Path>, S: AsRef<str>>(
-    paths: &[P],
-    extensions: &[S],
-    excludes: FilePatternSet,
-    exclude_mode: ExcludeMode,
-    gitignore_mode: GitignoreMode,
-) -> Result<Vec<PathBuf>> {
-    // If exclude_mode is set to Force, remove paths that match the exclude patterns
-    let paths: Vec<_> = if matches!(exclude_mode, ExcludeMode::Force) {
-        paths.iter().filter(|p| !excludes.matches(p)).collect()
-    } else {
-        paths.iter().collect()
-    };
-
-    // The remaining non-directory paths are always included; split into directories and files.
-    // Note that this includes paths that do not exist, as these should be reported to the user.
-    let (dirs, files): (Vec<_>, Vec<_>) = paths
-        .into_iter()
-        .map(|p| fs::normalize_path(p.as_ref()))
-        .partition(|p| p.is_dir());
-
-    // Collect all files from directories
-    let dir_contents = if let Some((first_dir, rest)) = dirs.split_first() {
-        // Create a directory walker that follows exclude patterns
-        let mut builder = WalkBuilder::new(first_dir);
-        for path in rest {
-            builder.add(path);
-        }
-        builder.standard_filters(gitignore_mode.into());
-        builder.hidden(false);
-        builder.filter_entry(move |e| !excludes.matches(e.path()));
-
-        // Add file type filter for provided file extensions
-        // Directories will be skipped
-        let mut file_types = TypesBuilder::new();
-        for ext in extensions {
-            file_types.add(ext.as_ref(), format!("*.{}", ext.as_ref()).as_str())?;
-        }
-        file_types.select("all");
-        builder.types(file_types.build()?);
-
-        // Collect all valid files from directories
-        builder
-            .build()
-            .filter_map(|p| p.ok()) // skip dirs if user doesn't have permission
-            .map(|p| p.into_path())
-            .filter(|p| !p.is_dir())
-            .collect()
-    } else {
-        // No dirs remain after removing excludes and splitting into dirs and files
-        vec![]
-    };
-
-    // Return all files found
-    Ok(files.into_iter().chain(dir_contents).collect())
 }
 
 /// Parse a file, check it for issues, and return the report.

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -4,9 +4,10 @@ use std::path::PathBuf;
 
 use crate::{
     build,
+    fs::FilePattern,
     logging::LogLevel,
     rule_selector::RuleSelector,
-    settings::{FilePattern, OutputFormat, PatternPrefixPair, ProgressBar},
+    settings::{OutputFormat, PatternPrefixPair, ProgressBar},
     RuleSelectorParser,
 };
 

--- a/fortitude/src/fs.rs
+++ b/fortitude/src/fs.rs
@@ -1,9 +1,96 @@
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use ignore::{types::TypesBuilder, WalkBuilder};
 use path_absolutize::Absolutize;
+use serde::{de, Deserialize, Deserializer};
 
 use crate::registry::Rule;
 use crate::rule_selector::CompiledPerFileIgnoreList;
+use crate::settings::{ExcludeMode, GitignoreMode};
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+pub enum FilePattern {
+    Builtin(&'static str),
+    User(String, PathBuf),
+}
+
+impl FilePattern {
+    const EXPECTED_PATTERN: &'static str = "<FilePattern>";
+
+    pub fn add_to(self, builder: &mut GlobSetBuilder) -> anyhow::Result<()> {
+        match self {
+            FilePattern::Builtin(pattern) => {
+                builder.add(Glob::from_str(pattern)?);
+            }
+            FilePattern::User(pattern, absolute) => {
+                // Add the absolute path.
+                builder.add(Glob::new(&absolute.to_string_lossy())?);
+
+                // Add basename path.
+                if !pattern.contains(std::path::MAIN_SEPARATOR) {
+                    builder.add(Glob::new(&pattern)?);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for FilePattern {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let pattern = s.to_string();
+        let absolute = normalize_path(&pattern);
+        Ok(Self::User(pattern, absolute))
+    }
+}
+
+impl<'de> Deserialize<'de> for FilePattern {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let str_result = String::deserialize(deserializer)?;
+        Self::from_str(str_result.as_str()).map_err(|_| {
+            de::Error::invalid_value(
+                de::Unexpected::Str(str_result.as_str()),
+                &Self::EXPECTED_PATTERN,
+            )
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FilePatternSet {
+    pub set: GlobSet,
+}
+
+impl FilePatternSet {
+    pub fn try_from_iter<I>(patterns: I) -> Result<Self, anyhow::Error>
+    where
+        I: IntoIterator<Item = FilePattern>,
+    {
+        let mut builder = GlobSetBuilder::new();
+        for pattern in patterns {
+            pattern.add_to(&mut builder)?;
+        }
+        let set = builder.build()?;
+        Ok(FilePatternSet { set })
+    }
+
+    pub fn matches<P: AsRef<Path>>(&self, path: P) -> bool {
+        match std::path::absolute(path.as_ref()) {
+            Ok(path) => match path.clone().file_name() {
+                Some(basename) => self.set.is_match(path) || self.set.is_match(basename),
+                None => false,
+            },
+            _ => false,
+        }
+    }
+}
 
 /// Create a set with codes matching the pattern/code pairs.
 pub(crate) fn ignores_from_path(path: &Path, ignore_list: &CompiledPerFileIgnoreList) -> Vec<Rule> {
@@ -71,4 +158,86 @@ pub fn relativize_path_to<P: AsRef<Path>, R: AsRef<Path>>(path: P, project_root:
             .expect("Could not diff paths")
             .display()
     )
+}
+
+/// Default extensions to check
+pub const FORTRAN_EXTS: &[&str] = &[
+    "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "f18", "F18", "f23", "F23",
+];
+
+// Default paths to exclude when searching paths
+pub(crate) static EXCLUDE_BUILTINS: &[FilePattern] = &[
+    FilePattern::Builtin(".git"),
+    FilePattern::Builtin(".git-rewrite"),
+    FilePattern::Builtin(".hg"),
+    FilePattern::Builtin(".svn"),
+    FilePattern::Builtin("venv"),
+    FilePattern::Builtin(".venv"),
+    FilePattern::Builtin("pyenv"),
+    FilePattern::Builtin(".pyenv"),
+    FilePattern::Builtin(".eggs"),
+    FilePattern::Builtin("site-packages"),
+    FilePattern::Builtin(".vscode"),
+    FilePattern::Builtin("build"),
+    FilePattern::Builtin("_build"),
+    FilePattern::Builtin("dist"),
+    FilePattern::Builtin("_dist"),
+];
+
+/// Expand the input list of files to include all Fortran files.
+pub fn get_files<P: AsRef<Path>, S: AsRef<str>>(
+    paths: &[P],
+    extensions: &[S],
+    excludes: FilePatternSet,
+    exclude_mode: ExcludeMode,
+    gitignore_mode: GitignoreMode,
+) -> anyhow::Result<Vec<PathBuf>> {
+    // If exclude_mode is set to Force, remove paths that match the exclude patterns
+    let paths: Vec<_> = if matches!(exclude_mode, ExcludeMode::Force) {
+        paths.iter().filter(|p| !excludes.matches(p)).collect()
+    } else {
+        paths.iter().collect()
+    };
+
+    // The remaining non-directory paths are always included; split into directories and files.
+    // Note that this includes paths that do not exist, as these should be reported to the user.
+    let (dirs, files): (Vec<_>, Vec<_>) = paths
+        .into_iter()
+        .map(|p| normalize_path(p.as_ref()))
+        .partition(|p| p.is_dir());
+
+    // Collect all files from directories
+    let dir_contents = if let Some((first_dir, rest)) = dirs.split_first() {
+        // Create a directory walker that follows exclude patterns
+        let mut builder = WalkBuilder::new(first_dir);
+        for path in rest {
+            builder.add(path);
+        }
+        builder.standard_filters(gitignore_mode.into());
+        builder.hidden(false);
+        builder.filter_entry(move |e| !excludes.matches(e.path()));
+
+        // Add file type filter for provided file extensions
+        // Directories will be skipped
+        let mut file_types = TypesBuilder::new();
+        for ext in extensions {
+            file_types.add(ext.as_ref(), format!("*.{}", ext.as_ref()).as_str())?;
+        }
+        file_types.select("all");
+        builder.types(file_types.build()?);
+
+        // Collect all valid files from directories
+        builder
+            .build()
+            .filter_map(|p| p.ok()) // skip dirs if user doesn't have permission
+            .map(|p| p.into_path())
+            .filter(|p| !p.is_dir())
+            .collect()
+    } else {
+        // No dirs remain after removing excludes and splitting into dirs and files
+        vec![]
+    };
+
+    // Return all files found
+    Ok(files.into_iter().chain(dir_contents).collect())
 }

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -4,15 +4,12 @@
 
 /// A collection of user-modifiable settings. Should be expanded as new features are added.
 use std::fmt::{Display, Formatter};
-use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use globset::{Glob, GlobSet, GlobSetBuilder};
 use ruff_diagnostics::Applicability;
 use ruff_macros::CacheKey;
 use serde::{de, Deserialize, Deserializer, Serialize};
 
-use crate::fs;
 use crate::rule_selector::RuleSelector;
 
 pub struct Settings {
@@ -140,88 +137,6 @@ impl FromStr for PatternPrefixPair {
         let pattern = pattern_str.into();
         let prefix = RuleSelector::from_str(code_string)?;
         Ok(Self { pattern, prefix })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
-pub enum FilePattern {
-    Builtin(&'static str),
-    User(String, PathBuf),
-}
-
-impl FilePattern {
-    const EXPECTED_PATTERN: &'static str = "<FilePattern>";
-
-    pub fn add_to(self, builder: &mut GlobSetBuilder) -> anyhow::Result<()> {
-        match self {
-            FilePattern::Builtin(pattern) => {
-                builder.add(Glob::from_str(pattern)?);
-            }
-            FilePattern::User(pattern, absolute) => {
-                // Add the absolute path.
-                builder.add(Glob::new(&absolute.to_string_lossy())?);
-
-                // Add basename path.
-                if !pattern.contains(std::path::MAIN_SEPARATOR) {
-                    builder.add(Glob::new(&pattern)?);
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-impl FromStr for FilePattern {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let pattern = s.to_string();
-        let absolute = fs::normalize_path(&pattern);
-        Ok(Self::User(pattern, absolute))
-    }
-}
-
-impl<'de> Deserialize<'de> for FilePattern {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let str_result = String::deserialize(deserializer)?;
-        Self::from_str(str_result.as_str()).map_err(|_| {
-            de::Error::invalid_value(
-                de::Unexpected::Str(str_result.as_str()),
-                &Self::EXPECTED_PATTERN,
-            )
-        })
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct FilePatternSet {
-    pub set: GlobSet,
-}
-
-impl FilePatternSet {
-    pub fn try_from_iter<I>(patterns: I) -> Result<Self, anyhow::Error>
-    where
-        I: IntoIterator<Item = FilePattern>,
-    {
-        let mut builder = GlobSetBuilder::new();
-        for pattern in patterns {
-            pattern.add_to(&mut builder)?;
-        }
-        let set = builder.build()?;
-        Ok(FilePatternSet { set })
-    }
-
-    pub fn matches<P: AsRef<Path>>(&self, path: P) -> bool {
-        match std::path::absolute(path.as_ref()) {
-            Ok(path) => match path.clone().file_name() {
-                Some(basename) => self.set.is_match(path) || self.set.is_match(basename),
-                None => false,
-            },
-            _ => false,
-        }
     }
 }
 

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -1014,11 +1014,13 @@ fn check_force_exclude() -> anyhow::Result<()> {
     apply_common_filters!();
     // Expect:
     // - Don't see error in foo.f90 despite it being asked for
+    // - Also shouldn't see numpy.f90
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
                          .arg("check")
                          .arg("--select=typing")
                          .arg("--force-exclude")
                          .arg("foo/foo.f90")
+                         .arg(".venv/lib/site-packages/numpy/numpy.f90")
                          .current_dir(exclude_test_path(tempdir.path())),
                          @r"
     success: true


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/288

Also tidied a lot of file-handling things into `fs.rs` and added some debugging logs.

TODO: Ruff will stop checking path ancestors on reaching the 'project root', but Fortitude keeps going. This means `--exclude=home --force-exclude` will prevent any files being scanned. I'll need to add a similar concept to Fortitude to get this working in full.