### PR TITLE
Fix some issues with newlines in fixes on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,19 @@ on:
   push:
     paths:
       - '**.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/test.yml'
   pull_request:
     paths:
       - '**.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/test.yml'
+  workflow_dispatch:
 
 env:
+  CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -16,6 +24,26 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --all-targets --all-features --verbose
+
+  build-windows:
+    name: Build and Test (windows)
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --all-targets --all-features --verbose
+
+  build-macos:
+    name: Build and Test (macos)
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
     - name: Build

--- a/fortitude/src/ast.rs
+++ b/fortitude/src/ast.rs
@@ -212,7 +212,7 @@ impl FortitudeNode<'_> for Node<'_> {
 
 /// Strip line breaks from a string of Fortran code.
 pub fn strip_line_breaks(src: &str) -> String {
-    src.replace('&', "").replace('\n', " ")
+    src.replace('&', "").replace('\n', " ").replace('\r', "")
 }
 
 /// Returns true if the type passed to it is number-like, and of a kind that can be modified using

--- a/fortitude/src/rules/bugprone/mod.rs
+++ b/fortitude/src/rules/bugprone/mod.rs
@@ -9,6 +9,7 @@ mod tests {
     use insta::assert_snapshot;
     use test_case::test_case;
 
+    use crate::apply_common_filters;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;
@@ -21,6 +22,7 @@ mod tests {
             &[rule_code],
             &Settings::default(),
         )?;
+        apply_common_filters!();
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
     }

--- a/fortitude/src/rules/io/mod.rs
+++ b/fortitude/src/rules/io/mod.rs
@@ -10,6 +10,7 @@ mod tests {
     use insta::assert_snapshot;
     use test_case::test_case;
 
+    use crate::apply_common_filters;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;
@@ -24,6 +25,7 @@ mod tests {
             &[rule_code],
             &Settings::default(),
         )?;
+        apply_common_filters!();
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
     }

--- a/fortitude/src/rules/modules/mod.rs
+++ b/fortitude/src/rules/modules/mod.rs
@@ -13,6 +13,7 @@ mod tests {
     use insta::assert_snapshot;
     use test_case::test_case;
 
+    use crate::apply_common_filters;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;
@@ -32,6 +33,7 @@ mod tests {
             &[rule_code],
             &Settings::default(),
         )?;
+        apply_common_filters!();
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
     }

--- a/fortitude/src/rules/obsolescent/mod.rs
+++ b/fortitude/src/rules/obsolescent/mod.rs
@@ -14,6 +14,7 @@ mod tests {
     use insta::assert_snapshot;
     use test_case::test_case;
 
+    use crate::apply_common_filters;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;
@@ -31,6 +32,7 @@ mod tests {
             &[rule_code],
             &Settings::default(),
         )?;
+        apply_common_filters!();
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
     }

--- a/fortitude/src/rules/precision/mod.rs
+++ b/fortitude/src/rules/precision/mod.rs
@@ -11,6 +11,7 @@ mod tests {
     use insta::assert_snapshot;
     use test_case::test_case;
 
+    use crate::apply_common_filters;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;
@@ -25,6 +26,7 @@ mod tests {
             &[rule_code],
             &Settings::default(),
         )?;
+        apply_common_filters!();
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
     }

--- a/fortitude/src/rules/readability/mod.rs
+++ b/fortitude/src/rules/readability/mod.rs
@@ -9,6 +9,7 @@ mod tests {
     use insta::assert_snapshot;
     use test_case::test_case;
 
+    use crate::apply_common_filters;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;
@@ -21,6 +22,7 @@ mod tests {
             &[rule_code],
             &Settings::default(),
         )?;
+        apply_common_filters!();
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
     }

--- a/fortitude/src/rules/style/mod.rs
+++ b/fortitude/src/rules/style/mod.rs
@@ -16,6 +16,7 @@ mod tests {
     use insta::assert_snapshot;
     use test_case::test_case;
 
+    use crate::apply_common_filters;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;
@@ -37,6 +38,7 @@ mod tests {
             &[rule_code],
             &Settings::default(),
         )?;
+        apply_common_filters!();
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
     }
@@ -54,6 +56,7 @@ mod tests {
             &[rule_code],
             &settings,
         )?;
+        apply_common_filters!();
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
     }

--- a/fortitude/src/rules/style/whitespace.rs
+++ b/fortitude/src/rules/style/whitespace.rs
@@ -6,7 +6,7 @@ use ruff_text_size::{TextLen, TextRange, TextSize};
 use tree_sitter::Node;
 
 use crate::settings::Settings;
-use crate::{ast::FortitudeNode, AstRule, FromAstNode, TextRule};
+use crate::{AstRule, FromAstNode, TextRule};
 
 /// ## What does it do?
 /// Checks for tailing whitespace
@@ -90,13 +90,7 @@ impl AstRule for IncorrectSpaceBeforeComment {
             return None;
         }
         if whitespace < 2 {
-            // Comment node can contain whitespace characters at the end, and is inconsistent
-            // between Windows and Unix line endings. A CR may be inserted even if there isn't
-            // one in the source code!
-            let trim_comment = node.to_text(source.text())?.trim();
-            let comment_end = comment_start + TextSize::try_from(trim_comment.len()).unwrap();
-            let replacement = format!("{}{}", &"  "[whitespace..], trim_comment);
-            let edit = Edit::replacement(replacement, comment_start, comment_end);
+            let edit = Edit::insertion("  "[whitespace..].to_string(), comment_start);
             return some_vec!(Diagnostic::from_node(Self {}, node).with_fix(Fix::safe_edit(edit)));
         }
         None

--- a/fortitude/src/rules/style/whitespace.rs
+++ b/fortitude/src/rules/style/whitespace.rs
@@ -1,7 +1,7 @@
 /// Defines rules that enforce widely accepted whitespace rules.
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_source_file::{OneIndexed, SourceFile};
+use ruff_source_file::{SourceFile, UniversalNewlines};
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use tree_sitter::Node;
 
@@ -33,7 +33,7 @@ impl TextRule for TrailingWhitespace {
     fn check(_settings: &Settings, source_file: &SourceFile) -> Vec<Diagnostic> {
         let source = source_file.to_source_code();
         let mut violations = Vec::new();
-        for (idx, line) in source.text().lines().enumerate() {
+        for line in source.text().universal_newlines() {
             let whitespace_bytes: TextSize = line
                 .chars()
                 .rev()
@@ -41,8 +41,7 @@ impl TextRule for TrailingWhitespace {
                 .map(TextLen::text_len)
                 .sum();
             if whitespace_bytes > 0.into() {
-                let line_end_byte = source.line_end_exclusive(OneIndexed::from_zero_indexed(idx));
-                let range = TextRange::new(line_end_byte - whitespace_bytes, line_end_byte);
+                let range = TextRange::new(line.end() - whitespace_bytes, line.end());
                 let edit = Edit::range_deletion(range);
                 violations.push(Diagnostic::new(Self {}, range).with_fix(Fix::safe_edit(edit)));
             }

--- a/fortitude/src/rules/typing/mod.rs
+++ b/fortitude/src/rules/typing/mod.rs
@@ -16,6 +16,7 @@ mod tests {
     use insta::assert_snapshot;
     use test_case::test_case;
 
+    use crate::apply_common_filters;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;
@@ -41,6 +42,7 @@ mod tests {
             &[rule_code],
             &Settings::default(),
         )?;
+        apply_common_filters!();
         assert_snapshot!(snapshot, diagnostics);
         Ok(())
     }

--- a/fortitude/src/test.rs
+++ b/fortitude/src/test.rs
@@ -14,6 +14,16 @@ use crate::{
     settings::{FixMode, Settings, UnsafeFixes},
 };
 
+#[macro_export]
+macro_rules! apply_common_filters {
+    {} => {
+        let mut settings = insta::Settings::clone_current();
+        // Convert windows paths to Unix Paths.
+        settings.add_filter(r"\\\\?([\w\d.])", "/$1");
+        let _bound = settings.bind_to_scope();
+    }
+}
+
 pub(crate) fn test_resource_path(path: impl AsRef<Path>) -> std::path::PathBuf {
     Path::new("./resources/test/").join(path)
 }

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -696,7 +696,6 @@ per-file-ignores = [
                          .arg("check")
                          .arg("--select=typing")
                          .arg("--per-file-ignores=**/double_nested/*.f90:implicit-typing")
-                         .arg(path)
                          .current_dir(path),
                          @r"
     success: false
@@ -806,7 +805,6 @@ per-file-ignores = [
                          .arg("check")
                          .arg("--select=typing")
                          .arg("--extend-per-file-ignores=**/double_nested/*.f90:implicit-typing")
-                         .arg(path)
                          .current_dir(path),
                          @r"
     success: false

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -17,6 +17,8 @@ macro_rules! apply_common_filters {
         settings.add_filter(r"\b[A-Z]:\\.*\\Local\\Temp\\\S+", "[TEMP_FILE]");
         // Convert windows paths to Unix Paths.
         settings.add_filter(r"\\\\?([\w\d.])", "/$1");
+        // Ignore specific os errors
+        settings.add_filter(r"E000 Error opening file: .*", "E000 Error opening file: [OS_ERROR]");
         let _bound = settings.bind_to_scope();
     }
 }
@@ -31,7 +33,7 @@ fn check_file_doesnt_exist() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    test/file/doesnt/exist.f90:1:1: E000 Error opening file: No such file or directory (os error 2)
+    test/file/doesnt/exist.f90:1:1: E000 Error opening file: [OS_ERROR]
     fortitude: 0 files scanned, 1 could not be read.
     Number of errors: 1
 

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -23,6 +23,7 @@ macro_rules! apply_common_filters {
 
 #[test]
 fn check_file_doesnt_exist() -> anyhow::Result<()> {
+    apply_common_filters!();
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
                          .arg("check")
                          .arg("test/file/doesnt/exist.f90"),


### PR DESCRIPTION
When I deduplicated building the binaries, it also stopped us building on different platforms.

And it looks like we were never actually testing on those platforms!

Windows failures seem pretty simple: paths are using `\` instead of `/` as expected in the snapshots. Can probably do something simple to fix those in the tests.

Mac failures more puzzling, looks like `per-file-ignores` not working quite as expected?