### PR TITLE
docs: fix links to best practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Written in Rust :crab: and installable with Python :snake:.
 - :chart_with_upwards_trend: 30+ rules, with many more planned.
 - :page_with_curl: Multiple output formats, including SARIF and GitHub/GitLab CI.
 - :handshake: Follows [community best
-  practices](https://fortran-lang.org/en/learn/best_practices/).
+  practices](https://fortran-lang.org/learn/best_practices/).
 - :muscle: Built on a robust [tree-sitter](https://tree-sitter.github.io/tree-sitter/)
   parser -- even syntax errors won't stop it!
 

--- a/docs/rules/double-precision.md
+++ b/docs/rules/double-precision.md
@@ -21,4 +21,4 @@ For code that should be compatible with C, you should instead use
 ## References
 - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained: Incorporating Fortran
   2018_, Oxford University Press, Appendix A 'Deprecated Features'
-- [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
+- [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/learn/best_practices/floating_point/)

--- a/docs/rules/implicit-real-kind.md
+++ b/docs/rules/implicit-real-kind.md
@@ -31,4 +31,4 @@ which is set to either `sp` or `dp` and used throughout a project. This can
 then be easily toggled depending on the user's needs.
 
 ## References
-- [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
+- [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/learn/best_practices/floating_point/)

--- a/docs/rules/no-real-suffix.md
+++ b/docs/rules/no-real-suffix.md
@@ -47,4 +47,4 @@ This rule will therefore require an explicit kind statement in the majority
 of cases where a floating point literal is found in an expression.
 
 ## References
-- [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
+- [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/learn/best_practices/floating_point/)

--- a/fortitude/src/rules/correctness/implicit_kinds.rs
+++ b/fortitude/src/rules/correctness/implicit_kinds.rs
@@ -38,7 +38,7 @@ use tree_sitter::Node;
 /// then be easily toggled depending on the user's needs.
 ///
 /// ## References
-/// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
+/// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/learn/best_practices/floating_point/)
 #[derive(ViolationMetadata)]
 pub(crate) struct ImplicitRealKind {
     dtype: String,

--- a/fortitude/src/rules/correctness/kind_suffixes.rs
+++ b/fortitude/src/rules/correctness/kind_suffixes.rs
@@ -55,7 +55,7 @@ use tree_sitter::Node;
 /// of cases where a floating point literal is found in an expression.
 ///
 /// ## References
-/// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
+/// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/learn/best_practices/floating_point/)
 #[derive(ViolationMetadata)]
 pub(crate) struct NoRealSuffix {
     literal: String,

--- a/fortitude/src/rules/modernisation/double_precision.rs
+++ b/fortitude/src/rules/modernisation/double_precision.rs
@@ -30,7 +30,7 @@ use tree_sitter::Node;
 /// ## References
 /// - Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained: Incorporating Fortran
 ///   2018_, Oxford University Press, Appendix A 'Deprecated Features'
-/// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/en/learn/best_practices/floating_point/)
+/// - [Fortran-Lang Best Practices on Floating Point Numbers](https://fortran-lang.org/learn/best_practices/floating_point/)
 #[derive(ViolationMetadata)]
 pub(crate) struct DoublePrecision {
     original: String, // TODO: could be &'static str


### PR DESCRIPTION
Noticed an old link in the README.md. Did a search throughout, and fixed these too.