### PR TITLE
Don't raise linter violations or apply fixes when syntax errors are detected

### DIFF
--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -373,6 +373,15 @@ pub(crate) fn check_and_fix_file<'a>(
 
         if iterations == 0 {
             is_valid_syntax = !tree.root_node().has_error();
+            if !is_valid_syntax {
+                warn_user_once_by_message!(
+                    "Syntax errors detected in file: {}. No fixes will be applied.",
+                    path.to_string_lossy()
+                );
+                return Err(anyhow!(
+                    "File contains syntax errors, no fixes will be applied"
+                ));
+            }
         } else if is_valid_syntax && tree.root_node().has_error() {
             report_fix_syntax_error(path, transformed.source_text(), fixed.keys().copied());
             return Err(anyhow!("Fix introduced a syntax error"));

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -296,6 +296,8 @@ pub(crate) fn check_path(
             "Syntax errors detected in file: {}. Discarding subsequent violations.",
             path.to_string_lossy()
         );
+        // Sort by byte-offset in the file
+        violations.sort_by_key(|diagnostic| diagnostic.range.start());
         // Retain all violations up to the first syntax error, inclusive.
         let syntax_error_idx = violations
             .iter()

--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -12,11 +12,16 @@ use crate::rule_table::RuleTable;
 #[cfg(any(feature = "test-rules", test))]
 use crate::rules::testing::test_rules::{self, TestRule, TEST_RULES};
 use crate::rules::Rule;
-use crate::rules::{error::ioerror::IoError, AstRuleEnum, PathRuleEnum, TextRuleEnum};
+use crate::rules::{
+    error::ioerror::IoError, error::syntax_error::SyntaxError, AstRuleEnum, PathRuleEnum,
+    TextRuleEnum,
+};
 use crate::settings::{self, CheckSettings, FixMode, ProgressBar, Settings};
 use crate::show_files::show_files;
 use crate::show_settings::show_settings;
 use crate::stdin::read_from_stdin;
+use crate::warn_user_once_by_message;
+use crate::FromAstNode;
 use crate::{fs, locator::Locator, warn_user_once};
 
 use anyhow::{anyhow, Context, Result};
@@ -210,6 +215,38 @@ pub(crate) fn check_path(
     let mut violations = Vec::new();
     let mut allow_comments = Vec::new();
 
+    // Perform AST analysis
+    let root = tree.root_node();
+    // If detecting syntax errors, ignore all other violations if a syntax error is found.
+    // This is because syntax errors can cause false positives in other rules.
+    if rules.enabled(Rule::SyntaxError) && root.has_error() {
+        warn_user_once_by_message!(
+            "Syntax errors detected in file: {}. No further checks will be performed.",
+            path.to_string_lossy()
+        );
+        for node in once(root).chain(root.descendants()) {
+            if node.is_error() {
+                violations.push(Diagnostic::from_node(SyntaxError {}, &node))
+            }
+        }
+        return violations;
+    } else {
+        for node in once(root).chain(root.descendants()) {
+            if let Some(rules) = ast_entrypoints.get(node.kind()) {
+                for rule in rules {
+                    if let Some(violation) = rule.check(settings, &node, file) {
+                        for v in violation {
+                            violations.push(v);
+                        }
+                    }
+                }
+            }
+            if let Some(allow_rules) = gather_allow_comments(&node, file) {
+                allow_comments.push(allow_rules);
+            };
+        }
+    }
+
     for rule in path_rules {
         if let Some(violation) = rule.check(settings, path) {
             violations.push(violation);
@@ -219,23 +256,6 @@ pub(crate) fn check_path(
     // Perform plain text analysis
     for rule in text_rules {
         violations.extend(rule.check(settings, file));
-    }
-
-    // Perform AST analysis
-    let root = tree.root_node();
-    for node in once(root).chain(root.descendants()) {
-        if let Some(rules) = ast_entrypoints.get(node.kind()) {
-            for rule in rules {
-                if let Some(violation) = rule.check(settings, &node, file) {
-                    for v in violation {
-                        violations.push(v);
-                    }
-                }
-            }
-        }
-        if let Some(allow_rules) = gather_allow_comments(&node, file) {
-            allow_comments.push(allow_rules);
-        };
     }
 
     // Raise violations for internal test rules

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -610,10 +610,10 @@ end program foo
     Ok(())
 }
 
-/// When checking a file with syntax errors, only syntax errors should be
-/// reported.  This is to prevent the linter from raising false positives due to
-/// an inaccurate AST.  In this case, the syntax error should cause the linter
-/// to ignore the missing implicit none.
+/// When checking a file with syntax errors, any violations after the syntax
+/// error are discarded.  This is to prevent the linter from raising false
+/// positives due to an inaccurate AST. In this case, the syntax error should
+/// cause the linter to ignore the second superfluous semi-colon violation.
 #[test]
 fn check_syntax_errors() -> anyhow::Result<()> {
     let tempdir = TempDir::new()?;
@@ -622,44 +622,57 @@ fn check_syntax_errors() -> anyhow::Result<()> {
         &test_file,
         r#"
 program foo
-  ! Missing implicit none should raise a violation
+  implicit none (type, external)
   integer :: i
   integer :: j
-  i = 2
+  i = 2;
   j = i ^ 2  ! This is a syntax error
-  print *, j
+  print *, j;
 end program foo
 "#,
     )?;
     apply_common_filters!();
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
                          .arg("check")
-                         .arg("--select=implicit-typing,syntax-error")
+                         .arg("--select=syntax-error,superfluous-semicolon")
+                         .arg("--preview")
                          .arg(&test_file),
                          @r"
     success: false
     exit_code: 1
     ----- stdout -----
+    [TEMP_FILE] S081 [*] unnecessary semicolon
+      |
+    4 |   integer :: i
+    5 |   integer :: j
+    6 |   i = 2;
+      |        ^ S081
+    7 |   j = i ^ 2  ! This is a syntax error
+    8 |   print *, j;
+      |
+      = help: Remove this character
+
     [TEMP_FILE] E001 Syntax error
       |
     5 |   integer :: j
-    6 |   i = 2
+    6 |   i = 2;
     7 |   j = i ^ 2  ! This is a syntax error
       |         ^^^ E001
-    8 |   print *, j
+    8 |   print *, j;
     9 | end program foo
       |
 
     fortitude: 1 files scanned.
-    Number of errors: 1
+    Number of errors: 2
 
     For more information about specific rules, run:
 
         fortitude explain X001,Y002,...
 
+    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: Syntax errors detected in file: [TEMP_FILE] No further checks will be performed.
+    warning: Syntax errors detected in file: [TEMP_FILE] Discarding subsequent violations.
     ",);
     Ok(())
 }
@@ -673,41 +686,121 @@ fn check_ignore_syntax_errors() -> anyhow::Result<()> {
         &test_file,
         r#"
 program foo
-  ! Missing implicit none should raise a violation
+  implicit none (type, external)
   integer :: i
   integer :: j
-  i = 2
+  i = 2;
   j = i ^ 2  ! This is a syntax error
-  print *, j
+  print *, j;
 end program foo
 "#,
     )?;
     apply_common_filters!();
     assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
                          .arg("check")
-                         .arg("--select=implicit-typing")
+                         .arg("--select=superfluous-semicolon")
+                         .arg("--preview")
                          .arg(&test_file),
                          @r"
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] C001 program missing 'implicit none'
+    [TEMP_FILE] S081 [*] unnecessary semicolon
       |
-    2 | program foo
-      | ^^^^^^^^^^^ C001
-    3 |   ! Missing implicit none should raise a violation
     4 |   integer :: i
+    5 |   integer :: j
+    6 |   i = 2;
+      |        ^ S081
+    7 |   j = i ^ 2  ! This is a syntax error
+    8 |   print *, j;
       |
+      = help: Remove this character
+
+    [TEMP_FILE] S081 [*] unnecessary semicolon
+      |
+    6 |   i = 2;
+    7 |   j = i ^ 2  ! This is a syntax error
+    8 |   print *, j;
+      |             ^ S081
+    9 | end program foo
+      |
+      = help: Remove this character
 
     fortitude: 1 files scanned.
-    Number of errors: 1
+    Number of errors: 2
 
     For more information about specific rules, run:
 
         fortitude explain X001,Y002,...
 
+    [*] 2 fixable with the `--fix` option.
 
     ----- stderr -----
+    ",);
+    Ok(())
+}
+
+/// Syntax errors can also be ignored with allow comments
+#[test]
+fn check_allow_syntax_errors() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f90");
+    fs::write(
+        &test_file,
+        r#"
+program foo
+  implicit none (type, external)
+  integer :: i
+  integer :: j
+  i = 2;
+  ! allow(syntax-error)
+  j = i ^ 2  ! This is a syntax error
+  print *, j;
+end program foo
+"#,
+    )?;
+    apply_common_filters!();
+    assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
+                         .arg("check")
+                         .arg("--select=syntax-error,superfluous-semicolon")
+                         .arg("--preview")
+                         .arg(&test_file),
+                         @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    [TEMP_FILE] S081 [*] unnecessary semicolon
+      |
+    4 |   integer :: i
+    5 |   integer :: j
+    6 |   i = 2;
+      |        ^ S081
+    7 |   ! allow(syntax-error)
+    8 |   j = i ^ 2  ! This is a syntax error
+      |
+      = help: Remove this character
+
+    [TEMP_FILE] S081 [*] unnecessary semicolon
+       |
+     7 |   ! allow(syntax-error)
+     8 |   j = i ^ 2  ! This is a syntax error
+     9 |   print *, j;
+       |             ^ S081
+    10 | end program foo
+       |
+       = help: Remove this character
+
+    fortitude: 1 files scanned.
+    Number of errors: 2
+
+    For more information about specific rules, run:
+
+        fortitude explain X001,Y002,...
+
+    [*] 2 fixable with the `--fix` option.
+
+    ----- stderr -----
+    warning: Syntax errors detected in file: [TEMP_FILE] Discarding subsequent violations.
     ",);
     Ok(())
 }

--- a/fortitude_macros/src/map_codes.rs
+++ b/fortitude_macros/src/map_codes.rs
@@ -261,6 +261,9 @@ fn generate_rule_to_code(
 
     let mut rule_noqa_code_match_arms = quote!();
     let mut rule_group_match_arms = quote!();
+    let mut rule_is_path_rule_match_arms = quote!();
+    let mut rule_is_text_rule_match_arms = quote!();
+    let mut rule_is_ast_rule_match_arms = quote!();
     let mut rule_defaultness_arms = quote!();
 
     for (rule, codes) in rule_to_codes {
@@ -275,6 +278,7 @@ fn generate_rule_to_code(
         let RuleMeta {
             category,
             code,
+            kind,
             group,
             attrs,
             defaultness,
@@ -291,6 +295,20 @@ fn generate_rule_to_code(
 
         rule_group_match_arms.extend(quote! {
             #(#attrs)* Rule::#rule_name => #group,
+        });
+
+        let is_path = kind.is_ident("Path");
+        let is_text = kind.is_ident("Text");
+        let is_ast = kind.is_ident("Ast");
+
+        rule_is_path_rule_match_arms.extend(quote! {
+            #(#attrs)* Rule::#rule_name => #is_path,
+        });
+        rule_is_text_rule_match_arms.extend(quote! {
+            #(#attrs)* Rule::#rule_name => #is_text,
+        });
+        rule_is_ast_rule_match_arms.extend(quote! {
+            #(#attrs)* Rule::#rule_name => #is_ast,
         });
 
         let is_default = defaultness.is_ident("Default");
@@ -332,6 +350,24 @@ fn generate_rule_to_code(
 
             pub fn is_removed(&self) -> bool {
                 matches!(self.group(), RuleGroup::Removed)
+            }
+
+            pub fn is_path_rule(&self) -> bool {
+                match self {
+                    #rule_is_path_rule_match_arms
+                }
+            }
+
+            pub fn is_text_rule(&self) -> bool {
+                match self {
+                    #rule_is_text_rule_match_arms
+                }
+            }
+
+            pub fn is_ast_rule(&self) -> bool {
+                match self {
+                    #rule_is_ast_rule_match_arms
+                }
             }
 
             pub fn is_default(&self) -> bool {


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/333

As suggested by @ZedThree, this could be altered so that linter violations are reported up to and including the first `syntax-error`. I'm currently playing around to see if there are any counter-examples that means a rule could be checking beyond a syntax error and return bad data as a result.