### PR TITLE
docs: Remove readthedocs version menu from nav bar

### DIFF
--- a/docs/javascript/readthedocs.js
+++ b/docs/javascript/readthedocs.js
@@ -5,30 +5,3 @@ document.querySelector(".md-search__input").addEventListener("focus", (e) => {
         document.dispatchEvent(event);
     });
 });
-
-// Use CustomEvent to generate the version selector
-document.addEventListener(
-        "readthedocs-addons-data-ready",
-        function (event) {
-        const config = event.detail.data();
-        const versioning = `
-<div class="md-version">
-<button class="md-version__current" aria-label="Select version">
-    ${config.versions.current.slug}
-</button>
-
-<ul class="md-version__list">
-${ config.versions.active.map(
-    (version) => `
-    <li class="md-version__item">
-    <a href="${ version.urls.documentation }" class="md-version__link">
-        ${ version.slug }
-    </a>
-            </li>`).join("\n")}
-</ul>
-</div>`;
-
-    document.querySelector(".md-version").remove();
-    document.querySelector(".md-version__list").remove();
-    document.querySelector(".md-header__topic").insertAdjacentHTML("beforeend", versioning);
-});

--- a/docs/javascript/readthedocs.js
+++ b/docs/javascript/readthedocs.js
@@ -28,5 +28,7 @@ ${ config.versions.active.map(
 </ul>
 </div>`;
 
+    document.querySelector(".md-version").remove();
+    document.querySelector(".md-version__list").remove();
     document.querySelector(".md-header__topic").insertAdjacentHTML("beforeend", versioning);
 });


### PR DESCRIPTION
Previously this was getting duplicated on every page navigation due to
some incompatibility with mkdoc-material's "instant loading"
feature. It's probably better to have a speedy website than a fancy one!