### PR TITLE
Bugfix: Count files scanned and files skipped correctly

### DIFF
--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -1082,6 +1082,7 @@ impl RuleSelection {
     }
 }
 
+/// Helper object to store the results of all checks
 pub(crate) struct CheckResults {
     /// All diagnostics found in all files
     pub(crate) diagnostics: Diagnostics,
@@ -1136,6 +1137,7 @@ impl CheckResults {
     }
 }
 
+/// Enum used to report the result of a single file check
 enum CheckStatus {
     /// The file was checked and no issues were found
     Ok,
@@ -1341,7 +1343,6 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
     }
 }
 
-/// Enum used to report the result of a single file check
 #[allow(clippy::too_many_arguments)]
 fn check_files(
     files: &[PathBuf],

--- a/fortitude/src/diagnostics.rs
+++ b/fortitude/src/diagnostics.rs
@@ -21,6 +21,10 @@ impl Diagnostics {
             fixed: FixMap::default(),
         }
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.messages.is_empty()
+    }
 }
 
 impl Add for Diagnostics {


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/289

Introduces helper enum `CheckStatus` to denote the result of a single file check:

```rust
enum CheckStatus {
    /// The file was checked and no issues were found
    Ok,
    /// The file was checked and issues were found
    Violations(Diagnostics),
    /// The file was skipped due to an error
    Skipped(Diagnostics),
    /// The file was skipped but no violations were raised
    SkippedNoDiagnostic,
}
```

Also introduces the struct `CheckResults` that gathers all of the `CheckStatus` objects and tracks files scanned, files skipped, and diagnostics gathered.