### PR TITLE
Bump ruff packages to 0.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1203,12 +1203,12 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "ruff_cache"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.6#524cf6e5155066132da772b9f84e2e6695f241b8"
 dependencies = [
  "filetime",
  "glob",
  "globset",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "regex",
  "seahash",
 ]
@@ -1216,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "ruff_diagnostics"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.6#524cf6e5155066132da772b9f84e2e6695f241b8"
 dependencies = [
  "anyhow",
  "is-macro",
@@ -1228,9 +1228,9 @@ dependencies = [
 [[package]]
 name = "ruff_macros"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.6#524cf6e5155066132da772b9f84e2e6695f241b8"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "ruff_python_trivia",
@@ -1240,9 +1240,9 @@ dependencies = [
 [[package]]
 name = "ruff_python_trivia"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.6#524cf6e5155066132da772b9f84e2e6695f241b8"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "ruff_source_file",
  "ruff_text_size",
  "unicode-ident",
@@ -1251,7 +1251,7 @@ dependencies = [
 [[package]]
 name = "ruff_source_file"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.6#524cf6e5155066132da772b9f84e2e6695f241b8"
 dependencies = [
  "memchr",
  "ruff_text_size",
@@ -1261,7 +1261,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.7.1#337af836d3b2d88413c1391495a94755af46f574"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.6#524cf6e5155066132da772b9f84e2e6695f241b8"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ anyhow = "1.0.79"
 clap = { version = "4.4.16", features = ["derive", "string", "env"] }
 colored = { version = "2.1.0" }
 itertools = "0.12.0"
-ruff_cache = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
-ruff_diagnostics = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
-ruff_macros = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
-ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.7.1", version = "0.0.0" }
+ruff_cache = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.6", version = "0.0.0" }
+ruff_diagnostics = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.6", version = "0.0.0" }
+ruff_macros = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.6", version = "0.0.0" }
+ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.6", version = "0.0.0" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.6", version = "0.0.0" }
 serde_json = { version = "1.0.113" }
 strum = { version = "0.26.0", features = ["strum_macros"] }
 strum_macros = { version = "0.26.0" }

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -18,7 +18,7 @@ use crate::settings::{CheckSettings, FixMode, PreviewMode, ProgressBar, Settings
 use crate::show_files::show_files;
 use crate::show_settings::show_settings;
 use crate::stdin::read_from_stdin;
-use crate::{fs, warn_user_once};
+use crate::{fs, locator::Locator, warn_user_once};
 
 use anyhow::{anyhow, Context, Result};
 use colored::Colorize;
@@ -28,7 +28,7 @@ use lazy_regex::{regex, regex_captures};
 use log::{debug, warn};
 use rayon::prelude::*;
 use ruff_diagnostics::Diagnostic;
-use ruff_source_file::{Locator, SourceFile, SourceFileBuilder};
+use ruff_source_file::{SourceFile, SourceFileBuilder};
 use ruff_text_size::{TextRange, TextSize};
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;

--- a/fortitude/src/fix/mod.rs
+++ b/fortitude/src/fix/mod.rs
@@ -8,9 +8,10 @@ use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use ruff_diagnostics::{Diagnostic, Edit, Fix, IsolationLevel, SourceMap};
-use ruff_source_file::{Locator, SourceFile, SourceFileBuilder};
+use ruff_source_file::{SourceFile, SourceFileBuilder};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
+use crate::locator::Locator;
 use crate::registry::{AsRule, Rule};
 use crate::settings::UnsafeFixes;
 
@@ -146,10 +147,10 @@ fn cmp_fix(_rule1: Rule, _rule2: Rule, fix1: &Fix, fix2: &Fix) -> std::cmp::Orde
 #[cfg(test)]
 mod tests {
     use ruff_diagnostics::{Diagnostic, Edit, Fix, SourceMarker};
-    use ruff_source_file::Locator;
     use ruff_text_size::{Ranged, TextSize};
 
     use crate::fix::{apply_fixes, FixResult};
+    use crate::locator::Locator;
     use crate::rules::modules::use_statements::UseAll;
 
     #[allow(deprecated)]

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -6,6 +6,7 @@ mod diagnostics;
 pub mod explain;
 mod fix;
 mod fs;
+mod locator;
 pub mod logging;
 pub mod message;
 pub mod options;

--- a/fortitude/src/locator.rs
+++ b/fortitude/src/locator.rs
@@ -1,0 +1,311 @@
+// Taken from ruff
+// Copyright 2022 Charles Marsh
+// SPDX-License-Identifier: MIT
+
+//! Struct used to efficiently slice source code at (row, column) Locations.
+
+use std::cell::OnceCell;
+
+use ruff_source_file::{LineIndex, LineRanges, OneIndexed, SourceCode, SourceLocation};
+use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct Locator<'a> {
+    contents: &'a str,
+    index: OnceCell<LineIndex>,
+}
+
+#[allow(dead_code)]
+impl<'a> Locator<'a> {
+    pub const fn new(contents: &'a str) -> Self {
+        Self {
+            contents,
+            index: OnceCell::new(),
+        }
+    }
+
+    pub fn with_index(contents: &'a str, index: LineIndex) -> Self {
+        Self {
+            contents,
+            index: OnceCell::from(index),
+        }
+    }
+
+    #[deprecated(
+        note = "This is expensive, avoid using outside of the diagnostic phase. Prefer the other `Locator` methods instead."
+    )]
+    pub fn compute_line_index(&self, offset: TextSize) -> OneIndexed {
+        self.to_index().line_index(offset)
+    }
+
+    #[deprecated(
+        note = "This is expensive, avoid using outside of the diagnostic phase. Prefer the other `Locator` methods instead."
+    )]
+    pub fn compute_source_location(&self, offset: TextSize) -> SourceLocation {
+        self.to_source_code().source_location(offset)
+    }
+
+    pub fn to_index(&self) -> &LineIndex {
+        self.index
+            .get_or_init(|| LineIndex::from_source_text(self.contents))
+    }
+
+    pub fn line_index(&self) -> Option<&LineIndex> {
+        self.index.get()
+    }
+
+    pub fn to_source_code(&self) -> SourceCode {
+        SourceCode::new(self.contents, self.to_index())
+    }
+
+    /// Take the source code up to the given [`TextSize`].
+    #[inline]
+    pub fn up_to(&self, offset: TextSize) -> &'a str {
+        &self.contents[TextRange::up_to(offset)]
+    }
+
+    /// Take the source code after the given [`TextSize`].
+    #[inline]
+    pub fn after(&self, offset: TextSize) -> &'a str {
+        &self.contents[usize::from(offset)..]
+    }
+
+    /// Finds the closest [`TextSize`] not exceeding the offset for which `is_char_boundary` is
+    /// `true`.
+    ///
+    /// Can be replaced with `str::floor_char_boundary` once it's stable.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # use ruff_text_size::{Ranged, TextRange, TextSize};
+    /// # use ruff_linter::Locator;
+    ///
+    /// let locator = Locator::new("Hello");
+    ///
+    /// assert_eq!(
+    ///     locator.floor_char_boundary(TextSize::from(0)),
+    ///     TextSize::from(0)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     locator.floor_char_boundary(TextSize::from(5)),
+    ///     TextSize::from(5)
+    /// );
+    ///
+    /// let locator = Locator::new("α");
+    ///
+    /// assert_eq!(
+    ///     locator.floor_char_boundary(TextSize::from(0)),
+    ///     TextSize::from(0)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     locator.floor_char_boundary(TextSize::from(1)),
+    ///     TextSize::from(0)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     locator.floor_char_boundary(TextSize::from(2)),
+    ///     TextSize::from(2)
+    /// );
+    /// ```
+    pub fn floor_char_boundary(&self, offset: TextSize) -> TextSize {
+        if offset >= self.text_len() {
+            self.text_len()
+        } else {
+            // We know that the character boundary is within four bytes.
+            (0u32..=3u32)
+                .map(TextSize::from)
+                .filter_map(|index| offset.checked_sub(index))
+                .find(|offset| self.contents.is_char_boundary(offset.to_usize()))
+                .unwrap_or_default()
+        }
+    }
+
+    /// Finds the closest [`TextSize`] not less than the offset given for which
+    /// `is_char_boundary` is `true`. Unless the offset given is greater than
+    /// the length of the underlying contents, in which case, the length of the
+    /// contents is returned.
+    ///
+    /// Can be replaced with `str::ceil_char_boundary` once it's stable.
+    ///
+    /// # Examples
+    ///
+    /// From `std`:
+    ///
+    /// ```
+    /// use ruff_text_size::{Ranged, TextSize};
+    /// use ruff_linter::Locator;
+    ///
+    /// let locator = Locator::new("❤️🧡💛💚💙💜");
+    /// assert_eq!(locator.text_len(), TextSize::from(26));
+    /// assert!(!locator.contents().is_char_boundary(13));
+    ///
+    /// let closest = locator.ceil_char_boundary(TextSize::from(13));
+    /// assert_eq!(closest, TextSize::from(14));
+    /// assert_eq!(&locator.contents()[..closest.to_usize()], "❤️🧡💛");
+    /// ```
+    ///
+    /// Additional examples:
+    ///
+    /// ```
+    /// use ruff_text_size::{Ranged, TextRange, TextSize};
+    /// use ruff_linter::Locator;
+    ///
+    /// let locator = Locator::new("Hello");
+    ///
+    /// assert_eq!(
+    ///     locator.ceil_char_boundary(TextSize::from(0)),
+    ///     TextSize::from(0)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     locator.ceil_char_boundary(TextSize::from(5)),
+    ///     TextSize::from(5)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     locator.ceil_char_boundary(TextSize::from(6)),
+    ///     TextSize::from(5)
+    /// );
+    ///
+    /// let locator = Locator::new("α");
+    ///
+    /// assert_eq!(
+    ///     locator.ceil_char_boundary(TextSize::from(0)),
+    ///     TextSize::from(0)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     locator.ceil_char_boundary(TextSize::from(1)),
+    ///     TextSize::from(2)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     locator.ceil_char_boundary(TextSize::from(2)),
+    ///     TextSize::from(2)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     locator.ceil_char_boundary(TextSize::from(3)),
+    ///     TextSize::from(2)
+    /// );
+    /// ```
+    pub fn ceil_char_boundary(&self, offset: TextSize) -> TextSize {
+        let upper_bound = offset
+            .to_u32()
+            .saturating_add(4)
+            .min(self.text_len().to_u32());
+        (offset.to_u32()..upper_bound)
+            .map(TextSize::from)
+            .find(|offset| self.contents.is_char_boundary(offset.to_usize()))
+            .unwrap_or_else(|| TextSize::from(upper_bound))
+    }
+
+    /// Take the source code between the given [`TextRange`].
+    #[inline]
+    pub fn slice<T: Ranged>(&self, ranged: T) -> &'a str {
+        &self.contents[ranged.range()]
+    }
+
+    /// Return the underlying source code.
+    pub const fn contents(&self) -> &'a str {
+        self.contents
+    }
+
+    /// Return the number of bytes in the source code.
+    pub const fn len(&self) -> usize {
+        self.contents.len()
+    }
+
+    pub fn text_len(&self) -> TextSize {
+        self.contents.text_len()
+    }
+
+    /// Return `true` if the source code is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.contents.is_empty()
+    }
+}
+
+// Override the `_str` methods from [`LineRanges`] to extend the lifetime to `'a`.
+#[allow(dead_code)]
+impl<'a> Locator<'a> {
+    /// Returns the text of the `offset`'s line.
+    ///
+    /// See [`LineRanges::full_lines_str`].
+    pub fn full_line_str(&self, offset: TextSize) -> &'a str {
+        self.contents.full_line_str(offset)
+    }
+
+    /// Returns the text of the `offset`'s line.
+    ///
+    /// See [`LineRanges::line_str`].
+    pub fn line_str(&self, offset: TextSize) -> &'a str {
+        self.contents.line_str(offset)
+    }
+
+    /// Returns the text of all lines that include `range`.
+    ///
+    /// See [`LineRanges::lines_str`].
+    pub fn lines_str(&self, range: TextRange) -> &'a str {
+        self.contents.lines_str(range)
+    }
+
+    /// Returns the text of all lines that include `range`.
+    ///
+    /// See [`LineRanges::full_lines_str`].
+    pub fn full_lines_str(&self, range: TextRange) -> &'a str {
+        self.contents.full_lines_str(range)
+    }
+}
+
+// Allow calling [`LineRanges`] methods on [`Locator`] directly.
+impl LineRanges for Locator<'_> {
+    #[inline]
+    fn line_start(&self, offset: TextSize) -> TextSize {
+        self.contents.line_start(offset)
+    }
+
+    #[inline]
+    fn bom_start_offset(&self) -> TextSize {
+        self.contents.bom_start_offset()
+    }
+
+    #[inline]
+    fn full_line_end(&self, offset: TextSize) -> TextSize {
+        self.contents.full_line_end(offset)
+    }
+
+    #[inline]
+    fn line_end(&self, offset: TextSize) -> TextSize {
+        self.contents.line_end(offset)
+    }
+
+    #[inline]
+    fn full_line_str(&self, offset: TextSize) -> &str {
+        self.contents.full_line_str(offset)
+    }
+
+    #[inline]
+    fn line_str(&self, offset: TextSize) -> &str {
+        self.contents.line_str(offset)
+    }
+
+    #[inline]
+    fn contains_line_break(&self, range: TextRange) -> bool {
+        self.contents.contains_line_break(range)
+    }
+
+    #[inline]
+    fn lines_str(&self, range: TextRange) -> &str {
+        self.contents.lines_str(range)
+    }
+
+    #[inline]
+    fn full_lines_str(&self, range: TextRange) -> &str {
+        self.contents.full_lines_str(range)
+    }
+}

--- a/fortitude/src/rules/bugprone/select_default.rs
+++ b/fortitude/src/rules/bugprone/select_default.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -15,13 +15,13 @@ use tree_sitter::Node;
 /// Unfortunately, because Fortran doesn't have proper enums, it's not possible
 /// for the compiler to issue warnings for non-exhaustive cases. Having a default
 /// case allows for the program to gracefully handle errors.
-#[violation]
-pub struct MissingDefaultCase {}
+#[derive(ViolationMetadata)]
+pub(crate) struct MissingDefaultCase {}
 
 impl Violation for MissingDefaultCase {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing default case may not handle all values")
+        "Missing default case may not handle all values".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/fortitude/src/rules/bugprone/trailing_backslash.rs
+++ b/fortitude/src/rules/bugprone/trailing_backslash.rs
@@ -4,7 +4,7 @@ use crate::settings::Settings;
 use crate::AstRule;
 use lazy_regex::regex;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 use tree_sitter::Node;
@@ -42,13 +42,13 @@ use tree_sitter::Node;
 /// ```
 /// which causes the assignment to not be compiled.
 ///
-#[violation]
-pub struct TrailingBackslash {}
+#[derive(ViolationMetadata)]
+pub(crate) struct TrailingBackslash {}
 
 impl Violation for TrailingBackslash {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Trailing backslash")
+        "Trailing backslash".to_string()
     }
 }
 

--- a/fortitude/src/rules/error/allow_comments.rs
+++ b/fortitude/src/rules/error/allow_comments.rs
@@ -1,5 +1,5 @@
 use ruff_diagnostics::Violation;
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 
 /// ## What it does
 /// Checks for invalid rules in allow comments.
@@ -14,8 +14,8 @@ use ruff_macros::{derive_message_formats, violation};
 /// program test
 /// end program test
 /// ```
-#[violation]
-pub struct InvalidRuleCodeOrName {
+#[derive(ViolationMetadata)]
+pub(crate) struct InvalidRuleCodeOrName {
     pub message: String,
 }
 

--- a/fortitude/src/rules/error/ioerror.rs
+++ b/fortitude/src/rules/error/ioerror.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use ruff_diagnostics::Violation;
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 
 /// ## What it does
 /// This is not a regular diagnostic; instead, it's raised when a file cannot be read
@@ -27,8 +27,8 @@ use ruff_macros::{derive_message_formats, violation};
 /// ## References
 /// - [UNIX Permissions introduction](https://mason.gmu.edu/~montecin/UNIXpermiss.htm)
 /// - [Command Line Basics: Symbolic Links](https://www.digitalocean.com/community/tutorials/workflow-symbolic-links)
-#[violation]
-pub struct IoError {
+#[derive(ViolationMetadata)]
+pub(crate) struct IoError {
     pub message: String,
 }
 

--- a/fortitude/src/rules/error/syntax_error.rs
+++ b/fortitude/src/rules/error/syntax_error.rs
@@ -2,7 +2,7 @@ use crate::settings::Settings;
 use crate::{some_vec, AstRule, FromAstNode};
 
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -16,13 +16,13 @@ use tree_sitter::Node;
 ///
 /// If this rule is reporting valid Fortran, please let us know, as it's likely a
 /// bug in our code or in our parser!
-#[violation]
-pub struct SyntaxError {}
+#[derive(ViolationMetadata)]
+pub(crate) struct SyntaxError {}
 
 impl Violation for SyntaxError {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Syntax error")
+        "Syntax error".to_string()
     }
 }
 

--- a/fortitude/src/rules/filesystem/extensions.rs
+++ b/fortitude/src/rules/filesystem/extensions.rs
@@ -1,5 +1,5 @@
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_text_size::TextRange;
 
 use crate::settings::Settings;
@@ -13,13 +13,13 @@ use std::path::Path;
 /// The standard file extensions for modern (free-form) Fortran are '.f90' or  '.F90'.
 /// Forms that reference later Fortran standards such as '.f08' or '.F95' may be rejected
 /// by some compilers and build tools.
-#[violation]
-pub struct NonStandardFileExtension {}
+#[derive(ViolationMetadata)]
+pub(crate) struct NonStandardFileExtension {}
 
 impl Violation for NonStandardFileExtension {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("file extension should be '.f90' or '.F90'")
+        "file extension should be '.f90' or '.F90'".to_string()
     }
 }
 

--- a/fortitude/src/rules/io/magic_io_unit.rs
+++ b/fortitude/src/rules/io/magic_io_unit.rs
@@ -2,7 +2,7 @@ use crate::ast::{is_keyword_argument, FortitudeNode};
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -30,8 +30,8 @@ use tree_sitter::Node;
 /// read(example_unit, fmt=*) int
 /// close(example_unit)
 /// ```
-#[violation]
-pub struct MagicIoUnit {
+#[derive(ViolationMetadata)]
+pub(crate) struct MagicIoUnit {
     value: i32,
 }
 
@@ -76,8 +76,8 @@ impl AstRule for MagicIoUnit {
 /// The Fortran standard does not specify numeric values for `stdin` or
 /// `stdout`. Instead, use the named constants `input_unit` and `output_unit`
 /// from the `iso_fortran_env` module.
-#[violation]
-pub struct NonPortableIoUnit {
+#[derive(ViolationMetadata)]
+pub(crate) struct NonPortableIoUnit {
     value: i32,
     kind: String,
     replacement: Option<String>,

--- a/fortitude/src/rules/io/missing_specifier.rs
+++ b/fortitude/src/rules/io/missing_specifier.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -14,13 +14,13 @@ use tree_sitter::Node;
 /// programmer's intent. Explicitly specifying `read`, `write` or `readwrite`
 /// makes it clear how the file is intended to be used, and prevents the
 /// accidental overwriting of input data.
-#[violation]
-pub struct MissingActionSpecifier {}
+#[derive(ViolationMetadata)]
+pub(crate) struct MissingActionSpecifier {}
 
 impl Violation for MissingActionSpecifier {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("file opened without action specifier")
+        "file opened without action specifier".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/fortitude/src/rules/modules/accessibility_statements.rs
+++ b/fortitude/src/rules/modules/accessibility_statements.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -21,8 +21,8 @@ use tree_sitter::Node;
 /// all of the same downsides as the default behaviour, but an explicit
 /// `public` statement makes it clear that the programmer is choosing
 /// this behaviour intentionally.  
-#[violation]
-pub struct MissingAccessibilityStatement {
+#[derive(ViolationMetadata)]
+pub(crate) struct MissingAccessibilityStatement {
     name: String,
 }
 
@@ -76,8 +76,8 @@ impl AstRule for MissingAccessibilityStatement {
 /// accidentally expose more than necessary. Public accessibility also makes
 /// it harder to detect unused entities, which can often be indicative of
 /// errors within the code.
-#[violation]
-pub struct DefaultPublicAccessibility {
+#[derive(ViolationMetadata)]
+pub(crate) struct DefaultPublicAccessibility {
     name: String,
 }
 

--- a/fortitude/src/rules/modules/external_functions.rs
+++ b/fortitude/src/rules/modules/external_functions.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -13,8 +13,8 @@ use tree_sitter::Node;
 /// Functions and subroutines should be contained within (sub)modules or programs.
 /// Fortran compilers are unable to perform type checks and conversions on functions
 /// defined outside of these scopes, and this is a common source of bugs.
-#[violation]
-pub struct ProcedureNotInModule {
+#[derive(ViolationMetadata)]
+pub(crate) struct ProcedureNotInModule {
     procedure: String,
 }
 

--- a/fortitude/src/rules/modules/file_contents.rs
+++ b/fortitude/src/rules/modules/file_contents.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -12,13 +12,13 @@ use tree_sitter::Node;
 /// Placing each module into its own file improves maintainability
 /// by making each module easier to locate for developers, and also
 /// making dependency generation in build systems easier.
-#[violation]
-pub struct MultipleModules {}
+#[derive(ViolationMetadata)]
+pub(crate) struct MultipleModules {}
 
 impl Violation for MultipleModules {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multiple modules in one file, split into one module per file")
+        "Multiple modules in one file, split into one module per file".to_string()
     }
 }
 
@@ -49,13 +49,13 @@ impl AstRule for MultipleModules {
 /// Separating top-level constructs into their own files improves
 /// maintainability by making each easier to locate for developers,
 /// and also making dependency generation in build systems easier.
-#[violation]
-pub struct ProgramWithModule {}
+#[derive(ViolationMetadata)]
+pub(crate) struct ProgramWithModule {}
 
 impl Violation for ProgramWithModule {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Program and module in one file, split into their own files")
+        "Program and module in one file, split into their own files".to_string()
     }
 }
 

--- a/fortitude/src/rules/modules/include_statement.rs
+++ b/fortitude/src/rules/modules/include_statement.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -21,13 +21,13 @@ use tree_sitter::Node;
 ///   'Deprecated Features'
 /// - _Difference between INCLUDE and modules in Fortran_, 2013,
 ///   https://stackoverflow.com/a/15668209
-#[violation]
-pub struct IncludeStatement {}
+#[derive(ViolationMetadata)]
+pub(crate) struct IncludeStatement {}
 
 impl Violation for IncludeStatement {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Include statement is deprecated, use modules instead")
+        "Include statement is deprecated, use modules instead".to_string()
     }
 }
 

--- a/fortitude/src/rules/modules/use_statements.rs
+++ b/fortitude/src/rules/modules/use_statements.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Edit, Fix, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextSize;
 use tree_sitter::Node;
@@ -28,13 +28,13 @@ use tree_sitter::Node;
 /// This makes it easier for programmers to understand where the symbols in your
 /// code have come from, and avoids introducing many unneeded components to your
 /// local scope.
-#[violation]
-pub struct UseAll {}
+#[derive(ViolationMetadata)]
+pub(crate) struct UseAll {}
 
 impl Violation for UseAll {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("'use' statement missing 'only' clause")
+        "'use' statement missing 'only' clause".to_string()
     }
 }
 
@@ -71,8 +71,8 @@ impl AstRule for UseAll {
 ///
 /// This ensures the compiler will use the built-in module instead of a different
 /// module with the same name.
-#[violation]
-pub struct MissingIntrinsic {}
+#[derive(ViolationMetadata)]
+pub(crate) struct MissingIntrinsic {}
 
 const INTRINSIC_MODULES: &[&str] = &[
     "iso_fortran_env",
@@ -85,7 +85,7 @@ const INTRINSIC_MODULES: &[&str] = &[
 impl Violation for MissingIntrinsic {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("'use' for intrinsic module missing 'intrinsic' modifier")
+        "'use' for intrinsic module missing 'intrinsic' modifier".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/fortitude/src/rules/obsolescent/common_blocks.rs
+++ b/fortitude/src/rules/obsolescent/common_blocks.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -64,13 +64,13 @@ use tree_sitter::Node;
 /// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
 ///   Incorporating Fortran 2018_, Oxford University Press, Appendix B
 ///   'Obsolescent and Deleted Features'
-#[violation]
-pub struct CommonBlock {}
+#[derive(ViolationMetadata)]
+pub(crate) struct CommonBlock {}
 
 impl Violation for CommonBlock {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("common blocks are obsolescent, prefer modules or derived types")
+        "common blocks are obsolescent, prefer modules or derived types".to_string()
     }
 }
 

--- a/fortitude/src/rules/obsolescent/computed_goto.rs
+++ b/fortitude/src/rules/obsolescent/computed_goto.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -69,13 +69,13 @@ use tree_sitter::Node;
 /// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
 ///   Incorporating Fortran 2018_, Oxford University Press, Appendix B
 ///   'Obsolescent and Deleted Features'
-#[violation]
-pub struct ComputedGoTo {}
+#[derive(ViolationMetadata)]
+pub(crate) struct ComputedGoTo {}
 
 impl Violation for ComputedGoTo {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("computed go to statements are obsolescent, use a select case statement")
+        "computed go to statements are obsolescent, use a select case statement".to_string()
     }
 }
 

--- a/fortitude/src/rules/obsolescent/entry_statement.rs
+++ b/fortitude/src/rules/obsolescent/entry_statement.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -21,13 +21,13 @@ use tree_sitter::Node;
 /// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
 ///   Incorporating Fortran 2018, Oxford University Press, Appendix B
 ///   'Obsolescent and Deleted Features'
-#[violation]
-pub struct EntryStatement {}
+#[derive(ViolationMetadata)]
+pub(crate) struct EntryStatement {}
 
 impl Violation for EntryStatement {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("entry statements are obsolescent, use module procedures with generic interface")
+        "entry statements are obsolescent, use module procedures with generic interface".to_string()
     }
 }
 

--- a/fortitude/src/rules/obsolescent/pause_statement.rs
+++ b/fortitude/src/rules/obsolescent/pause_statement.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Fix, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -18,13 +18,13 @@ use tree_sitter::Node;
 /// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
 ///   Incorporating Fortran 2018, Oxford University Press, Appendix B
 ///   'Obsolescent and Deleted Features'
-#[violation]
-pub struct PauseStatement {}
+#[derive(ViolationMetadata)]
+pub(crate) struct PauseStatement {}
 
 impl Violation for PauseStatement {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`pause` statements are a deleted feature")
+        "`pause` statements are a deleted feature".to_string()
     }
     fn fix_title(&self) -> Option<String> {
         Some("Use 'read(*, *)' instead".into())

--- a/fortitude/src/rules/obsolescent/specific_names.rs
+++ b/fortitude/src/rules/obsolescent/specific_names.rs
@@ -3,7 +3,7 @@ use crate::rules::utilities;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Fix, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -68,8 +68,8 @@ fn map_specific_intrinsic_functions(name: &str) -> Option<&'static str> {
 /// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
 ///   Incorporating Fortran 2018_, Oxford University Press, Appendix B
 ///   'Obsolescent and Deleted Features'
-#[violation]
-pub struct SpecificName {
+#[derive(ViolationMetadata)]
+pub(crate) struct SpecificName {
     func: String,
     new_func: String,
 }

--- a/fortitude/src/rules/obsolescent/statement_functions.rs
+++ b/fortitude/src/rules/obsolescent/statement_functions.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -36,13 +36,13 @@ use tree_sitter::Node;
 /// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
 ///   Incorporating Fortran 2018_, Oxford University Press, Appendix B
 ///   'Obsolescent and Deleted Features'
-#[violation]
-pub struct StatementFunction {}
+#[derive(ViolationMetadata)]
+pub(crate) struct StatementFunction {}
 
 impl Violation for StatementFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("statement functions are obsolescent, prefer internal functions")
+        "statement functions are obsolescent, prefer internal functions".to_string()
     }
 }
 

--- a/fortitude/src/rules/precision/double_precision.rs
+++ b/fortitude/src/rules/precision/double_precision.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -31,8 +31,8 @@ use tree_sitter::Node;
 /// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained: Incorporating Fortran
 ///   2018_, Oxford University Press, Appendix A 'Deprecated Features'
 /// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
-#[violation]
-pub struct DoublePrecision {
+#[derive(ViolationMetadata)]
+pub(crate) struct DoublePrecision {
     original: String, // TODO: could be &'static str
     preferred: String,
 }

--- a/fortitude/src/rules/precision/implicit_kinds.rs
+++ b/fortitude/src/rules/precision/implicit_kinds.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -39,8 +39,8 @@ use tree_sitter::Node;
 ///
 /// ## References
 /// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
-#[violation]
-pub struct ImplicitRealKind {
+#[derive(ViolationMetadata)]
+pub(crate) struct ImplicitRealKind {
     dtype: String,
 }
 

--- a/fortitude/src/rules/precision/kind_suffixes.rs
+++ b/fortitude/src/rules/precision/kind_suffixes.rs
@@ -3,7 +3,7 @@ use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -56,8 +56,8 @@ use tree_sitter::Node;
 ///
 /// ## References
 /// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
-#[violation]
-pub struct NoRealSuffix {
+#[derive(ViolationMetadata)]
+pub(crate) struct NoRealSuffix {
     literal: String,
 }
 

--- a/fortitude/src/rules/readability/magic_numbers.rs
+++ b/fortitude/src/rules/readability/magic_numbers.rs
@@ -3,7 +3,7 @@ use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use itertools::Itertools;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -30,8 +30,8 @@ use tree_sitter::Node;
 /// integer, parameter :: NUM_SPLINE_POINTS = 10
 /// integer, dimension(NUM_SPLINE_POINTS) :: x, y
 /// ```
-#[violation]
-pub struct MagicNumberInArraySize {
+#[derive(ViolationMetadata)]
+pub(crate) struct MagicNumberInArraySize {
     value: i32,
 }
 

--- a/fortitude/src/rules/style/double_colon_in_decl.rs
+++ b/fortitude/src/rules/style/double_colon_in_decl.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextSize;
 use tree_sitter::Node;
@@ -13,13 +13,13 @@ use tree_sitter::Node;
 /// ## Why is this bad?
 /// The double-colon separator is required when declaring variables with
 /// attributes, so for consistency, all variable declarations should use it.
-#[violation]
-pub struct MissingDoubleColon {}
+#[derive(ViolationMetadata)]
+pub(crate) struct MissingDoubleColon {}
 
 impl AlwaysFixableViolation for MissingDoubleColon {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("variable declaration missing '::'")
+        "variable declaration missing '::'".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/fortitude/src/rules/style/end_statements.rs
+++ b/fortitude/src/rules/style/end_statements.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -36,8 +36,8 @@ use tree_sitter::Node;
 /// ```
 ///
 /// Similar rules apply for many other Fortran statements
-#[violation]
-pub struct UnnamedEndStatement {
+#[derive(ViolationMetadata)]
+pub(crate) struct UnnamedEndStatement {
     statement: String,
     name: String,
 }
@@ -45,7 +45,7 @@ pub struct UnnamedEndStatement {
 impl AlwaysFixableViolation for UnnamedEndStatement {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("end statement should be named.")
+        "end statement should be named.".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/fortitude/src/rules/style/exit_labels.rs
+++ b/fortitude/src/rules/style/exit_labels.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextSize;
 use tree_sitter::Node;
@@ -21,8 +21,8 @@ use tree_sitter::Node;
 /// Using named loops is particularly useful for nested or complicated loops, as it
 /// helps the reader keep track of the flow of logic. It's also the only way to `exit`
 /// or `cycle` outer loops from within inner ones.
-#[violation]
-pub struct MissingExitOrCycleLabel {
+#[derive(ViolationMetadata)]
+pub(crate) struct MissingExitOrCycleLabel {
     name: String,
     label: String,
 }

--- a/fortitude/src/rules/style/line_length.rs
+++ b/fortitude/src/rules/style/line_length.rs
@@ -3,7 +3,7 @@ use crate::settings::Settings;
 use crate::TextRule;
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{TextLen, TextRange, TextSize};
@@ -26,8 +26,8 @@ use ruff_text_size::{TextLen, TextRange, TextSize};
 /// Note that the Fortran standard states a maximum line length of 132 characters,
 /// and while some modern compilers will support longer lines, for portability it
 /// is recommended to stay beneath this limit.
-#[violation]
-pub struct LineTooLong {
+#[derive(ViolationMetadata)]
+pub(crate) struct LineTooLong {
     max_length: usize,
     actual_length: usize,
 }

--- a/fortitude/src/rules/style/old_style_array_literal.rs
+++ b/fortitude/src/rules/style/old_style_array_literal.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -13,13 +13,13 @@ use tree_sitter::Node;
 /// Fortran 2003 introduced a shorter syntax for array literals: `[...]`. While the
 /// older style, `(/.../)`, is still valid, the F2003 style is shorter and easier to
 /// match.
-#[violation]
-pub struct OldStyleArrayLiteral {}
+#[derive(ViolationMetadata)]
+pub(crate) struct OldStyleArrayLiteral {}
 
 impl AlwaysFixableViolation for OldStyleArrayLiteral {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Array literal uses old-style syntax: prefer `[...]`")
+        "Array literal uses old-style syntax: prefer `[...]`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/fortitude/src/rules/style/relational_operators.rs
+++ b/fortitude/src/rules/style/relational_operators.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -25,8 +25,8 @@ fn map_relational_symbols(name: &str) -> Option<&'static str> {
 /// Fortran 90 introduced the traditional symbols for relational operators: `>`,
 /// `>=`, `<`, and so on. Prefer these over the deprecated forms `.gt.`, `.le.`, and
 /// so on.
-#[violation]
-pub struct DeprecatedRelationalOperator {
+#[derive(ViolationMetadata)]
+pub(crate) struct DeprecatedRelationalOperator {
     symbol: String,
     new_symbol: String,
 }

--- a/fortitude/src/rules/style/semicolons.rs
+++ b/fortitude/src/rules/style/semicolons.rs
@@ -1,5 +1,5 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextSize;
 use tree_sitter::Node;
@@ -59,17 +59,17 @@ fn semicolon_is_superfluous(node: &Node) -> bool {
 ///
 /// A semicolon at the beginning of a statement similarly has no effect, nor do
 /// multiple semicolons in sequence.
-#[violation]
-pub struct SuperfluousSemicolon {}
+#[derive(ViolationMetadata)]
+pub(crate) struct SuperfluousSemicolon {}
 
 impl AlwaysFixableViolation for SuperfluousSemicolon {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("unnecessary semicolon")
+        "unnecessary semicolon".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove this character")
+        "Remove this character".to_string()
     }
 }
 
@@ -92,17 +92,17 @@ impl AstRule for SuperfluousSemicolon {
 ///
 /// ## Why is this bad?
 /// This can have a detrimental effect on code readability.
-#[violation]
-pub struct MultipleStatementsPerLine {}
+#[derive(ViolationMetadata)]
+pub(crate) struct MultipleStatementsPerLine {}
 
 impl AlwaysFixableViolation for MultipleStatementsPerLine {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("multiple statements per line")
+        "multiple statements per line".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Separate over two lines")
+        "Separate over two lines".to_string()
     }
 }
 

--- a/fortitude/src/rules/style/whitespace.rs
+++ b/fortitude/src/rules/style/whitespace.rs
@@ -1,6 +1,6 @@
 /// Defines rules that enforce widely accepted whitespace rules.
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::{SourceFile, UniversalNewlines};
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use tree_sitter::Node;
@@ -15,17 +15,17 @@ use crate::{AstRule, FromAstNode, TextRule};
 /// Trailing whitespace is difficult to spot, and as some editors will remove it
 /// automatically while others leave it, it can cause unwanted 'diff noise' in
 /// shared projects.
-#[violation]
-pub struct TrailingWhitespace {}
+#[derive(ViolationMetadata)]
+pub(crate) struct TrailingWhitespace {}
 
 impl AlwaysFixableViolation for TrailingWhitespace {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("trailing whitespace")
+        "trailing whitespace".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove trailing whitespace")
+        "Remove trailing whitespace".to_string()
     }
 }
 
@@ -61,17 +61,17 @@ impl TextRule for TrailingWhitespace {
 /// ## References
 /// - [PEP8 Python Style Guide](https://peps.python.org/pep-0008/)
 /// - [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html#Horizontal_Whitespace)
-#[violation]
-pub struct IncorrectSpaceBeforeComment {}
+#[derive(ViolationMetadata)]
+pub(crate) struct IncorrectSpaceBeforeComment {}
 
 impl AlwaysFixableViolation for IncorrectSpaceBeforeComment {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("need at least 2 spaces before inline comment")
+        "need at least 2 spaces before inline comment".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("add extra whitespace")
+        "add extra whitespace".to_string()
     }
 }
 impl AstRule for IncorrectSpaceBeforeComment {

--- a/fortitude/src/rules/testing/test_rules.rs
+++ b/fortitude/src/rules/testing/test_rules.rs
@@ -4,7 +4,7 @@
 
 /// Fake rules for testing fortitude's behaviour
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::rules::Rule;
@@ -43,15 +43,15 @@ pub(crate) trait TestRule {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct StableTestRule;
+#[derive(ViolationMetadata)]
+pub(crate) struct StableTestRule;
 
 impl Violation for StableTestRule {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a stable test rule.")
+        "Hey this is a stable test rule.".to_string()
     }
 }
 
@@ -76,15 +76,15 @@ impl TestRule for StableTestRule {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct StableTestRuleSafeFix;
+#[derive(ViolationMetadata)]
+pub(crate) struct StableTestRuleSafeFix;
 
 impl Violation for StableTestRuleSafeFix {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a stable test rule with a safe fix.")
+        "Hey this is a stable test rule with a safe fix.".to_string()
     }
 }
 
@@ -114,15 +114,15 @@ impl TestRule for StableTestRuleSafeFix {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct StableTestRuleUnsafeFix;
+#[derive(ViolationMetadata)]
+pub(crate) struct StableTestRuleUnsafeFix;
 
 impl Violation for StableTestRuleUnsafeFix {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a stable test rule with an unsafe fix.")
+        "Hey this is a stable test rule with an unsafe fix.".to_string()
     }
 }
 
@@ -151,15 +151,15 @@ impl TestRule for StableTestRuleUnsafeFix {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct StableTestRuleDisplayOnlyFix;
+#[derive(ViolationMetadata)]
+pub(crate) struct StableTestRuleDisplayOnlyFix;
 
 impl Violation for StableTestRuleDisplayOnlyFix {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a stable test rule with a display only fix.")
+        "Hey this is a stable test rule with a display only fix.".to_string()
     }
 }
 
@@ -189,15 +189,15 @@ impl TestRule for StableTestRuleDisplayOnlyFix {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct PreviewTestRule;
+#[derive(ViolationMetadata)]
+pub(crate) struct PreviewTestRule;
 
 impl Violation for PreviewTestRule {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a preview test rule.")
+        "Hey this is a preview test rule.".to_string()
     }
 }
 
@@ -222,15 +222,15 @@ impl TestRule for PreviewTestRule {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct DeprecatedTestRule;
+#[derive(ViolationMetadata)]
+pub(crate) struct DeprecatedTestRule;
 
 impl Violation for DeprecatedTestRule {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a deprecated test rule.")
+        "Hey this is a deprecated test rule.".to_string()
     }
 }
 
@@ -255,15 +255,15 @@ impl TestRule for DeprecatedTestRule {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct AnotherDeprecatedTestRule;
+#[derive(ViolationMetadata)]
+pub(crate) struct AnotherDeprecatedTestRule;
 
 impl Violation for AnotherDeprecatedTestRule {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is another deprecated test rule.")
+        "Hey this is another deprecated test rule.".to_string()
     }
 }
 
@@ -288,15 +288,15 @@ impl TestRule for AnotherDeprecatedTestRule {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct RemovedTestRule;
+#[derive(ViolationMetadata)]
+pub(crate) struct RemovedTestRule;
 
 impl Violation for RemovedTestRule {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a removed test rule.")
+        "Hey this is a removed test rule.".to_string()
     }
 }
 
@@ -321,15 +321,15 @@ impl TestRule for RemovedTestRule {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct AnotherRemovedTestRule;
+#[derive(ViolationMetadata)]
+pub(crate) struct AnotherRemovedTestRule;
 
 impl Violation for AnotherRemovedTestRule {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a another removed test rule.")
+        "Hey this is a another removed test rule.".to_string()
     }
 }
 
@@ -354,15 +354,15 @@ impl TestRule for AnotherRemovedTestRule {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct RedirectedFromTestRule;
+#[derive(ViolationMetadata)]
+pub(crate) struct RedirectedFromTestRule;
 
 impl Violation for RedirectedFromTestRule {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a test rule that was redirected to another.")
+        "Hey this is a test rule that was redirected to another.".to_string()
     }
 }
 
@@ -387,15 +387,15 @@ impl TestRule for RedirectedFromTestRule {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct RedirectedToTestRule;
+#[derive(ViolationMetadata)]
+pub(crate) struct RedirectedToTestRule;
 
 impl Violation for RedirectedToTestRule {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a test rule that was redirected from another.")
+        "Hey this is a test rule that was redirected from another.".to_string()
     }
 }
 
@@ -420,15 +420,15 @@ impl TestRule for RedirectedToTestRule {
 /// ```f90
 /// bar
 /// ```
-#[violation]
-pub struct RedirectedFromPrefixTestRule;
+#[derive(ViolationMetadata)]
+pub(crate) struct RedirectedFromPrefixTestRule;
 
 impl Violation for RedirectedFromPrefixTestRule {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a test rule that was redirected to another by prefix.")
+        "Hey this is a test rule that was redirected to another by prefix.".to_string()
     }
 }
 

--- a/fortitude/src/rules/typing/assumed_size.rs
+++ b/fortitude/src/rules/typing/assumed_size.rs
@@ -3,7 +3,7 @@ use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use itertools::Itertools;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -41,8 +41,8 @@ use tree_sitter::Node;
 /// Note that this doesn't apply to `character` types, where `character(len=*)` is
 /// actually the most appropriate specification for `intent(in)` arguments! This is
 /// because `character(len=:)` must be either a `pointer` or `allocatable`.
-#[violation]
-pub struct AssumedSize {
+#[derive(ViolationMetadata)]
+pub(crate) struct AssumedSize {
     name: String,
 }
 
@@ -148,8 +148,8 @@ impl AstRule for AssumedSize {
 ///   end subroutine set_text
 /// end program
 /// ```
-#[violation]
-pub struct AssumedSizeCharacterIntent {
+#[derive(ViolationMetadata)]
+pub(crate) struct AssumedSizeCharacterIntent {
     name: String,
 }
 
@@ -231,8 +231,8 @@ impl AstRule for AssumedSizeCharacterIntent {
 /// ## Why is this bad?
 /// The syntax `character*(*)` is a deprecated form of `character(len=*)`. Prefer the
 /// second form.
-#[violation]
-pub struct DeprecatedAssumedSizeCharacter {
+#[derive(ViolationMetadata)]
+pub(crate) struct DeprecatedAssumedSizeCharacter {
     name: String,
 }
 

--- a/fortitude/src/rules/typing/derived_default_init.rs
+++ b/fortitude/src/rules/typing/derived_default_init.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Edit, Fix, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextSize;
 use tree_sitter::Node;
@@ -52,8 +52,8 @@ use tree_sitter::Node;
 ///   Incorporating Fortran 2018_, Oxford University Press, Section 8.5.3/8.5.4.
 /// - Clerman, N. Spector, W., 2012, _Modern Fortran: Style and Usage_, Cambridge
 ///   University Press, Rule 136, p. 189.
-#[violation]
-pub struct MissingDefaultPointerInitalisation {
+#[derive(ViolationMetadata)]
+pub(crate) struct MissingDefaultPointerInitalisation {
     var: String,
 }
 

--- a/fortitude/src/rules/typing/external.rs
+++ b/fortitude/src/rules/typing/external.rs
@@ -1,5 +1,5 @@
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -14,8 +14,8 @@ use crate::{ast::FortitudeNode, settings::Settings, AstRule, FromAstNode};
 ///
 /// If the procedure is in your project, put it in a module (see
 /// `external-function`), or write an explicit interface.
-#[violation]
-pub struct ExternalProcedure {
+#[derive(ViolationMetadata)]
+pub(crate) struct ExternalProcedure {
     name: String,
 }
 

--- a/fortitude/src/rules/typing/implicit_typing.rs
+++ b/fortitude/src/rules/typing/implicit_typing.rs
@@ -3,7 +3,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextSize;
 use tree_sitter::Node;
@@ -28,8 +28,8 @@ fn child_is_implicit_none(node: &Node) -> bool {
 /// ## Why is this bad?
 /// 'implicit none' should be used in all modules and programs, as implicit typing
 /// reduces the readability of code and increases the chances of typing errors.
-#[violation]
-pub struct ImplicitTyping {
+#[derive(ViolationMetadata)]
+pub(crate) struct ImplicitTyping {
     entity: String,
 }
 
@@ -61,8 +61,8 @@ impl AstRule for ImplicitTyping {
 /// ## Why is this bad?
 /// Interface functions and subroutines require 'implicit none', even if they are
 /// inside a module that uses 'implicit none'.
-#[violation]
-pub struct InterfaceImplicitTyping {
+#[derive(ViolationMetadata)]
+pub(crate) struct InterfaceImplicitTyping {
     name: String,
 }
 
@@ -96,8 +96,8 @@ impl AstRule for InterfaceImplicitTyping {
 /// ## Why is this bad?
 /// If a module has 'implicit none' set, it is not necessary to set it in contained
 /// functions and subroutines (except when using interfaces).
-#[violation]
-pub struct SuperfluousImplicitNone {
+#[derive(ViolationMetadata)]
+pub(crate) struct SuperfluousImplicitNone {
     entity: String,
 }
 
@@ -161,13 +161,13 @@ impl AstRule for SuperfluousImplicitNone {
 ///
 /// `implicit none` is equivalent to `implicit none (type)`, so the full
 /// statement should be `implicit none (type, external)`.
-#[violation]
-pub struct ImplicitExternalProcedures {}
+#[derive(ViolationMetadata)]
+pub(crate) struct ImplicitExternalProcedures {}
 
 impl Violation for ImplicitExternalProcedures {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("'implicit none' missing 'external'")
+        "'implicit none' missing 'external'".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/fortitude/src/rules/typing/init_decls.rs
+++ b/fortitude/src/rules/typing/init_decls.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -65,8 +65,8 @@ use tree_sitter::Node;
 ///   print*, var
 /// end subroutine example
 /// ```
-#[violation]
-pub struct InitialisationInDeclaration {
+#[derive(ViolationMetadata)]
+pub(crate) struct InitialisationInDeclaration {
     name: String,
 }
 

--- a/fortitude/src/rules/typing/intent.rs
+++ b/fortitude/src/rules/typing/intent.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -24,8 +24,8 @@ use tree_sitter::Node;
 /// Finally, `intent(inout)` arguments can be both read and modified by the
 /// routine. If an `intent` is not specified, it will default to
 /// `intent(inout)`.
-#[violation]
-pub struct MissingIntent {
+#[derive(ViolationMetadata)]
+pub(crate) struct MissingIntent {
     entity: String,
     name: String,
 }

--- a/fortitude/src/rules/typing/literal_kinds.rs
+++ b/fortitude/src/rules/typing/literal_kinds.rs
@@ -3,7 +3,7 @@ use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -83,8 +83,8 @@ fn iso_fortran_env_param<S: AsRef<str>>(dtype: S, literal: u8) -> Option<String>
 ///                                          i4 => int32, &
 ///                                          i8 => int64
 /// ```
-#[violation]
-pub struct LiteralKind {
+#[derive(ViolationMetadata)]
+pub(crate) struct LiteralKind {
     dtype: String,
     literal: u8,
 }
@@ -179,8 +179,8 @@ fn integer_literal_kind<'a>(node: &'a Node, src: &str) -> Option<Node<'a>> {
 /// real(sp), parameter :: sqrt2 = 1.41421_sp
 /// real(dp), parameter :: pi = 3.14159265358979_dp
 /// ```
-#[violation]
-pub struct LiteralKindSuffix {
+#[derive(ViolationMetadata)]
+pub(crate) struct LiteralKindSuffix {
     literal: String,
     suffix: u8,
 }

--- a/fortitude/src/rules/typing/star_kinds.rs
+++ b/fortitude/src/rules/typing/star_kinds.rs
@@ -2,7 +2,7 @@ use crate::ast::{dtype_is_plain_number, strip_line_breaks, FortitudeNode};
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Fix, FixAvailability, Violation};
-use ruff_macros::{derive_message_formats, violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -24,8 +24,8 @@ use tree_sitter::Node;
 ///
 /// In a future version, we hope to upgrade this to a safe fix by use of parameters
 /// in `iso_fortran_env`, as `real*8` should always correspond to `real(real64)`.
-#[violation]
-pub struct StarKind {
+#[derive(ViolationMetadata)]
+pub(crate) struct StarKind {
     dtype: String,
     size: String,
     kind: String,

--- a/fortitude_macros/src/map_codes.rs
+++ b/fortitude_macros/src/map_codes.rs
@@ -431,8 +431,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
         rule_fixable_match_arms.extend(
             quote! {#(#attrs)* Self::#name => <#path as ruff_diagnostics::Violation>::FIX_AVAILABILITY,},
         );
-        rule_explanation_match_arms
-            .extend(quote! {#(#attrs)* Self::#name => #path::explanation(),});
+        rule_explanation_match_arms.extend(quote! {#(#attrs)* Self::#name => #path::explain(),});
         rule_name_match_arms.extend(quote! {#(#attrs)* Self::#name => stringify!(#name),});
 
         // Enable conversion from `DiagnosticKind` to `Rule`.
@@ -534,6 +533,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
 
             /// Returns the documentation for this rule.
             pub fn explanation(&self) -> Option<&'static str> {
+                use ruff_diagnostics::ViolationMetadata;
                 match self { #rule_explanation_match_arms }
             }
 


### PR DESCRIPTION
Bumping all the ruff packages to the latest ruff so that we don't drift too far from them

The only breaking changes are:

1. `Locator` is no longer in `ruff_source_file` but `ruff_linter`, which we don't want to use, so we need to vendor it completely. We actually don't use most of it currently, but there's definitely a few bits we will want to use (the index stuff is useful for LSP it seems)
2. `#[violation]` is now `#[derive(ViolationMetadata)]`
3. `Violation::mesage` now really hates `format!()` that doesn't actually format any arguments, so needs to be `"".to_string()` instead