### PR TITLE
Write to stdout even when no fixes are applied in stdin mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Written in Rust :crab: and installable with Python :snake:.
 - :zap: Blazingly fast, up to hundreds of times faster than other open-source Fortran
   linters.
 - :wrench: Automatically fixes linter warnings.
-- :chart_with_upwards_trend: 30+ rules, with many more planned.
+- :chart_with_upwards_trend: 50+ rules, with many more planned.
 - :page_with_curl: Multiple output formats, including SARIF and GitHub/GitLab CI.
 - :handshake: Follows [community best
   practices](https://fortran-lang.org/learn/best_practices/).
 - :muscle: Built on a robust [tree-sitter](https://tree-sitter.github.io/tree-sitter/)
-  parser -- even syntax errors won't stop it!
+  parser.
 
 ## Table of Contents
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,3 +154,21 @@ see the [Poetry](https://python-poetry.org/docs/#enable-tab-completion-for-bash-
 As an example: to enable autocompletion for Bash, run `fortitude
 generate-shell-completion bash > ~/.bash_completion`, then reload your
 shell.
+
+## Editor integration
+
+We aim to add full Language Server Protocol (LSP) support in a future release
+which will enable Fortitude to run from within editors such as (Neo)Vim, Emacs
+and VSCode. In the meantime, it is possible to configure these editors to
+automate some tasks.
+
+### (NeoVim)
+
+Adding the following to your `~/.vimrc` or `~/.config/nvim/init.vim` file
+will set the commands `:FortitudeFix` and `:FortitudeFixUnsafe` which will
+apply fixes to the current file in your buffer:
+
+```vim
+command! FortitudeFix execute ':%! fortitude check --fix-only --silent --stdin-filename=%'
+command! FortitudeFixUnsafe execute ':%! fortitude check --fix-only --unsafe-fixes --silent --stdin-filename=%'
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,12 @@ Written in Rust :crab: and installable with Python :snake:.
 - :zap: Blazingly fast, up to hundreds of times faster than other open-source Fortran
   linters.
 - :wrench: Automatically fixes linter warnings.
-- :chart_with_upwards_trend: 30+ rules, with many more planned.
+- :chart_with_upwards_trend: 50+ rules, with many more planned.
 - :page_with_curl: Multiple output formats, including SARIF and GitHub/GitLab CI.
 - :handshake: Follows [community best
   practices](https://fortran-lang.org/learn/best_practices/).
 - :muscle: Built on a robust [tree-sitter](https://tree-sitter.github.io/tree-sitter/)
-  parser -- even syntax errors won't stop it!
+  parser.
 
 ## Quickstart
 
@@ -183,3 +183,5 @@ fortitude check --extend-select=OB
 Similar options include [`--extend-exclude`](settings.md#extend-exclude),
 `--extend-ignore` (command line only), and `--extend-per-file-ignores` (command
 line only).
+
+For a full list of options, please see the [settings page](settings.md).

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -2026,3 +2026,66 @@ end program test
 
     Ok(())
 }
+
+/// Check that fixing in stdin mode outputs the fixed file and nothing else.
+#[test]
+fn stdin_fix_mode() -> anyhow::Result<()> {
+    let input_file = r#"
+program test
+  implicit none
+end program test
+"#;
+    apply_common_filters!();
+    assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
+                         .arg("check")
+                         .arg("--select=C003")
+                         .arg("--fix-only")
+                         .arg("--unsafe-fixes")
+                         .arg("--silent")
+                         .arg("--stdin-filename=test.f90")
+                         .pass_stdin(input_file),
+                         @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    program test
+      implicit none (type, external)
+    end program test
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
+/// Check that fixing in stdin mode outputs the unmodified input file if there
+/// are no fixes to be made.
+#[test]
+fn stdin_fix_mode_no_fix() -> anyhow::Result<()> {
+    let input_file = r#"
+program test
+  implicit none (type, external)
+end program test
+"#;
+    assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
+                         .arg("check")
+                         .arg("--select=C003")
+                         .arg("--fix-only")
+                         .arg("--unsafe-fixes")
+                         .arg("--silent")
+                         .arg("--stdin-filename=test.f90")
+                         .pass_stdin(input_file),
+                         @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    program test
+      implicit none (type, external)
+    end program test
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
Solves https://github.com/PlasmaFAIR/fortitude/issues/355

Also updates the docs (and fixes some minor docs issues I've been aware of in the process). @ZedThree Could you let me know if there's an equivalent Emacs command? I'll try to figure out how to add this to VSCode's command palette.

While working on this I also uncovered and fixed some bugs in the behaviour of `--fix-only` mode. I'll raise a separate PR to keep things nicer in the changelog.
