### PR TITLE
Switch to `ruff`'s `version` machinery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,26 +271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,15 +318,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -500,7 +471,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "shadow-rs",
  "similar",
  "similar-asserts",
  "strum",
@@ -833,12 +803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_debug"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,27 +933,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1084,12 +1033,6 @@ name = "portable-atomic"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -1396,17 +1339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shadow-rs"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cfcd0643497a9f780502063aecbcc4a3212cbe4948fd25ee8fd179c2cf9a18"
-dependencies = [
- "const_format",
- "is_debug",
- "time",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,39 +1551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
-dependencies = [
- "deranged",
- "itoa",
- "libc",
- "num-conv",
- "num_threads",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,12 +1664,6 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,7 @@ Usage: fortitude [OPTIONS] <COMMAND>
 Commands:
   check    Perform static analysis on files and report issues
   explain  Get descriptions, rationales, and solutions for each rule
+  version  Display Fortitude's version
   help     Print this message or the help of the given subcommand(s)
 
 Options:

--- a/fortitude/Cargo.toml
+++ b/fortitude/Cargo.toml
@@ -45,7 +45,6 @@ serde = { version = "1.0.210", features = ["derive"] }
 serde_json = { workspace = true }
 similar = { version = "2.4.0", features = ["inline"] }
 similar-asserts = "1.6.0"
-shadow-rs = { version = "0.36.0", default-features = false }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 textwrap = { workspace = true }
@@ -58,9 +57,6 @@ url = { version = "2.5.0" }
 globset = "0.4.15"
 log = "0.4.22"
 fern = "0.7.1"
-
-[build-dependencies]
-shadow-rs = { version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/fortitude/build.rs
+++ b/fortitude/build.rs
@@ -1,3 +1,108 @@
-fn main() -> shadow_rs::SdResult<()> {
-    shadow_rs::new()
+// Adapted from ruff
+// Copyright 2022 Charles Marsh
+// SPDX-License-Identifier: MIT
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn main() {
+    // The workspace root directory is not available without walking up the tree
+    // https://github.com/rust-lang/cargo/issues/3946
+    let workspace_root = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("..");
+
+    commit_info(&workspace_root);
+
+    #[allow(clippy::disallowed_methods)]
+    let target = std::env::var("TARGET").unwrap();
+    println!("cargo::rustc-env=RUST_HOST_TARGET={target}");
+}
+
+fn commit_info(workspace_root: &Path) {
+    // If not in a git repository, do not attempt to retrieve commit information
+    let git_dir = workspace_root.join(".git");
+    if !git_dir.exists() {
+        return;
+    }
+
+    if let Some(git_head_path) = git_head(&git_dir) {
+        println!("cargo:rerun-if-changed={}", git_head_path.display());
+
+        let git_head_contents = fs::read_to_string(git_head_path);
+        if let Ok(git_head_contents) = git_head_contents {
+            // The contents are either a commit or a reference in the following formats
+            // - "<commit>" when the head is detached
+            // - "ref <ref>" when working on a branch
+            // If a commit, checking if the HEAD file has changed is sufficient
+            // If a ref, we need to add the head file for that ref to rebuild on commit
+            let mut git_ref_parts = git_head_contents.split_whitespace();
+            git_ref_parts.next();
+            if let Some(git_ref) = git_ref_parts.next() {
+                let git_ref_path = git_dir.join(git_ref);
+                println!("cargo:rerun-if-changed={}", git_ref_path.display());
+            }
+        }
+    }
+
+    let output = match Command::new("git")
+        .arg("log")
+        .arg("-1")
+        .arg("--date=short")
+        .arg("--abbrev=9")
+        .arg("--format=%H %h %cd %(describe:tags)")
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return,
+    };
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let mut parts = stdout.split_whitespace();
+    let mut next = || parts.next().unwrap();
+    println!("cargo::rustc-env=FORTITUDE_COMMIT_HASH={}", next());
+    println!("cargo::rustc-env=FORTITUDE_COMMIT_SHORT_HASH={}", next());
+    println!("cargo::rustc-env=FORTITUDE_COMMIT_DATE={}", next());
+
+    // Describe can fail for some commits
+    // https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emdescribeoptionsem
+    if let Some(describe) = parts.next() {
+        let mut describe_parts = describe.split('-');
+        println!(
+            "cargo::rustc-env=FORTITUDE_LAST_TAG={}",
+            describe_parts.next().unwrap()
+        );
+        // If this is the tagged commit, this component will be missing
+        println!(
+            "cargo::rustc-env=FORTITUDE_LAST_TAG_DISTANCE={}",
+            describe_parts.next().unwrap_or("0")
+        );
+    }
+}
+
+fn git_head(git_dir: &Path) -> Option<PathBuf> {
+    // The typical case is a standard git repository.
+    let git_head_path = git_dir.join("HEAD");
+    if git_head_path.exists() {
+        return Some(git_head_path);
+    }
+    if !git_dir.is_file() {
+        return None;
+    }
+    // If `.git/HEAD` doesn't exist and `.git` is actually a file,
+    // then let's try to attempt to read it as a worktree. If it's
+    // a worktree, then its contents will look like this, e.g.:
+    //
+    //     gitdir: /home/andrew/astral/uv/main/.git/worktrees/pr2
+    //
+    // And the HEAD file we want to watch will be at:
+    //
+    //     /home/andrew/astral/uv/main/.git/worktrees/pr2/HEAD
+    let contents = fs::read_to_string(git_dir).ok()?;
+    let (label, worktree_path) = contents.split_once(':')?;
+    if label != "gitdir" {
+        return None;
+    }
+    let worktree_path = worktree_path.trim();
+    Some(PathBuf::from(worktree_path))
 }

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -3,7 +3,6 @@ use serde::Deserialize;
 use std::path::PathBuf;
 
 use crate::{
-    build,
     fs::FilePattern,
     logging::LogLevel,
     rule_selector::RuleSelector,
@@ -18,7 +17,7 @@ use crate::{
     about = "Fortitude: A Fortran linter, inspired by (and built upon) Ruff.",
     after_help = "For help with a specific command, see: `fortitude help <command>`."
 )]
-#[command(version = build::CLAP_LONG_VERSION, about)]
+#[command(version, about)]
 pub struct Cli {
     #[clap(subcommand)]
     pub command: SubCommands,
@@ -101,6 +100,11 @@ pub enum SubCommands {
     GenerateShellCompletion {
         shell: clap_complete_command::Shell,
     },
+    /// Display Fortitude's version
+    Version {
+        #[arg(long, value_enum, default_value = "text")]
+        output_format: HelpFormat,
+    },
 }
 
 /// Get descriptions, rationales, and solutions for each rule.
@@ -115,6 +119,12 @@ pub struct ExplainArgs {
         hide_possible_values = true
     )]
     pub rules: Vec<RuleSelector>,
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum HelpFormat {
+    Text,
+    Json,
 }
 
 /// Perform static analysis on files and report issues.

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -1,3 +1,5 @@
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 mod allow_comments;
 mod ast;
 pub mod check;
@@ -25,6 +27,7 @@ pub mod stdin;
 #[cfg(test)]
 mod test;
 mod text_helpers;
+pub mod version;
 pub use crate::registry::clap_completion::RuleParser;
 pub use crate::rule_selector::clap_completion::RuleSelectorParser;
 
@@ -32,11 +35,8 @@ use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 use settings::Settings;
-use shadow_rs::shadow;
 use std::path::Path;
 use tree_sitter::Node;
-
-shadow!(build);
 
 // Violation type
 // --------------

--- a/fortitude/src/main.rs
+++ b/fortitude/src/main.rs
@@ -21,6 +21,10 @@ fn main() -> Result<ExitCode> {
             shell.generate(&mut Cli::command(), &mut stdout());
             return Ok(ExitCode::SUCCESS);
         }
+        SubCommands::Version { output_format } => {
+            fortitude::version::version_command(output_format)?;
+            return Ok(ExitCode::SUCCESS);
+        }
     };
     match status {
         Ok(code) => Ok(code),

--- a/fortitude/src/message/sarif.rs
+++ b/fortitude/src/message/sarif.rs
@@ -11,11 +11,11 @@ use serde_json::json;
 
 use ruff_source_file::OneIndexed;
 
-use crate::build::VERSION;
 use crate::fs::normalize_path;
 use crate::message::Emitter;
 use crate::registry::{Category, RuleNamespace};
 use crate::rules::Rule;
+use crate::VERSION;
 
 use super::DiagnosticMessage;
 

--- a/fortitude/src/snapshots/fortitude__version__tests__version_formatting.snap
+++ b/fortitude/src/snapshots/fortitude__version__tests__version_formatting.snap
@@ -1,0 +1,6 @@
+---
+source: fortitude/src/version.rs
+expression: version
+snapshot_kind: text
+---
+0.0.0

--- a/fortitude/src/snapshots/fortitude__version__tests__version_formatting_with_commit_info.snap
+++ b/fortitude/src/snapshots/fortitude__version__tests__version_formatting_with_commit_info.snap
@@ -1,0 +1,6 @@
+---
+source: fortitude/src/version.rs
+expression: version
+snapshot_kind: text
+---
+0.0.0 (53b0f5d92 2023-10-19)

--- a/fortitude/src/snapshots/fortitude__version__tests__version_formatting_with_commits_since_last_tag.snap
+++ b/fortitude/src/snapshots/fortitude__version__tests__version_formatting_with_commits_since_last_tag.snap
@@ -1,0 +1,6 @@
+---
+source: fortitude/src/version.rs
+expression: version
+snapshot_kind: text
+---
+0.0.0+24 (53b0f5d92 2023-10-19)

--- a/fortitude/src/snapshots/fortitude__version__tests__version_serializable.snap
+++ b/fortitude/src/snapshots/fortitude__version__tests__version_serializable.snap
@@ -1,0 +1,15 @@
+---
+source: fortitude/src/version.rs
+expression: version
+snapshot_kind: text
+---
+{
+  "version": "0.0.0",
+  "commit_info": {
+    "short_commit_hash": "53b0f5d92",
+    "commit_hash": "53b0f5d924110e5b26fbf09f6fd3a03d67b475b7",
+    "commit_date": "2023-10-19",
+    "last_tag": "v0.0.1",
+    "commits_since_last_tag": 0
+  }
+}

--- a/fortitude/src/version.rs
+++ b/fortitude/src/version.rs
@@ -1,0 +1,156 @@
+// Adapted from ruff
+// Copyright 2022 Charles Marsh
+// SPDX-License-Identifier: MIT
+
+//! Code for representing Fortitude's release version number.
+use serde::Serialize;
+use std::fmt;
+
+use std::io::{self, BufWriter, Write};
+
+use anyhow::Result;
+
+use crate::cli::HelpFormat;
+
+/// Display version information
+pub fn version_command(output_format: HelpFormat) -> Result<()> {
+    let mut stdout = BufWriter::new(io::stdout().lock());
+    let version_info = version();
+
+    match output_format {
+        HelpFormat::Text => {
+            writeln!(stdout, "fortitude {}", &version_info)?;
+        }
+        HelpFormat::Json => {
+            serde_json::to_writer_pretty(stdout, &version_info)?;
+        }
+    };
+    Ok(())
+}
+
+/// Information about the git repository where Fortitude was built from.
+#[derive(Serialize)]
+pub(crate) struct CommitInfo {
+    short_commit_hash: String,
+    commit_hash: String,
+    commit_date: String,
+    last_tag: Option<String>,
+    commits_since_last_tag: u32,
+}
+
+/// Fortitude's version.
+#[derive(Serialize)]
+pub(crate) struct VersionInfo {
+    /// Fortitude's version, such as "0.5.1"
+    version: String,
+    /// Information about the git commit we may have been built from.
+    ///
+    /// `None` if not built from a git repo or if retrieval failed.
+    commit_info: Option<CommitInfo>,
+}
+
+impl fmt::Display for VersionInfo {
+    /// Formatted version information: "<version>[+<commits>] (<commit> <date>)"
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.version)?;
+
+        if let Some(ref ci) = self.commit_info {
+            if ci.commits_since_last_tag > 0 {
+                write!(f, "+{}", ci.commits_since_last_tag)?;
+            }
+            write!(f, " ({} {})", ci.short_commit_hash, ci.commit_date)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns information about Fortitude's version.
+pub(crate) fn version() -> VersionInfo {
+    // Environment variables are only read at compile-time
+    macro_rules! option_env_str {
+        ($name:expr) => {
+            option_env!($name).map(|s| s.to_string())
+        };
+    }
+
+    // This version is pulled from Cargo.toml and set by Cargo
+    let version = option_env_str!("CARGO_PKG_VERSION").unwrap();
+
+    // Commit info is pulled from git and set by `build.rs`
+    let commit_info = option_env_str!("FORTITUDE_COMMIT_HASH").map(|commit_hash| CommitInfo {
+        short_commit_hash: option_env_str!("FORTITUDE_COMMIT_SHORT_HASH").unwrap(),
+        commit_hash,
+        commit_date: option_env_str!("FORTITUDE_COMMIT_DATE").unwrap(),
+        last_tag: option_env_str!("FORTITUDE_LAST_TAG"),
+        commits_since_last_tag: option_env_str!("FORTITUDE_LAST_TAG_DISTANCE")
+            .as_deref()
+            .map_or(0, |value| value.parse::<u32>().unwrap_or(0)),
+    });
+
+    VersionInfo {
+        version,
+        commit_info,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::{assert_json_snapshot, assert_snapshot};
+
+    use super::{CommitInfo, VersionInfo};
+
+    #[test]
+    fn version_formatting() {
+        let version = VersionInfo {
+            version: "0.0.0".to_string(),
+            commit_info: None,
+        };
+        assert_snapshot!(version);
+    }
+
+    #[test]
+    fn version_formatting_with_commit_info() {
+        let version = VersionInfo {
+            version: "0.0.0".to_string(),
+            commit_info: Some(CommitInfo {
+                short_commit_hash: "53b0f5d92".to_string(),
+                commit_hash: "53b0f5d924110e5b26fbf09f6fd3a03d67b475b7".to_string(),
+                last_tag: Some("v0.0.1".to_string()),
+                commit_date: "2023-10-19".to_string(),
+                commits_since_last_tag: 0,
+            }),
+        };
+        assert_snapshot!(version);
+    }
+
+    #[test]
+    fn version_formatting_with_commits_since_last_tag() {
+        let version = VersionInfo {
+            version: "0.0.0".to_string(),
+            commit_info: Some(CommitInfo {
+                short_commit_hash: "53b0f5d92".to_string(),
+                commit_hash: "53b0f5d924110e5b26fbf09f6fd3a03d67b475b7".to_string(),
+                last_tag: Some("v0.0.1".to_string()),
+                commit_date: "2023-10-19".to_string(),
+                commits_since_last_tag: 24,
+            }),
+        };
+        assert_snapshot!(version);
+    }
+
+    #[test]
+    fn version_serializable() {
+        let version = VersionInfo {
+            version: "0.0.0".to_string(),
+            commit_info: Some(CommitInfo {
+                short_commit_hash: "53b0f5d92".to_string(),
+                commit_hash: "53b0f5d924110e5b26fbf09f6fd3a03d67b475b7".to_string(),
+                last_tag: Some("v0.0.1".to_string()),
+                commit_date: "2023-10-19".to_string(),
+                commits_since_last_tag: 0,
+            }),
+        };
+        assert_json_snapshot!(version);
+    }
+}


### PR DESCRIPTION
This gives us a cleaner `--version` output on releases, while still
giving us more information on development versions.

Closes #348