### PR TITLE
Fix testcase extension in generated rule template

### DIFF
--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -50,7 +50,7 @@ def main(*, name: str, prefix: str, code: str, category: str) -> None:
             ):
                 indent = get_indent(line)
                 lines.append(
-                    f'{indent}#[test_case(Rule::{name}, Path::new("{filestem}.py"))]',
+                    f'{indent}#[test_case(Rule::{name}, Path::new("{filestem}.f90"))]',
                 )
                 fp.write("\n".join(lines))
                 fp.write("\n")


### PR DESCRIPTION
The testcase file is created as a `.f90` extension, but the script called it a `.py` file when adding the testcase to the module.