### PR TITLE
Add `Settings` struct for final resolved settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,8 @@ Options:
           Enable preview mode; checks will include unstable rules and fixes. Use `--no-preview` to disable
       --progress-bar <PROGRESS_BAR>
           Progress bar settings. Options are "off" (default), "ascii", and "fancy" [possible values: off, fancy, ascii]
+      --show-settings
+          See the settings fortitude will use to check a given Fortran file
       --stdin-filename <STDIN_FILENAME>
           The name of the file when passing it through stdin
   -h, --help

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,8 @@ Options:
           Progress bar settings. Options are "off" (default), "ascii", and "fancy" [possible values: off, fancy, ascii]
       --show-settings
           See the settings fortitude will use to check a given Fortran file
+      --show-files
+          See the files fortitude will be run against with the current settings
       --stdin-filename <STDIN_FILENAME>
           The name of the file when passing it through stdin
   -h, --help

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -15,6 +15,7 @@ use crate::rules::testing::test_rules::{self, TestRule, TEST_RULES};
 use crate::rules::Rule;
 use crate::rules::{error::ioerror::IoError, AstRuleEnum, PathRuleEnum, TextRuleEnum};
 use crate::settings::{CheckSettings, FixMode, PreviewMode, ProgressBar, Settings};
+use crate::show_settings::show_settings;
 use crate::stdin::read_from_stdin;
 use crate::{fs, warn_user_once};
 
@@ -683,7 +684,7 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
 
     let stdin_filename = args.stdin_filename;
 
-    let writer: Box<dyn Write> = match args.output_file {
+    let mut writer: Box<dyn Write> = match args.output_file {
         Some(path) => {
             colored::control::set_override(false);
             if let Some(parent) = path.parent() {
@@ -697,6 +698,11 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
     let stderr_writer = Box::new(BufWriter::new(io::stderr()));
 
     let is_stdin = is_stdin(&args.files.unwrap_or_default(), stdin_filename.as_deref());
+
+    if args.show_settings {
+        show_settings(&settings, &mut writer)?;
+        return Ok(ExitCode::SUCCESS);
+    }
 
     let CheckSettings {
         fix,

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -15,6 +15,7 @@ use crate::rules::testing::test_rules::{self, TestRule, TEST_RULES};
 use crate::rules::Rule;
 use crate::rules::{error::ioerror::IoError, AstRuleEnum, PathRuleEnum, TextRuleEnum};
 use crate::settings::{CheckSettings, FixMode, PreviewMode, ProgressBar, Settings};
+use crate::show_files::show_files;
 use crate::show_settings::show_settings;
 use crate::stdin::read_from_stdin;
 use crate::{fs, warn_user_once};
@@ -701,6 +702,11 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
 
     if args.show_settings {
         show_settings(&settings, &mut writer)?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    if args.show_files {
+        show_files(&settings.file_resolver, is_stdin, &mut writer)?;
         return Ok(ExitCode::SUCCESS);
     }
 

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -165,6 +165,10 @@ pub struct CheckArgs {
     #[arg(long, value_enum)]
     pub progress_bar: Option<ProgressBar>,
 
+    /// See the settings fortitude will use to check a given Fortran file.
+    #[arg(long)]
+    pub show_settings: bool,
+
     // Rule selection
     /// Comma-separated list of rules to ignore.
     #[arg(

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -166,8 +166,19 @@ pub struct CheckArgs {
     pub progress_bar: Option<ProgressBar>,
 
     /// See the settings fortitude will use to check a given Fortran file.
-    #[arg(long)]
+    #[arg(long,
+        // Fake subcommands.
+        conflicts_with = "show_files",
+        // conflicts_with = "show_settings",
+    )]
     pub show_settings: bool,
+    /// See the files fortitude will be run against with the current settings.
+    #[arg(long,
+          // Fake subcommands.
+        // conflicts_with = "show_files",
+        conflicts_with = "show_settings",
+    )]
+    pub show_files: bool,
 
     // Rule selection
     /// Comma-separated list of rules to ignore.

--- a/fortitude/src/configuration.rs
+++ b/fortitude/src/configuration.rs
@@ -141,7 +141,7 @@ pub fn parse_config_file(config_file: &Option<PathBuf>) -> Result<Options> {
 // This is our "known good" intermediate settings struct after we've
 // read the config file, but before we've overridden it from the CLI
 #[derive(Debug)]
-pub struct CheckSettings {
+pub struct Configuration {
     pub files: Vec<PathBuf>,
     pub ignore: Vec<RuleSelector>,
     pub select: Option<Vec<RuleSelector>>,
@@ -162,7 +162,7 @@ pub struct CheckSettings {
     pub gitignore_mode: GitignoreMode,
 }
 
-impl Default for CheckSettings {
+impl Default for Configuration {
     fn default() -> Self {
         Self {
             files: Default::default(),
@@ -170,7 +170,7 @@ impl Default for CheckSettings {
             select: Default::default(),
             extend_select: Default::default(),
             per_file_ignores: Default::default(),
-            line_length: Settings::default().line_length,
+            line_length: Settings::default().check.line_length,
             file_extensions: FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect(),
             fix: Default::default(),
             fix_only: Default::default(),
@@ -187,7 +187,7 @@ impl Default for CheckSettings {
     }
 }
 
-impl CheckSettings {
+impl Configuration {
     /// Convert from config file options struct into our "known good" struct
     pub fn from_options(options: Options, project_root: &Path) -> Self {
         let check = options.check.unwrap_or_default();
@@ -205,7 +205,9 @@ impl CheckSettings {
                     })
                     .collect()
             }),
-            line_length: check.line_length.unwrap_or(Settings::default().line_length),
+            line_length: check
+                .line_length
+                .unwrap_or(Settings::default().check.line_length),
             file_extensions: check
                 .file_extensions
                 .unwrap_or(FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect_vec()),

--- a/fortitude/src/configuration.rs
+++ b/fortitude/src/configuration.rs
@@ -259,6 +259,8 @@ impl Configuration {
 
     pub fn into_settings(self, project_root: &Path, args: &CheckArgs) -> Result<Settings> {
         let args = args.clone();
+
+        let files = args.files.unwrap_or(self.files);
         let file_extensions = args.file_extensions.unwrap_or(self.file_extensions);
 
         let per_file_ignores = if let Some(per_file_ignores) = args.per_file_ignores {
@@ -348,7 +350,8 @@ impl Configuration {
             file_resolver: FileResolverSettings {
                 project_root: project_root.to_path_buf(),
                 excludes: exclude,
-                file_extensions: file_extensions.clone(),
+                files,
+                file_extensions,
                 respect_gitignore: respect_gitignore.is_respect_gitignore(),
                 force_exclude: force_exclude.is_force(),
             },

--- a/fortitude/src/fs.rs
+++ b/fortitude/src/fs.rs
@@ -266,13 +266,26 @@ pub(crate) static EXCLUDE_BUILTINS: &[FilePattern] = &[
     FilePattern::Builtin("_dist"),
 ];
 
+/// Returns the default set of files if none are provided, otherwise
+/// returns a list with just the current working directory.
+fn resolve_default_files(files: &[PathBuf], is_stdin: bool) -> Vec<PathBuf> {
+    if files.is_empty() {
+        if is_stdin {
+            vec![Path::new("-").to_path_buf()]
+        } else {
+            vec![Path::new(".").to_path_buf()]
+        }
+    } else {
+        files.to_vec()
+    }
+}
+
 /// Expand the input list of files to include all Fortran files.
-pub fn get_files<P: AsRef<Path>>(
-    paths: &[P],
-    resolver: &FileResolverSettings,
-) -> anyhow::Result<Vec<PathBuf>> {
+pub fn get_files(resolver: &FileResolverSettings, is_stdin: bool) -> anyhow::Result<Vec<PathBuf>> {
     debug!("Gathering files");
     debug!("Project root: {:?}", resolver.project_root);
+    let paths = resolve_default_files(&resolver.files, is_stdin);
+
     // Normalise all paths and remove duplicates.
     // If exclude_mode is set to Force, remove paths that match the exclude patterns.
     let paths: Vec<_> = if resolver.force_exclude {

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -17,6 +17,7 @@ mod rule_selector;
 pub mod rule_table;
 pub mod rules;
 pub mod settings;
+mod show_files;
 mod show_settings;
 pub mod stdin;
 #[cfg(test)]

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -17,6 +17,7 @@ mod rule_selector;
 pub mod rule_table;
 pub mod rules;
 pub mod settings;
+mod show_settings;
 pub mod stdin;
 #[cfg(test)]
 mod test;

--- a/fortitude/src/rules/style/line_length.rs
+++ b/fortitude/src/rules/style/line_length.rs
@@ -46,7 +46,7 @@ impl Violation for LineTooLong {
 impl TextRule for LineTooLong {
     fn check(settings: &Settings, source_file: &SourceFile) -> Vec<Diagnostic> {
         let source = source_file.to_source_code();
-        let max_length = settings.line_length;
+        let max_length = settings.check.line_length;
         let mut violations = Vec::new();
         for line in source.text().universal_newlines() {
             // Note: Can't use string.len(), as that gives byte length, not char length

--- a/fortitude/src/rules/style/mod.rs
+++ b/fortitude/src/rules/style/mod.rs
@@ -18,7 +18,7 @@ mod tests {
 
     use crate::apply_common_filters;
     use crate::registry::Rule;
-    use crate::settings::Settings;
+    use crate::settings::{CheckSettings, Settings};
     use crate::test::test_path;
 
     #[test_case(Rule::LineTooLong, Path::new("S001.f90"))]
@@ -46,10 +46,15 @@ mod tests {
     #[test_case(Rule::LineTooLong, Path::new("S001_line_length_20.f90"))]
     fn line_too_long_line_length_20(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+
+        let default = Settings::default();
         #[allow(clippy::needless_update)]
         let settings = Settings {
-            line_length: 20,
-            ..Settings::default()
+            check: CheckSettings {
+                line_length: 20,
+                ..default.check
+            },
+            ..default
         };
         let diagnostics = test_path(
             Path::new("style").join(path).as_path(),

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -110,11 +110,9 @@ impl fmt::Display for CheckSettings {
 }
 #[derive(Debug, CacheKey)]
 pub struct FileResolverSettings {
-    pub exclude: FilePatternSet,
-    pub extend_exclude: FilePatternSet,
+    pub excludes: FilePatternSet,
     pub force_exclude: bool,
     pub file_extensions: Vec<String>,
-    pub extend_include: FilePatternSet,
     pub respect_gitignore: bool,
     pub project_root: PathBuf,
 }
@@ -126,11 +124,9 @@ impl fmt::Display for FileResolverSettings {
             formatter = f,
             namespace = "file_resolver",
             fields = [
-                self.exclude,
-                self.extend_exclude,
+                self.excludes,
                 self.force_exclude,
                 self.file_extensions | array,
-                self.extend_include,
                 self.respect_gitignore,
                 self.project_root | path,
             ]
@@ -143,9 +139,7 @@ impl FileResolverSettings {
     fn new(project_root: &Path) -> Self {
         Self {
             project_root: project_root.to_path_buf(),
-            exclude: FilePatternSet::try_from_iter(EXCLUDE_BUILTINS.iter().cloned()).unwrap(),
-            extend_exclude: FilePatternSet::default(),
-            extend_include: FilePatternSet::default(),
+            excludes: FilePatternSet::try_from_iter(EXCLUDE_BUILTINS.iter().cloned()).unwrap(),
             force_exclude: false,
             respect_gitignore: true,
             file_extensions: FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect(),

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -3,22 +3,153 @@
 // SPDX-License-Identifier: MIT
 
 /// A collection of user-modifiable settings. Should be expanded as new features are added.
-use std::fmt::{Display, Formatter};
+use std::fmt;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use path_absolutize::path_dedot;
 use ruff_diagnostics::Applicability;
 use ruff_macros::CacheKey;
 use serde::{de, Deserialize, Deserializer, Serialize};
 
-use crate::rule_selector::RuleSelector;
+use crate::display_settings;
+use crate::fs::{FilePatternSet, EXCLUDE_BUILTINS, FORTRAN_EXTS};
+use crate::rule_selector::{CompiledPerFileIgnoreList, PreviewOptions, RuleSelector};
+use crate::rule_table::RuleTable;
 
+#[derive(Debug)]
 pub struct Settings {
-    pub line_length: usize,
+    pub check: CheckSettings,
+    pub file_resolver: FileResolverSettings,
 }
 
 impl Default for Settings {
     fn default() -> Self {
-        Self { line_length: 100 }
+        let project_root = path_dedot::CWD.as_path();
+        Self {
+            check: CheckSettings::new(project_root),
+            file_resolver: FileResolverSettings::new(project_root),
+        }
+    }
+}
+
+impl fmt::Display for Settings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "\n# General Settings")?;
+        display_settings! {
+            formatter = f,
+            fields = [
+                self.check         | nested,
+                self.file_resolver | nested,
+            ]
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct CheckSettings {
+    pub project_root: PathBuf,
+
+    pub rules: RuleTable,
+    pub per_file_ignores: CompiledPerFileIgnoreList,
+
+    pub line_length: usize,
+
+    pub fix: bool,
+    pub fix_only: bool,
+    pub show_fixes: bool,
+    pub unsafe_fixes: UnsafeFixes,
+    pub output_format: OutputFormat,
+    pub progress_bar: ProgressBar,
+    pub preview: PreviewMode,
+}
+
+impl CheckSettings {
+    fn new(project_root: &Path) -> Self {
+        Self {
+            project_root: project_root.to_path_buf(),
+            rules: DEFAULT_SELECTORS
+                .iter()
+                .flat_map(|selector| selector.rules(&PreviewOptions::default()))
+                .collect(),
+            per_file_ignores: CompiledPerFileIgnoreList::default(),
+            line_length: 100,
+            fix: false,
+            fix_only: false,
+            show_fixes: false,
+            unsafe_fixes: UnsafeFixes::default(),
+            output_format: OutputFormat::default(),
+            progress_bar: ProgressBar::default(),
+            preview: PreviewMode::default(),
+        }
+    }
+}
+
+impl fmt::Display for CheckSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "\n# Check Settings")?;
+        display_settings! {
+            formatter = f,
+            namespace = "check",
+            fields = [
+                self.project_root | path,
+                self.rules | nested,
+                self.per_file_ignores,
+                self.line_length,
+                self.fix,
+                self.fix_only,
+                self.show_fixes,
+                self.output_format,
+                self.progress_bar,
+                self.preview,
+            ]
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, CacheKey)]
+pub struct FileResolverSettings {
+    pub exclude: FilePatternSet,
+    pub extend_exclude: FilePatternSet,
+    pub force_exclude: bool,
+    pub file_extensions: Vec<String>,
+    pub extend_include: FilePatternSet,
+    pub respect_gitignore: bool,
+    pub project_root: PathBuf,
+}
+
+impl fmt::Display for FileResolverSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "\n# File Resolver Settings")?;
+        display_settings! {
+            formatter = f,
+            namespace = "file_resolver",
+            fields = [
+                self.exclude,
+                self.extend_exclude,
+                self.force_exclude,
+                self.file_extensions | array,
+                self.extend_include,
+                self.respect_gitignore,
+                self.project_root | path,
+            ]
+        }
+        Ok(())
+    }
+}
+
+impl FileResolverSettings {
+    fn new(project_root: &Path) -> Self {
+        Self {
+            project_root: project_root.to_path_buf(),
+            exclude: FilePatternSet::try_from_iter(EXCLUDE_BUILTINS.iter().cloned()).unwrap(),
+            extend_exclude: FilePatternSet::default(),
+            extend_include: FilePatternSet::default(),
+            force_exclude: false,
+            respect_gitignore: true,
+            file_extensions: FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect(),
+        }
     }
 }
 
@@ -40,8 +171,8 @@ impl From<bool> for PreviewMode {
     }
 }
 
-impl Display for PreviewMode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for PreviewMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Disabled => write!(f, "disabled"),
             Self::Enabled => write!(f, "enabled"),
@@ -64,8 +195,8 @@ pub enum UnsafeFixes {
     Enabled,
 }
 
-impl Display for UnsafeFixes {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for UnsafeFixes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",
@@ -197,8 +328,8 @@ pub enum ProgressBar {
     Ascii,
 }
 
-impl Display for ProgressBar {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ProgressBar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",
@@ -231,8 +362,8 @@ pub enum OutputFormat {
     Sarif,
 }
 
-impl Display for OutputFormat {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Concise => write!(f, "concise"),
             Self::Full => write!(f, "full"),

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -112,6 +112,7 @@ impl fmt::Display for CheckSettings {
 pub struct FileResolverSettings {
     pub excludes: FilePatternSet,
     pub force_exclude: bool,
+    pub files: Vec<PathBuf>,
     pub file_extensions: Vec<String>,
     pub respect_gitignore: bool,
     pub project_root: PathBuf,
@@ -126,6 +127,7 @@ impl fmt::Display for FileResolverSettings {
             fields = [
                 self.excludes,
                 self.force_exclude,
+                self.files | paths,
                 self.file_extensions | array,
                 self.respect_gitignore,
                 self.project_root | path,
@@ -142,6 +144,7 @@ impl FileResolverSettings {
             excludes: FilePatternSet::try_from_iter(EXCLUDE_BUILTINS.iter().cloned()).unwrap(),
             force_exclude: false,
             respect_gitignore: true,
+            files: Vec::default(),
             file_extensions: FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect(),
         }
     }

--- a/fortitude/src/show_files.rs
+++ b/fortitude/src/show_files.rs
@@ -1,0 +1,20 @@
+use std::io::Write;
+
+use anyhow::Result;
+use itertools::Itertools;
+
+use crate::{fs::get_files, settings::FileResolverSettings};
+
+pub(crate) fn show_files(
+    resolver: &FileResolverSettings,
+    is_stdin: bool,
+    writer: &mut impl Write,
+) -> Result<()> {
+    let files = get_files(resolver, is_stdin);
+
+    for file in files.into_iter().flatten().sorted_unstable() {
+        writeln!(writer, "{}", file.to_string_lossy())?;
+    }
+
+    Ok(())
+}

--- a/fortitude/src/show_settings.rs
+++ b/fortitude/src/show_settings.rs
@@ -1,0 +1,15 @@
+use std::io::Write;
+
+use anyhow::Result;
+
+use crate::settings::Settings;
+
+pub(crate) fn show_settings(settings: &Settings, writer: &mut impl Write) -> Result<()> {
+    writeln!(
+        writer,
+        "Resolved settings for \"{}\"",
+        settings.check.project_root.display()
+    )?;
+    write!(writer, "{settings}")?;
+    Ok(())
+}

--- a/fortitude/src/test.rs
+++ b/fortitude/src/test.rs
@@ -8,10 +8,9 @@ use crate::{
         ast_entrypoint_map, check_file, read_to_string, rules_to_path_rules, rules_to_text_rules,
     },
     message::{Emitter, TextEmitter},
-    rule_selector::CompiledPerFileIgnoreList,
     rule_table::RuleTable,
     rules::Rule,
-    settings::{FixMode, Settings, UnsafeFixes},
+    settings::{FixMode, Settings},
 };
 
 #[macro_export]
@@ -51,7 +50,6 @@ pub(crate) fn test_contents(
     let path_rules = rules_to_path_rules(&rule_table);
     let text_rules = rules_to_text_rules(&rule_table);
     let ast_entrypoints = ast_entrypoint_map(&rule_table);
-    let per_file_ignores = CompiledPerFileIgnoreList::resolve(vec![]).unwrap();
 
     match check_file(
         &rule_table,
@@ -62,8 +60,6 @@ pub(crate) fn test_contents(
         file,
         settings,
         FixMode::Generate,
-        UnsafeFixes::Hint,
-        &per_file_ignores,
     ) {
         Ok(violations) => {
             if violations.messages.is_empty() {


### PR DESCRIPTION
We now have several types for the input settings, they start at the bottom with:

- `Cli` and `Options` which represent the inputs
- `Configuration` as an intermediate step, representing the config file after reading and applying some defaults
- `Settings` representing the finalised settings, after overriding using the cli

This mirrors ruff, although their `Configuration` is more complicated and can be built up out of many files.

The point of this is to both a) tidy up `check.rs` even further, and b) give us one struct we can pass around, allowing us to remove a few repeated function arguments.

We _should_ be able to get rid of `rules` as a separate variable as well, except we currently still need to split it up into `path_rules` etc. We could probably rejig that now, but that's a separate PR.

The last two commits add `--show-settings` and `--show-files`, they should maybe go in separate PRs. They are sort of related, in that they're made much easier to implement by having this new one-true-struct.