### PR TITLE
Remove extraneous backtick from options docs

### DIFF
--- a/fortitude_dev/src/generate_options.rs
+++ b/fortitude_dev/src/generate_options.rs
@@ -205,7 +205,7 @@ fn format_tab(tab_name: &str, header: &str, content: &str) -> String {
 
 /// Format the TOML header for the example usage for a given option.
 ///
-/// For example: `[extra.fortitude.check]` in `fpm.toml`` or `[check]` in
+/// For example: `[extra.fortitude.check]` in `fpm.toml` or `[check]` in
 /// `fortitude.toml`.
 fn format_header(scope: Option<&str>, parents: &[Set], configuration: ConfigurationFile) -> String {
     let tool_parent = match configuration {


### PR DESCRIPTION
Tests failed on merging https://github.com/PlasmaFAIR/fortitude/pull/388: https://github.com/PlasmaFAIR/fortitude/actions/runs/14082244969/job/39437643819

Seems I accidentally hit backtick twice when I updated the docs here -- at this point it's just muscle memory from writing Python docs so often.