### PR TITLE
Fix `--statistics` reporting for unsafe fixes

### DIFF
--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -770,7 +770,7 @@ pub fn check(args: CheckArgs, global_options: &GlobalConfigArgs) -> Result<ExitC
     );
 
     if args.statistics {
-        printer.write_statistics(&results.diagnostics, &mut summary_writer)?;
+        printer.write_statistics(&results, &mut summary_writer)?;
     } else {
         printer.write_once(&results, &mut summary_writer)?;
     }

--- a/fortitude/src/message/mod.rs
+++ b/fortitude/src/message/mod.rs
@@ -89,7 +89,6 @@ impl DiagnosticMessage {
     }
 
     /// Returns `true` if the message contains a [`Fix`].
-    #[allow(dead_code)]
     pub fn fixable(&self) -> bool {
         self.fix().is_some()
     }

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -1958,10 +1958,61 @@ end program test
     exit_code: 1
     ----- stdout -----
     2	PORT011	[ ] literal-kind
+    2	PORT021	[ ] star-kind
+    1	C001   	[ ] implicit-typing
+    1	S101   	[*] trailing-whitespace
+    fortitude: 1 files scanned.
+    Number of errors: 6
+
+    For more information about specific rules, run:
+
+        fortitude explain X001,Y002,...
+
+    [*] 1 fixable with the `--fix` option (2 hidden fixes can be enabled with the `--unsafe-fixes` option).
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn show_statistics_unsafe_fixes() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f90");
+    fs::write(
+        &test_file,
+        r#"
+program test
+  logical*4, parameter :: true = .true.
+  logical*4, parameter :: false = .false.  
+end program test
+"#,
+    )?;
+
+    apply_common_filters!();
+    assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
+                         .arg("check")
+                         .arg(test_file)
+                         .args(["--select=C001,S061,PORT011,PORT021,S101"])
+                         .arg("--statistics")
+                         .arg("--unsafe-fixes"),
+                         @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    2	PORT011	[ ] literal-kind
     2	PORT021	[*] star-kind
     1	C001   	[ ] implicit-typing
     1	S101   	[*] trailing-whitespace
-    [*] fixable with `fortitude check --fix`
+    fortitude: 1 files scanned.
+    Number of errors: 6
+
+    For more information about specific rules, run:
+
+        fortitude explain X001,Y002,...
+
+    [*] 3 fixable with the `--fix` option.
 
     ----- stderr -----
     ");
@@ -2005,7 +2056,7 @@ end program test
         "code": "PORT021",
         "name": "star-kind",
         "count": 2,
-        "fixable": true
+        "fixable": false
       },
       {
         "code": "C001",


### PR DESCRIPTION
Fixes #367

Previously, unsafe fixes were counted as "fixable" in
`Printer::write_statistics`, in contrast to the behaviour in
`Printer::write_once`. This changes the behaviour to align with
`write_once`, including them only if `--unsafe-fixes` is set.

We now also reuse `Printer::write_summary` to avoid duplicating the
logic for whether or not to report if there are hidden fixes.