### PR TITLE
Proposal: Hardcode list of default rules

### DIFF
--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -12,10 +12,12 @@ use ruff_diagnostics::Applicability;
 use ruff_macros::CacheKey;
 use serde::{de, Deserialize, Deserializer, Serialize};
 
-use crate::display_settings;
 use crate::fs::{FilePatternSet, EXCLUDE_BUILTINS, FORTRAN_EXTS};
+use crate::registry::Category;
 use crate::rule_selector::{CompiledPerFileIgnoreList, PreviewOptions, RuleSelector};
 use crate::rule_table::RuleTable;
+use crate::rules::RuleCodePrefix;
+use crate::{display_settings, rules};
 
 #[derive(Debug)]
 pub struct Settings {
@@ -178,7 +180,93 @@ impl fmt::Display for PreviewMode {
 }
 
 /// Default rule selection
-pub const DEFAULT_SELECTORS: &[RuleSelector] = &[RuleSelector::All];
+pub const DEFAULT_SELECTORS: &[RuleSelector] = &[
+    RuleSelector::Category(Category::Error),
+    RuleSelector::Category(Category::Bugprone),
+    RuleSelector::Category(Category::Obsolescent),
+    RuleSelector::Category(Category::Filesystem),
+    // LineTooLong
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Style(rules::Style::_001),
+        redirected_from: None,
+    },
+    // MissingExitOrCycleLabel
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Style(rules::Style::_021),
+        redirected_from: None,
+    },
+    // OldStyleArrayLiteral
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Style(rules::Style::_041),
+        redirected_from: None,
+    },
+    // DeprecatedRelationalOperator
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Style(rules::Style::_051),
+        redirected_from: None,
+    },
+    // UnnamedEndStatement
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Style(rules::Style::_061),
+        redirected_from: None,
+    },
+    // MissingDoubleColon
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Style(rules::Style::_071),
+        redirected_from: None,
+    },
+    // SuperfluousSemicolon
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Style(rules::Style::_081),
+        redirected_from: None,
+    },
+    // MultipleStatementsPerLine
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Style(rules::Style::_082),
+        redirected_from: None,
+    },
+    // TrailingWhitespace
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Style(rules::Style::_101),
+        redirected_from: None,
+    },
+    // ImplicitTyping, InterfaceImplicitTyping,
+    // SuperfluousImplicitNone, ImplicitExternalProcedure
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Typing(rules::Typing::_00),
+        redirected_from: None,
+    },
+    // InitialisationInDeclaration
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Typing(rules::Typing::_05),
+        redirected_from: None,
+    },
+    // AssumedSize, AssumedSizeCharacterIntent, DeprecatedAssumedSizeCharacter
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Typing(rules::Typing::_04),
+        redirected_from: None,
+    },
+    // ExternalProcedure
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Typing(rules::Typing::_061),
+        redirected_from: None,
+    },
+    // MissingDefaultPointerInitalisation
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Typing(rules::Typing::_071),
+        redirected_from: None,
+    },
+    // ProcedureNotInModule
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Modules(rules::Modules::_001),
+        redirected_from: None,
+    },
+    // UseAll
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Modules(rules::Modules::_011),
+        redirected_from: None,
+    },
+];
 
 /// Toggle for unsafe fixes.
 /// `Hint` will not apply unsafe fixes but a message will be shown when they are available.


### PR DESCRIPTION
Here's another proposal for updating the default rules. Here, I've done two things:

1. hardcode the list of rules (and some prefixes)
2. gone more inclusive with what's turned on by default -- anything not "too" pedantic (probably some of the ones I've missed could also be default)

My issues with this version are:

1. tricky to communicate what's on by default
2. actually really quite ugly

The reason for 2 is that `DEFAULT_SELECTORS` is a `const` list of `RuleSelector`, and there's no straightforward conversion from `Rule` to `RuleSelector`, hence the ugliness. This could be improved if we used `lazy_static` and then we could just use `RuleSelector::from_str("rule-name")`, which would be both a _lot_ simpler and also much easier to read.

@LiamPattinson previously suggested having something in the `map_codes` macro to determine which rules were default, and I'd pushed back on the basis I thought this method was going to be fairly simple. As it's not, we could add something like `Default`/`Pedantic` to `map_codes`, which we could use to 

1. build this list
2. put something indicating whether or not it's on by default into the docs and `explain`. The config docstring would then just say "see the docs for which rules are on by default"

