### PR TITLE
Warn when selected rules are ignored for some reason

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "clap",
  "colored",
  "fern",
+ "fortitude",
  "fortitude_macros",
  "globset",
  "ignore",

--- a/fortitude/Cargo.toml
+++ b/fortitude/Cargo.toml
@@ -74,6 +74,8 @@ predicates = "3.1.2"
 pretty_assertions = "1.4.1"
 tempfile = "3.13.0"
 test-case = "3.3.1"
+# This is a bit weird, but this enables the test rules when we run the tests
+fortitude = { workspace = true, features = ["test-rules"] }
 
 [features]
 # Enables rules for internal integration tests

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -143,20 +143,20 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         #[cfg(any(feature = "test-rules", test))]
         (Error, "9903") => (RuleGroup::Stable, None, testing::test_rules::StableTestRuleDisplayOnlyFix),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9904") => (RuleGroup::Preview, None, testing::test_rules::PreviewTestRule),
+        (Error, "9911") => (RuleGroup::Preview, None, testing::test_rules::PreviewTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9905") => (RuleGroup::Deprecated, None, testing::test_rules::DeprecatedTestRule),
+        (Error, "9920") => (RuleGroup::Deprecated, None, testing::test_rules::DeprecatedTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9906") => (RuleGroup::Deprecated, None, testing::test_rules::AnotherDeprecatedTestRule),
+        (Error, "9921") => (RuleGroup::Deprecated, None, testing::test_rules::AnotherDeprecatedTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9907") => (RuleGroup::Removed, None, testing::test_rules::RemovedTestRule),
+        (Error, "9930") => (RuleGroup::Removed, None, testing::test_rules::RemovedTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9908") => (RuleGroup::Removed, None, testing::test_rules::AnotherRemovedTestRule),
+        (Error, "9931") => (RuleGroup::Removed, None, testing::test_rules::AnotherRemovedTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9909") => (RuleGroup::Removed, None, testing::test_rules::RedirectedFromTestRule),
+        (Error, "9940") => (RuleGroup::Removed, None, testing::test_rules::RedirectedFromTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9910") => (RuleGroup::Stable, None, testing::test_rules::RedirectedToTestRule),
+        (Error, "9950") => (RuleGroup::Stable, None, testing::test_rules::RedirectedToTestRule),
         #[cfg(any(feature = "test-rules", test))]
-        (Error, "9911") => (RuleGroup::Removed, None, testing::test_rules::RedirectedFromPrefixTestRule),
+        (Error, "9960") => (RuleGroup::Removed, None, testing::test_rules::RedirectedFromPrefixTestRule),
     })
 }

--- a/fortitude/src/rules/testing/test_rules.rs
+++ b/fortitude/src/rules/testing/test_rules.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: MIT
 
 /// Fake rules for testing fortitude's behaviour
-use ruff_diagnostics::{FixAvailability, Violation};
+use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_text_size::{TextRange, TextSize};
 
 use crate::rules::Rule;
 
-#[allow(dead_code)]
 pub(crate) const TEST_RULES: &[Rule] = &[
     Rule::StableTestRule,
     Rule::StableTestRuleSafeFix,
@@ -24,8 +24,9 @@ pub(crate) const TEST_RULES: &[Rule] = &[
     Rule::RedirectedFromPrefixTestRule,
 ];
 
-#[allow(dead_code)]
-pub(crate) trait TestRule {}
+pub(crate) trait TestRule {
+    fn check() -> Option<Diagnostic>;
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -34,12 +35,12 @@ pub(crate) trait TestRule {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -54,7 +55,11 @@ impl Violation for StableTestRule {
     }
 }
 
-impl TestRule for StableTestRule {}
+impl TestRule for StableTestRule {
+    fn check() -> Option<Diagnostic> {
+        Some(Diagnostic::new(Self {}, TextRange::default()))
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -63,12 +68,12 @@ impl TestRule for StableTestRule {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -83,7 +88,16 @@ impl Violation for StableTestRuleSafeFix {
     }
 }
 
-impl TestRule for StableTestRuleSafeFix {}
+impl TestRule for StableTestRuleSafeFix {
+    fn check() -> Option<Diagnostic> {
+        let comment = "! fix from stable-test-rule-safe-fix\n".to_string();
+
+        Some(
+            Diagnostic::new(Self {}, TextRange::default())
+                .with_fix(Fix::safe_edit(Edit::insertion(comment, TextSize::new(0)))),
+        )
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -92,12 +106,12 @@ impl TestRule for StableTestRuleSafeFix {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -112,7 +126,15 @@ impl Violation for StableTestRuleUnsafeFix {
     }
 }
 
-impl TestRule for StableTestRuleUnsafeFix {}
+impl TestRule for StableTestRuleUnsafeFix {
+    fn check() -> Option<Diagnostic> {
+        let comment = "! fix from stable-test-rule-unsafe-fix\n".to_string();
+        Some(
+            Diagnostic::new(Self {}, TextRange::default())
+                .with_fix(Fix::unsafe_edit(Edit::insertion(comment, TextSize::new(0)))),
+        )
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -121,12 +143,12 @@ impl TestRule for StableTestRuleUnsafeFix {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -141,7 +163,16 @@ impl Violation for StableTestRuleDisplayOnlyFix {
     }
 }
 
-impl TestRule for StableTestRuleDisplayOnlyFix {}
+impl TestRule for StableTestRuleDisplayOnlyFix {
+    fn check() -> Option<Diagnostic> {
+        let comment = "! fix from stable-test-rule-display-only-fix\n".to_string();
+        Some(
+            Diagnostic::new(Self {}, TextRange::default()).with_fix(Fix::display_only_edit(
+                Edit::insertion(comment, TextSize::new(0)),
+            )),
+        )
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -150,12 +181,12 @@ impl TestRule for StableTestRuleDisplayOnlyFix {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -170,7 +201,11 @@ impl Violation for PreviewTestRule {
     }
 }
 
-impl TestRule for PreviewTestRule {}
+impl TestRule for PreviewTestRule {
+    fn check() -> Option<Diagnostic> {
+        Some(Diagnostic::new(Self {}, TextRange::default()))
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -179,12 +214,12 @@ impl TestRule for PreviewTestRule {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -199,7 +234,11 @@ impl Violation for DeprecatedTestRule {
     }
 }
 
-impl TestRule for DeprecatedTestRule {}
+impl TestRule for DeprecatedTestRule {
+    fn check() -> Option<Diagnostic> {
+        Some(Diagnostic::new(Self {}, TextRange::default()))
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -208,12 +247,12 @@ impl TestRule for DeprecatedTestRule {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -228,7 +267,11 @@ impl Violation for AnotherDeprecatedTestRule {
     }
 }
 
-impl TestRule for AnotherDeprecatedTestRule {}
+impl TestRule for AnotherDeprecatedTestRule {
+    fn check() -> Option<Diagnostic> {
+        Some(Diagnostic::new(Self {}, TextRange::default()))
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -237,12 +280,12 @@ impl TestRule for AnotherDeprecatedTestRule {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -257,7 +300,11 @@ impl Violation for RemovedTestRule {
     }
 }
 
-impl TestRule for RemovedTestRule {}
+impl TestRule for RemovedTestRule {
+    fn check() -> Option<Diagnostic> {
+        Some(Diagnostic::new(Self {}, TextRange::default()))
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -266,12 +313,12 @@ impl TestRule for RemovedTestRule {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -286,7 +333,11 @@ impl Violation for AnotherRemovedTestRule {
     }
 }
 
-impl TestRule for AnotherRemovedTestRule {}
+impl TestRule for AnotherRemovedTestRule {
+    fn check() -> Option<Diagnostic> {
+        Some(Diagnostic::new(Self {}, TextRange::default()))
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -295,12 +346,12 @@ impl TestRule for AnotherRemovedTestRule {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -315,7 +366,11 @@ impl Violation for RedirectedFromTestRule {
     }
 }
 
-impl TestRule for RedirectedFromTestRule {}
+impl TestRule for RedirectedFromTestRule {
+    fn check() -> Option<Diagnostic> {
+        Some(Diagnostic::new(Self {}, TextRange::default()))
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -324,12 +379,12 @@ impl TestRule for RedirectedFromTestRule {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -344,7 +399,11 @@ impl Violation for RedirectedToTestRule {
     }
 }
 
-impl TestRule for RedirectedToTestRule {}
+impl TestRule for RedirectedToTestRule {
+    fn check() -> Option<Diagnostic> {
+        Some(Diagnostic::new(Self {}, TextRange::default()))
+    }
+}
 
 /// ## What it does
 /// Fake rule for testing.
@@ -353,12 +412,12 @@ impl TestRule for RedirectedToTestRule {}
 /// Tests must pass!
 ///
 /// ## Example
-/// ```python
+/// ```f90
 /// foo
 /// ```
 ///
 /// Use instead:
-/// ```python
+/// ```f90
 /// bar
 /// ```
 #[violation]
@@ -373,4 +432,8 @@ impl Violation for RedirectedFromPrefixTestRule {
     }
 }
 
-impl TestRule for RedirectedFromPrefixTestRule {}
+impl TestRule for RedirectedFromPrefixTestRule {
+    fn check() -> Option<Diagnostic> {
+        Some(Diagnostic::new(Self {}, TextRange::default()))
+    }
+}

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -92,6 +92,7 @@ end program
     apply_common_filters!();
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
                          .arg("check")
+                         .arg("--select=S061,T001,T011,T021")
                          .arg(test_file),
                          @r"
     success: false
@@ -408,6 +409,7 @@ end program foo
     apply_common_filters!();
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
                          .arg("check")
+                         .arg("--select=S071,P021,T003,T004")
                          .arg("--preview")
                          .arg("--fix")
                          .arg(&test_file),
@@ -486,6 +488,7 @@ end program foo
     apply_common_filters!();
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
                          .arg("check")
+                         .arg("--select=S071,P021,T003,T004")
                          .arg("--preview")
                          .arg("--fix")
                          .arg("--unsafe-fixes")
@@ -1165,7 +1168,7 @@ end program test
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
                          .arg("check")
                          .arg(test_file)
-                         .arg("--select=E"),
+                         .arg("--select=E011"),
                          @r"
     success: false
     exit_code: 1
@@ -1279,6 +1282,7 @@ end program myprogram
     apply_common_filters!();
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
                          .arg("check")
+                         .arg("--select=S001,F001,T001")
                          .current_dir(tempdir.path()),
                          @r"
     success: false
@@ -1486,6 +1490,80 @@ fn check_no_respect_gitignore() -> anyhow::Result<()> {
 
 
     ----- stderr -----
+    ");
+    Ok(())
+}
+
+#[test]
+fn preview_enabled_prefix() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f90");
+    fs::write(
+        &test_file,
+        r#"
+program test
+  logical*4, parameter :: true = .true.
+end program
+"#,
+    )?;
+    apply_common_filters!();
+
+    // All the E99XX test rules should be triggered
+    assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
+                         .arg("check")
+                         .args(["--select=E99", "--output-format=concise", "--preview"])
+                         .arg(test_file), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    [TEMP_FILE] E9900 Hey this is a stable test rule.
+    [TEMP_FILE] E9901 [*] Hey this is a stable test rule with a safe fix.
+    [TEMP_FILE] E9902 Hey this is a stable test rule with an unsafe fix.
+    [TEMP_FILE] E9903 Hey this is a stable test rule with a display only fix.
+    [TEMP_FILE] E9911 Hey this is a preview test rule.
+    [TEMP_FILE] E9950 Hey this is a test rule that was redirected from another.
+    fortitude: 1 files scanned.
+    Number of errors: 6
+
+    For more information about specific rules, run:
+
+        fortitude explain X001,Y002,...
+
+    [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
+#[test]
+fn preview_disabled_direct() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f90");
+    fs::write(
+        &test_file,
+        r#"
+program test
+  logical*4, parameter :: true = .true.
+end program
+"#,
+    )?;
+    apply_common_filters!();
+
+    // All the E99XX test rules should be triggered
+    assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
+                         .arg("check")
+                         .args(["--select=E9911", "--output-format=concise"])
+                         .arg(test_file), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    fortitude: 1 files scanned.
+    All checks passed!
+
+
+    ----- stderr -----
+    warning: Selection `E9911` has no effect because preview is not enabled.
     ");
     Ok(())
 }


### PR DESCRIPTION
So far this only applies to preview rules selected without `--preview`, but will also apply to any future redirected, deprecated, or removed rules.

There's a lot more tests we could ~~steal~~ borrow from ruff related to this, but they all read from stdin so it's a little annoying to convert them. I'll look into how easy it is to get reading from stdin separately

Related to #297 