### PR TITLE
Add rule to test for uninitialized pointers in derived types

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -39,6 +39,7 @@
 | T043 | [deprecated-assumed-size-character](rules/deprecated-assumed-size-character.md) | character '{name}' uses deprecated syntax for assumed size | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 | T051 | [initialisation-in-declaration](rules/initialisation-in-declaration.md) | '{name}' is initialised in its declaration and has no explicit `save` or `parameter` attribute | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 | T061 | [external-procedure](rules/external-procedure.md) | '{name}' declared as `external` | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
+| T071 | [missing-default-pointer-initalisation](rules/missing-default-pointer-initalisation.md) | '{var}' does not have a default initialiser | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> |
 
 ### Modules (M)
 

--- a/docs/rules/missing-default-pointer-initalisation.md
+++ b/docs/rules/missing-default-pointer-initalisation.md
@@ -1,0 +1,48 @@
+# missing-default-pointer-initalisation (T071)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for uninitialised pointer variables inside derived types
+
+## Why is this bad?
+Pointers inside derived types are undefined by default, and their
+status cannot be tested by intrinsics such as `associated`. Pointer
+variables should be initialised by either associating them with another
+variable, or associating to `null()`.
+
+
+## Examples
+For example, this derived type:
+
+```f90
+type mytype
+    real :: val1
+    integer :: val2
+
+    real, pointer :: pReal1
+
+    integer, pointer :: pInt1 => null()
+    integer, pointer :: pI1
+    integer, pointer :: pI2 => null(), pI3
+end mytype
+```
+will have the pointers `pReal1`, `pI1`, and `pI3` uninitialised
+whenever it is created. Instead, they should be initialised like:
+```f90
+type mytype
+    real :: val1
+    integer :: val2
+
+    real, pointer :: pReal1
+
+    integer, pointer :: pInt1 => null()
+    integer, pointer :: pI1 => null()
+    integer, pointer :: pI2 => null(), pI3  => null()
+end mytype
+```
+
+## References
+- Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
+  Incorporating Fortran 2018_, Oxford University Press, Section 8.5.3/8.5.4.
+- Clerman, N. Spector, W., 2012, _Modern Fortran: Style and Usage_, Cambridge
+  University Press, Rule 136, p. 189.

--- a/fortitude/resources/test/fixtures/typing/T071.f90
+++ b/fortitude/resources/test/fixtures/typing/T071.f90
@@ -1,0 +1,26 @@
+module test
+    use :: iso_fortran_env
+
+    type other
+        integer :: hi
+    end type other
+
+    type mytype
+        real :: val1
+        integer :: val2
+
+        real :: val3 = 4.0
+
+        integer :: i1, i2, i3
+
+        real(kind=real64), pointer :: pReal1
+
+        integer, pointer :: pInt1 => null()
+
+        integer, pointer :: pI1, pI2
+
+        integer(kind=int32), pointer :: pI3 => null(), pI4
+
+        type(other), pointer :: pVal4 => null()
+    end type mytype
+end module test

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -102,6 +102,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Typing, "043") => (RuleGroup::Stable, Ast, typing::assumed_size::DeprecatedAssumedSizeCharacter),
         (Typing, "051") => (RuleGroup::Stable, Ast, typing::init_decls::InitialisationInDeclaration),
         (Typing, "061") => (RuleGroup::Stable, Ast, typing::external::ExternalProcedure),
+        (Typing, "071") => (RuleGroup::Preview, Ast, typing::derived_default_init::MissingDefaultPointerInitalisation),
 
         (Obsolescent, "001") => (RuleGroup::Stable, Ast, obsolescent::statement_functions::StatementFunction),
         (Obsolescent, "011") => (RuleGroup::Stable, Ast, obsolescent::common_blocks::CommonBlock),

--- a/fortitude/src/rules/typing/derived_default_init.rs
+++ b/fortitude/src/rules/typing/derived_default_init.rs
@@ -61,7 +61,7 @@ impl Violation for MissingDefaultPointerInitalisation {
     #[derive_message_formats]
     fn message(&self) -> String {
         let Self { var } = self;
-        format!("'{var}' does not have a default initialiser")
+        format!("pointer component '{var}' does not have a default initialiser")
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -100,7 +100,7 @@ impl AstRule for MissingDefaultPointerInitalisation {
             .map(|node| {
                 let var_name = node.to_text(src.source_text()).unwrap_or("").to_string();
 
-                let init_var = format!("{var_name} => null()");
+                let init_var = format!(" => null()");
                 let start_pos = TextSize::try_from(node.end_byte()).unwrap();
                 let fix = Fix::unsafe_edit(Edit::insertion(init_var, start_pos));
 

--- a/fortitude/src/rules/typing/derived_default_init.rs
+++ b/fortitude/src/rules/typing/derived_default_init.rs
@@ -1,0 +1,117 @@
+use crate::ast::FortitudeNode;
+use crate::settings::Settings;
+use crate::{AstRule, FromAstNode};
+use ruff_diagnostics::{Diagnostic, Edit, Fix, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_source_file::SourceFile;
+use ruff_text_size::TextSize;
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks for uninitialised pointer variables inside derived types
+///
+/// ## Why is this bad?
+/// Pointers inside derived types are undefined by default, and their
+/// status cannot be tested by intrinsics such as `associated`. Pointer
+/// variables should be initialised by either associating them with another
+/// variable, or associating to `null()`.
+///
+///
+/// ## Examples
+/// For example, this derived type:
+///
+/// ```f90
+/// type mytype
+///     real :: val1
+///     integer :: val2
+///
+///     real, pointer :: pReal1
+///
+///     integer, pointer :: pInt1 => null()
+///     integer, pointer :: pI1
+///     integer, pointer :: pI2 => null(), pI3
+/// end mytype
+/// ```
+/// will have the pointers `pReal1`, `pI1`, and `pI3` uninitialised
+/// whenever it is created. Instead, they should be initialised like:
+/// ```f90
+/// type mytype
+///     real :: val1
+///     integer :: val2
+///
+///     real, pointer :: pReal1
+///
+///     integer, pointer :: pInt1 => null()
+///     integer, pointer :: pI1 => null()
+///     integer, pointer :: pI2 => null(), pI3  => null()
+/// end mytype
+/// ```
+///
+/// ## References
+/// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
+///   Incorporating Fortran 2018_, Oxford University Press, Section 8.5.3/8.5.4.
+/// - Clerman, N. Spector, W., 2012, _Modern Fortran: Style and Usage_, Cambridge
+///   University Press, Rule 136, p. 189.
+#[violation]
+pub struct MissingDefaultPointerInitalisation {
+    var: String,
+}
+
+impl Violation for MissingDefaultPointerInitalisation {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self { var } = self;
+        format!("'{var}' does not have a default initialiser")
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Associate to a known value, such as 'null()'".to_string())
+    }
+}
+
+impl AstRule for MissingDefaultPointerInitalisation {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        // Only operate on derived types
+        if node.parent()?.kind() != "derived_type_definition" {
+            return None;
+        }
+
+        let mut node_cursor = node.walk();
+
+        // Only check pointer variables
+        if !node.named_children(&mut node_cursor).any(|node| {
+            node.kind() == "type_qualifier"
+                && node
+                    .to_text(src.source_text())
+                    .unwrap_or("")
+                    .to_lowercase()
+                    .starts_with("pointer")
+        }) {
+            return None;
+        }
+
+        let violations: Vec<Diagnostic> = node
+            .named_descendants()
+            .filter(|node| node.kind() == "identifier")
+            .filter(|node| match node.parent() {
+                None => false,
+                Some(parent) => parent.kind() == "variable_declaration",
+            })
+            .map(|node| {
+                let var_name = node.to_text(src.source_text()).unwrap_or("").to_string();
+
+                let init_var = format!("{var_name} => null()");
+                let start_pos = TextSize::try_from(node.end_byte()).unwrap();
+                let fix = Fix::unsafe_edit(Edit::insertion(init_var, start_pos));
+
+                Diagnostic::from_node(Self { var: var_name }, &node).with_fix(fix)
+            })
+            .collect();
+
+        Some(violations)
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["variable_declaration"]
+    }
+}

--- a/fortitude/src/rules/typing/mod.rs
+++ b/fortitude/src/rules/typing/mod.rs
@@ -1,4 +1,5 @@
 pub mod assumed_size;
+pub mod derived_default_init;
 pub mod external;
 pub mod implicit_typing;
 pub mod init_decls;
@@ -32,6 +33,7 @@ mod tests {
     #[test_case(Rule::DeprecatedAssumedSizeCharacter, Path::new("T043.f90"))]
     #[test_case(Rule::InitialisationInDeclaration, Path::new("T051.f90"))]
     #[test_case(Rule::ExternalProcedure, Path::new("T061.f90"))]
+    #[test_case(Rule::MissingDefaultPointerInitalisation, Path::new("T071.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/typing/snapshots/fortitude__rules__typing__tests__missing-default-pointer-initalisation_T071.f90.snap
+++ b/fortitude/src/rules/typing/snapshots/fortitude__rules__typing__tests__missing-default-pointer-initalisation_T071.f90.snap
@@ -1,8 +1,9 @@
 ---
 source: fortitude/src/rules/typing/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
-./resources/test/fixtures/typing/T071.f90:16:39: T071 [*] 'pReal1' does not have a default initialiser
+./resources/test/fixtures/typing/T071.f90:16:39: T071 [*] pointer component 'pReal1' does not have a default initialiser
    |
 14 |         integer :: i1, i2, i3
 15 |
@@ -18,12 +19,12 @@ expression: diagnostics
 14 14 |         integer :: i1, i2, i3
 15 15 | 
 16    |-        real(kind=real64), pointer :: pReal1
-   16 |+        real(kind=real64), pointer :: pReal1pReal1 => null()
+   16 |+        real(kind=real64), pointer :: pReal1 => null()
 17 17 | 
 18 18 |         integer, pointer :: pInt1 => null()
 19 19 | 
 
-./resources/test/fixtures/typing/T071.f90:20:29: T071 [*] 'pI1' does not have a default initialiser
+./resources/test/fixtures/typing/T071.f90:20:29: T071 [*] pointer component 'pI1' does not have a default initialiser
    |
 18 |         integer, pointer :: pInt1 => null()
 19 |
@@ -39,12 +40,12 @@ expression: diagnostics
 18 18 |         integer, pointer :: pInt1 => null()
 19 19 | 
 20    |-        integer, pointer :: pI1, pI2
-   20 |+        integer, pointer :: pI1pI1 => null(), pI2
+   20 |+        integer, pointer :: pI1 => null(), pI2
 21 21 | 
 22 22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
 23 23 | 
 
-./resources/test/fixtures/typing/T071.f90:20:34: T071 [*] 'pI2' does not have a default initialiser
+./resources/test/fixtures/typing/T071.f90:20:34: T071 [*] pointer component 'pI2' does not have a default initialiser
    |
 18 |         integer, pointer :: pInt1 => null()
 19 |
@@ -60,12 +61,12 @@ expression: diagnostics
 18 18 |         integer, pointer :: pInt1 => null()
 19 19 | 
 20    |-        integer, pointer :: pI1, pI2
-   20 |+        integer, pointer :: pI1, pI2pI2 => null()
+   20 |+        integer, pointer :: pI1, pI2 => null()
 21 21 | 
 22 22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
 23 23 | 
 
-./resources/test/fixtures/typing/T071.f90:22:56: T071 [*] 'pI4' does not have a default initialiser
+./resources/test/fixtures/typing/T071.f90:22:56: T071 [*] pointer component 'pI4' does not have a default initialiser
    |
 20 |         integer, pointer :: pI1, pI2
 21 |
@@ -81,7 +82,7 @@ expression: diagnostics
 20 20 |         integer, pointer :: pI1, pI2
 21 21 | 
 22    |-        integer(kind=int32), pointer :: pI3 => null(), pI4
-   22 |+        integer(kind=int32), pointer :: pI3 => null(), pI4pI4 => null()
+   22 |+        integer(kind=int32), pointer :: pI3 => null(), pI4 => null()
 23 23 | 
 24 24 |         type(other), pointer :: pVal4 => null()
 25 25 |     end type mytype

--- a/fortitude/src/rules/typing/snapshots/fortitude__rules__typing__tests__missing-default-pointer-initalisation_T071.f90.snap
+++ b/fortitude/src/rules/typing/snapshots/fortitude__rules__typing__tests__missing-default-pointer-initalisation_T071.f90.snap
@@ -1,0 +1,87 @@
+---
+source: fortitude/src/rules/typing/mod.rs
+expression: diagnostics
+---
+./resources/test/fixtures/typing/T071.f90:16:39: T071 [*] 'pReal1' does not have a default initialiser
+   |
+14 |         integer :: i1, i2, i3
+15 |
+16 |         real(kind=real64), pointer :: pReal1
+   |                                       ^^^^^^ T071
+17 |
+18 |         integer, pointer :: pInt1 => null()
+   |
+   = help: Associate to a known value, such as 'null()'
+
+ℹ Unsafe fix
+13 13 | 
+14 14 |         integer :: i1, i2, i3
+15 15 | 
+16    |-        real(kind=real64), pointer :: pReal1
+   16 |+        real(kind=real64), pointer :: pReal1pReal1 => null()
+17 17 | 
+18 18 |         integer, pointer :: pInt1 => null()
+19 19 | 
+
+./resources/test/fixtures/typing/T071.f90:20:29: T071 [*] 'pI1' does not have a default initialiser
+   |
+18 |         integer, pointer :: pInt1 => null()
+19 |
+20 |         integer, pointer :: pI1, pI2
+   |                             ^^^ T071
+21 |
+22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
+   |
+   = help: Associate to a known value, such as 'null()'
+
+ℹ Unsafe fix
+17 17 | 
+18 18 |         integer, pointer :: pInt1 => null()
+19 19 | 
+20    |-        integer, pointer :: pI1, pI2
+   20 |+        integer, pointer :: pI1pI1 => null(), pI2
+21 21 | 
+22 22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
+23 23 | 
+
+./resources/test/fixtures/typing/T071.f90:20:34: T071 [*] 'pI2' does not have a default initialiser
+   |
+18 |         integer, pointer :: pInt1 => null()
+19 |
+20 |         integer, pointer :: pI1, pI2
+   |                                  ^^^ T071
+21 |
+22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
+   |
+   = help: Associate to a known value, such as 'null()'
+
+ℹ Unsafe fix
+17 17 | 
+18 18 |         integer, pointer :: pInt1 => null()
+19 19 | 
+20    |-        integer, pointer :: pI1, pI2
+   20 |+        integer, pointer :: pI1, pI2pI2 => null()
+21 21 | 
+22 22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
+23 23 | 
+
+./resources/test/fixtures/typing/T071.f90:22:56: T071 [*] 'pI4' does not have a default initialiser
+   |
+20 |         integer, pointer :: pI1, pI2
+21 |
+22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
+   |                                                        ^^^ T071
+23 |
+24 |         type(other), pointer :: pVal4 => null()
+   |
+   = help: Associate to a known value, such as 'null()'
+
+ℹ Unsafe fix
+19 19 | 
+20 20 |         integer, pointer :: pI1, pI2
+21 21 | 
+22    |-        integer(kind=int32), pointer :: pI3 => null(), pI4
+   22 |+        integer(kind=int32), pointer :: pI3 => null(), pI4pI4 => null()
+23 23 | 
+24 24 |         type(other), pointer :: pVal4 => null()
+25 25 |     end type mytype


### PR DESCRIPTION
Unlike normal variables in procedures, derived types can have non-saved default initializer values, and it is safest to ensure that pointers are associated, so that they can then be tested using intrinsics.

This is just the first type of variable to check in the derived types. Further checks can suggest default initializers on intrinsic typed variables.