### PR TITLE
WIP: Parse fixed-form, add basic converter to free-form

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "thiserror 1.0.66",
  "toml",
  "tree-sitter",
+ "tree-sitter-fixed-form-fortran",
  "tree-sitter-fortran",
  "unicode-width 0.2.0",
  "url",
@@ -1604,6 +1605,15 @@ dependencies = [
  "regex",
  "regex-syntax",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-fixed-form-fortran"
+version = "0.0.1"
+source = "git+https://github.com/ZedThree/tree-sitter-fixed-form-fortran.git?branch=f77-rebase#7f57e47f040479380e9f344b4174fba0efc57610"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,10 +39,11 @@ A Fortran linter, written in Rust and installable with Python
 Usage: fortitude [OPTIONS] <COMMAND>
 
 Commands:
-  check    Perform static analysis on files and report issues
-  explain  Get descriptions, rationales, and solutions for each rule
-  version  Display Fortitude's version
-  help     Print this message or the help of the given subcommand(s)
+  check          Perform static analysis on files and report issues
+  convert-fixed  Convert fixed form files to free form
+  explain        Get descriptions, rationales, and solutions for each rule
+  version        Display Fortitude's version
+  help           Print this message or the help of the given subcommand(s)
 
 Options:
       --config-file <CONFIG_FILE>  Path to a TOML configuration file
@@ -114,6 +115,8 @@ Rule selection:
 File selection:
       --file-extensions <EXTENSION>
           File extensions to check
+      --fixed-form-extensions <FIXED_EXTENSION>
+          File extensions to parse as fixed-form
       --exclude <FILE_PATTERN>
           List of paths, used to omit files and/or directories from analysis
       --extend-exclude <FILE_PATTERN>

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -229,6 +229,32 @@ Like [`fix`](#fix), but disables reporting on leftover violation. Implies [`fix`
 
 ---
 
+#### [`fixed-extensions`](#check_fixed-extensions) {: #check_fixed-extensions }
+<span id="fixed-extensions"></span>
+
+A list of extensions to parse as fixed-form
+
+**Default value**: `["f", "ftn"]`
+
+**Type**: `list[str]`
+
+**Example usage**:
+
+=== "fpm.toml"
+
+    ```toml
+    [fpm.extra.check]
+    ["f", "FOR"]
+    ```
+=== "fortitude.toml"
+
+    ```toml
+    [check]
+    ["f", "FOR"]
+    ```
+
+---
+
 #### [`force-exclude`](#check_force-exclude) {: #check_force-exclude }
 <span id="force-exclude"></span>
 

--- a/fortitude/Cargo.toml
+++ b/fortitude/Cargo.toml
@@ -52,6 +52,7 @@ thiserror = { version = "1.0.58" }
 toml = "0.8.19"
 tree-sitter = "~0.24.0"
 tree-sitter-fortran = "0.5.1"
+tree-sitter-fixed-form-fortran = { git = "https://github.com/ZedThree/tree-sitter-fixed-form-fortran.git", branch = "f77-rebase" }
 unicode-width = "0.2.0"
 url = { version = "2.5.0" }
 globset = "0.4.15"

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -94,6 +94,7 @@ impl From<&LogLevelArgs> for LogLevel {
 #[derive(Debug, Subcommand)]
 pub enum SubCommands {
     Check(CheckArgs),
+    ConvertFixed(ConvertFixedArgs),
     Explain(ExplainArgs),
     /// Generate shell completion.
     #[clap(hide = true)]
@@ -337,4 +338,28 @@ pub struct CheckArgs {
     /// Show counts for every rule with at least one violation.
     #[arg(long)]
     pub statistics: bool,
+}
+
+/// Convert fixed form files to free form
+#[derive(Debug, clap::Parser, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct ConvertFixedArgs {
+    /// List of files or directories to convert. Directories are searched recursively for
+    /// Fortran files. The `--file-extensions` option can be used to control which files
+    /// are included in the search.
+    #[arg(default_value = ".")]
+    pub files: Option<Vec<PathBuf>>,
+
+    /// File extensions to check
+    #[arg(long, value_delimiter = ',')]
+    pub file_extensions: Option<Vec<String>>,
+
+    /// List of paths, used to omit files and/or directories from conversion.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "FILE_PATTERN",
+        help_heading = "File selection"
+    )]
+    pub exclude: Option<Vec<FilePattern>>,
 }

--- a/fortitude/src/cli.rs
+++ b/fortitude/src/cli.rs
@@ -267,6 +267,15 @@ pub struct CheckArgs {
     )]
     pub file_extensions: Option<Vec<String>>,
 
+    /// File extensions to parse as fixed-form
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "FIXED_EXTENSION",
+        help_heading = "File selection"
+    )]
+    pub fixed_form_extensions: Option<Vec<String>>,
+
     /// List of paths, used to omit files and/or directories from analysis.
     #[arg(
         long,

--- a/fortitude/src/configuration.rs
+++ b/fortitude/src/configuration.rs
@@ -1,5 +1,5 @@
 use crate::cli::CheckArgs;
-use crate::fs::{FilePattern, FilePatternSet, EXCLUDE_BUILTINS, FIXED_EXTS, FORTRAN_EXTS};
+use crate::fs::{FilePattern, FilePatternSet, EXCLUDE_BUILTINS, FIXED_FORTRAN_EXTS, FORTRAN_EXTS};
 use crate::options::{ExitUnlabelledLoopOptions, Options};
 use crate::registry::RuleNamespace;
 use crate::rule_redirects::get_redirect;
@@ -180,7 +180,10 @@ impl Default for Configuration {
             per_file_ignores: Default::default(),
             line_length: Settings::default().check.line_length,
             file_extensions: FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect(),
-            fixed_extensions: FIXED_EXTS.iter().map(|ext| ext.to_string()).collect(),
+            fixed_extensions: FIXED_FORTRAN_EXTS
+                .iter()
+                .map(|ext| ext.to_string())
+                .collect(),
             fix: Default::default(),
             fix_only: Default::default(),
             show_fixes: Default::default(),
@@ -221,9 +224,12 @@ impl Configuration {
             file_extensions: check
                 .file_extensions
                 .unwrap_or(FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect_vec()),
-            fixed_extensions: check
-                .fixed_extensions
-                .unwrap_or(FIXED_EXTS.iter().map(|ext| ext.to_string()).collect_vec()),
+            fixed_extensions: check.fixed_extensions.unwrap_or(
+                FIXED_FORTRAN_EXTS
+                    .iter()
+                    .map(|ext| ext.to_string())
+                    .collect_vec(),
+            ),
             fix: check.fix.unwrap_or_default(),
             fix_only: check.fix_only.unwrap_or_default(),
             show_fixes: check.show_fixes.unwrap_or_default(),

--- a/fortitude/src/configuration.rs
+++ b/fortitude/src/configuration.rs
@@ -1,5 +1,5 @@
 use crate::cli::CheckArgs;
-use crate::fs::{FilePattern, FilePatternSet, EXCLUDE_BUILTINS, FORTRAN_EXTS};
+use crate::fs::{FilePattern, FilePatternSet, EXCLUDE_BUILTINS, FIXED_EXTS, FORTRAN_EXTS};
 use crate::options::{ExitUnlabelledLoopOptions, Options};
 use crate::registry::RuleNamespace;
 use crate::rule_redirects::get_redirect;
@@ -154,6 +154,7 @@ pub struct Configuration {
     pub per_file_ignores: Option<Vec<PerFileIgnore>>,
     pub line_length: usize,
     pub file_extensions: Vec<String>,
+    pub fixed_extensions: Vec<String>,
     pub fix: bool,
     pub fix_only: bool,
     pub show_fixes: bool,
@@ -179,6 +180,7 @@ impl Default for Configuration {
             per_file_ignores: Default::default(),
             line_length: Settings::default().check.line_length,
             file_extensions: FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect(),
+            fixed_extensions: FIXED_EXTS.iter().map(|ext| ext.to_string()).collect(),
             fix: Default::default(),
             fix_only: Default::default(),
             show_fixes: Default::default(),
@@ -219,6 +221,9 @@ impl Configuration {
             file_extensions: check
                 .file_extensions
                 .unwrap_or(FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect_vec()),
+            fixed_extensions: check
+                .fixed_extensions
+                .unwrap_or(FIXED_EXTS.iter().map(|ext| ext.to_string()).collect_vec()),
             fix: check.fix.unwrap_or_default(),
             fix_only: check.fix_only.unwrap_or_default(),
             show_fixes: check.show_fixes.unwrap_or_default(),
@@ -269,6 +274,7 @@ impl Configuration {
 
         let files = args.files.unwrap_or(self.files);
         let file_extensions = args.file_extensions.unwrap_or(self.file_extensions);
+        let fixed_extensions = args.fixed_form_extensions.unwrap_or(self.fixed_extensions);
 
         let per_file_ignores = if let Some(per_file_ignores) = args.per_file_ignores {
             Some(collect_per_file_ignores(per_file_ignores))
@@ -366,6 +372,7 @@ impl Configuration {
                 excludes: exclude,
                 files,
                 file_extensions,
+                fixed_extensions,
                 respect_gitignore: respect_gitignore.is_respect_gitignore(),
                 force_exclude: force_exclude.is_force(),
             },

--- a/fortitude/src/convert_fixed.rs
+++ b/fortitude/src/convert_fixed.rs
@@ -1,0 +1,128 @@
+use anyhow::{Context, Result};
+use itertools::Itertools;
+use lazy_regex::regex;
+use std::process::ExitCode;
+use tree_sitter::Parser;
+
+use crate::{
+    check::read_to_string,
+    cli::ConvertFixedArgs,
+    configuration::{self},
+    fs::{get_files, FilePatternSet, EXCLUDE_BUILTINS, FIXED_FORTRAN_EXTS},
+    settings::FileResolverSettings,
+    warn_user,
+};
+
+pub fn convert_fixed(args: ConvertFixedArgs) -> Result<ExitCode> {
+    let project_root = configuration::project_root(path_absolutize::path_dedot::CWD.as_path())?;
+
+    let file_extensions = args.file_extensions.unwrap_or(
+        FIXED_FORTRAN_EXTS
+            .iter()
+            .map(|ext| ext.to_string())
+            .collect_vec(),
+    );
+
+    let excludes = FilePatternSet::try_from_iter(
+        EXCLUDE_BUILTINS
+            .iter()
+            .cloned()
+            .chain(args.exclude.unwrap_or_default().into_iter()),
+    )?;
+
+    let resolver = FileResolverSettings {
+        excludes,
+        force_exclude: true,
+        files: args.files.unwrap_or_default(),
+        file_extensions,
+        fixed_extensions: vec![],
+        respect_gitignore: true,
+        project_root,
+    };
+
+    for path in get_files(&resolver, false)? {
+        let text = read_to_string(&path)?;
+
+        if has_syntax_errors(&text, FortranForm::Fixed)? {
+            warn_user!("file '{}' has syntax errors, skipping", &path.display());
+            continue;
+        }
+
+        let converted_text = convert_contents(text);
+
+        if has_syntax_errors(&converted_text, FortranForm::Free)? {
+            warn_user!("error converting file '{}', skipping", &path.display());
+            continue;
+        }
+
+        std::fs::write(path, converted_text)?;
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+enum FortranForm {
+    Fixed,
+    Free,
+}
+
+fn has_syntax_errors<S: AsRef<str>>(text: S, form: FortranForm) -> anyhow::Result<bool> {
+    let language = match form {
+        FortranForm::Fixed => tree_sitter_fixed_form_fortran::LANGUAGE,
+        FortranForm::Free => tree_sitter_fortran::LANGUAGE,
+    };
+    let mut parser = Parser::new();
+    parser
+        .set_language(&language.into())
+        .context("Error loading Fortran grammar")?;
+
+    let tree = parser
+        .parse(text.as_ref(), None)
+        .context("Failed to parse")?;
+
+    Ok(tree.root_node().has_error())
+}
+
+fn convert_contents<S: AsRef<str>>(fixed: S) -> String {
+    let comments_re = regex!(r#"^[^\s]"#im);
+    let new_string = comments_re.replace_all(fixed.as_ref(), "!");
+
+    let continue_re = regex!(r#"\n^     [^\s]"#m);
+    let new_string = continue_re.replace_all(&new_string, " &\n     &");
+
+    new_string.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use similar_asserts::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn basic_convert() -> Result<()> {
+        let fixed_file = r#"
+c Example fixed form program
+      PROGRAM TEST
+      PRINT*,'start
+     +        stop'
+* another comment
+      END
+"#;
+
+        let free_file = r#"
+! Example fixed form program
+      PROGRAM TEST
+      PRINT*,'start &
+     &        stop'
+! another comment
+      END
+"#;
+
+        let result = convert_contents(fixed_file);
+
+        assert_eq!(result, free_file);
+
+        Ok(())
+    }
+}

--- a/fortitude/src/fs.rs
+++ b/fortitude/src/fs.rs
@@ -247,6 +247,9 @@ pub const FORTRAN_EXTS: &[&str] = &[
     "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "f18", "F18", "f23", "F23",
 ];
 
+/// Default fixed-form extensions
+pub const FIXED_FORTRAN_EXTS: &[&str] = &["f", "ftn", "for", "fpp", "f77"];
+
 // Default paths to exclude when searching paths
 pub(crate) static EXCLUDE_BUILTINS: &[FilePattern] = &[
     FilePattern::Builtin(".git"),
@@ -325,6 +328,9 @@ pub fn get_files(resolver: &FileResolverSettings, is_stdin: bool) -> anyhow::Res
         // Directories will be skipped
         let mut file_types = TypesBuilder::new();
         for ext in &resolver.file_extensions {
+            file_types.add(ext.as_ref(), format!("*.{}", ext).as_str())?;
+        }
+        for ext in &resolver.fixed_extensions {
             file_types.add(ext.as_ref(), format!("*.{}", ext).as_str())?;
         }
         file_types.select("all");

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -5,6 +5,7 @@ mod ast;
 pub mod check;
 pub mod cli;
 mod configuration;
+pub mod convert_fixed;
 mod diagnostics;
 pub mod explain;
 mod fix;

--- a/fortitude/src/main.rs
+++ b/fortitude/src/main.rs
@@ -6,6 +6,7 @@ use clap::{CommandFactory, Parser};
 use colored::Colorize;
 use fortitude::check::check;
 use fortitude::cli::{Cli, SubCommands};
+use fortitude::convert_fixed::convert_fixed;
 use fortitude::explain::explain;
 use fortitude::logging::set_up_logging;
 
@@ -25,6 +26,7 @@ fn main() -> Result<ExitCode> {
             fortitude::version::version_command(output_format)?;
             return Ok(ExitCode::SUCCESS);
         }
+        SubCommands::ConvertFixed(args) => convert_fixed(args),
     };
     match status {
         Ok(code) => Ok(code),

--- a/fortitude/src/options.rs
+++ b/fortitude/src/options.rs
@@ -169,6 +169,14 @@ pub struct CheckOptions {
     )]
     pub file_extensions: Option<Vec<String>>,
 
+    /// A list of extensions to parse as fixed-form
+    #[option(
+        default = r#"["f", "ftn"]"#,
+        value_type = "list[str]",
+        example = r#"["f", "FOR"]"#
+    )]
+    pub fixed_extensions: Option<Vec<String>>,
+
     /// A list of file patterns to exclude from formatting and linting.
     ///
     /// Exclusions are based on globs, and can be either:

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -15,7 +15,7 @@ use serde::{de, Deserialize, Deserializer, Serialize};
 use strum::IntoEnumIterator;
 
 use crate::display_settings;
-use crate::fs::{FilePatternSet, EXCLUDE_BUILTINS, FORTRAN_EXTS};
+use crate::fs::{FilePatternSet, EXCLUDE_BUILTINS, FIXED_FORTRAN_EXTS, FORTRAN_EXTS};
 use crate::registry::Rule;
 use crate::rule_selector::{CompiledPerFileIgnoreList, PreviewOptions, RuleSelector};
 use crate::rule_table::RuleTable;
@@ -132,6 +132,7 @@ pub struct FileResolverSettings {
     pub force_exclude: bool,
     pub files: Vec<PathBuf>,
     pub file_extensions: Vec<String>,
+    pub fixed_extensions: Vec<String>,
     pub respect_gitignore: bool,
     pub project_root: PathBuf,
 }
@@ -147,6 +148,7 @@ impl fmt::Display for FileResolverSettings {
                 self.force_exclude,
                 self.files | paths,
                 self.file_extensions | array,
+                self.fixed_extensions | array,
                 self.respect_gitignore,
                 self.project_root | path,
             ]
@@ -164,6 +166,10 @@ impl FileResolverSettings {
             respect_gitignore: true,
             files: Vec::default(),
             file_extensions: FORTRAN_EXTS.iter().map(|ext| ext.to_string()).collect(),
+            fixed_extensions: FIXED_FORTRAN_EXTS
+                .iter()
+                .map(|ext| ext.to_string())
+                .collect(),
         }
     }
 }

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -145,7 +145,7 @@ unknown-key = 1
           |
         3 | unknown-key = 1
           | ^^^^^^^^^^^
-        unknown field `unknown-key`, expected one of `files`, `fix`, `unsafe-fixes`, `show-fixes`, `fix-only`, `output-format`, `preview`, `progress-bar`, `ignore`, `select`, `extend-select`, `file-extensions`, `exclude`, `extend-exclude`, `force-exclude`, `respect-gitignore`, `line-length`, `per-file-ignores`, `exit-unlabelled-loops`
+        unknown field `unknown-key`, expected one of `files`, `fix`, `unsafe-fixes`, `show-fixes`, `fix-only`, `output-format`, `preview`, `progress-bar`, `ignore`, `select`, `extend-select`, `file-extensions`, `fixed-extensions`, `exclude`, `extend-exclude`, `force-exclude`, `respect-gitignore`, `line-length`, `per-file-ignores`, `exit-unlabelled-loops`
     ");
     Ok(())
 }

--- a/fortitude/tests/convert.rs
+++ b/fortitude/tests/convert.rs
@@ -1,0 +1,146 @@
+use assert_cmd::prelude::*;
+use insta_cmd::assert_cmd_snapshot;
+use similar_asserts::assert_eq;
+use std::{fs, process::Command};
+use tempfile::TempDir;
+
+const BIN_NAME: &str = "fortitude";
+
+macro_rules! apply_common_filters {
+    {} => {
+        let mut settings = insta::Settings::clone_current();
+        // Macos Temp Folder
+        settings.add_filter(r"/var/folders/\S+?/T/\S+", "[TEMP_FILE]");
+        // Linux Temp Folder
+        settings.add_filter(r"/tmp/\.tmp\S+", "[TEMP_FILE]");
+        // Windows Temp folder
+        settings.add_filter(r"\b[A-Z]:\\.*\\Local\\Temp\\\S+", "[TEMP_FILE]");
+        // Convert windows paths to Unix Paths.
+        settings.add_filter(r"\\\\?([\w\d.])", "/$1");
+        let _bound = settings.bind_to_scope();
+    }
+}
+
+#[test]
+fn convert() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f");
+    fs::write(
+        &test_file,
+        r#"
+c Example fixed form program
+      PROGRAM TEST
+      PRINT*,'start
+     +        stop'
+* another comment
+      END
+"#,
+    )?;
+
+    apply_common_filters!();
+
+    assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
+                         .arg("convert-fixed")
+                         .arg(&test_file),
+                         @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    let expected = r#"
+! Example fixed form program
+      PROGRAM TEST
+      PRINT*,'start &
+     &        stop'
+! another comment
+      END
+"#;
+
+    let result = fs::read_to_string(test_file)?;
+
+    assert_eq!(result, expected);
+
+    Ok(())
+}
+
+#[test]
+fn convert_directory() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f");
+    fs::write(
+        &test_file,
+        r#"
+c Example fixed form program
+      PROGRAM TEST
+      PRINT*,'start
+     +        stop'
+* another comment
+      END
+"#,
+    )?;
+
+    apply_common_filters!();
+
+    assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
+                         .arg("convert-fixed")
+                         .current_dir(&tempdir),
+                         @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    let expected = r#"
+! Example fixed form program
+      PROGRAM TEST
+      PRINT*,'start &
+     &        stop'
+! another comment
+      END
+"#;
+
+    let result = fs::read_to_string(test_file)?;
+
+    assert_eq!(result, expected);
+
+    Ok(())
+}
+
+#[test]
+fn convert_syntax_error() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f");
+    let original = r#"
+c Example fixed form program
+      PROGRAM TEST
+      PRINT*,5 +
+* another comment
+      END
+"#;
+    fs::write(&test_file, original)?;
+
+    apply_common_filters!();
+
+    assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
+                         .arg("convert-fixed")
+                         .arg(&test_file),
+                         @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: file '[TEMP_FILE] has syntax errors, skipping
+    ");
+
+    let result = fs::read_to_string(test_file)?;
+
+    assert_eq!(result, original);
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #78 

Still a bunch of stuff to do, but this shows the how we can deal with fixed-form.

- [ ] Docs
- [ ] More tests?
- [ ] Better/more user settings
- [ ] Rule for "don't use fixed form"
- [ ] Parallelisation

This does the bare minimum in order to be able to parse fixed-form as free-form. There's lots of [existing tools](https://beliavsky.github.io/Fortran-Tools/#fixed-to-free-source-form-conversion) that do a fair bit more too, for example replacing `goto`, `continue`, etc with more modern features. I'm imagining we implement a lot those things with rules, as they may be used in free-form codes too, and then we could just find and fix those rules here too.

The other way we could implement this is as its own rule, and then we could either not provide a `convert-fixed` command, or just implement it essentially as `--select=fixed-form --fix`