### PR TITLE
Raise `SyntaxError` for missing nodes

### DIFF
--- a/fortitude/resources/test/fixtures/error/E001.f90
+++ b/fortitude/resources/test/fixtures/error/E001.f90
@@ -1,0 +1,7 @@
+program foo
+  implicit none
+contains
+  subroutine bar(x, y, )
+    integer, intent(in) :: x, y
+  end subroutine bar
+end program foo

--- a/fortitude/src/rules/error/mod.rs
+++ b/fortitude/src/rules/error/mod.rs
@@ -1,2 +1,30 @@
 pub mod ioerror;
 pub mod syntax_error;
+
+#[cfg(test)]
+mod tests {
+    use std::convert::AsRef;
+    use std::path::Path;
+
+    use anyhow::Result;
+    use insta::assert_snapshot;
+    use test_case::test_case;
+
+    use crate::apply_common_filters;
+    use crate::registry::Rule;
+    use crate::settings::Settings;
+    use crate::test::test_path;
+
+    #[test_case(Rule::SyntaxError, Path::new("E001.f90"))]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("error").join(path).as_path(),
+            &[rule_code],
+            &Settings::default(),
+        )?;
+        apply_common_filters!();
+        assert_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+}

--- a/fortitude/src/rules/error/snapshots/fortitude__rules__error__tests__syntax-error_E001.f90.snap
+++ b/fortitude/src/rules/error/snapshots/fortitude__rules__error__tests__syntax-error_E001.f90.snap
@@ -1,0 +1,14 @@
+---
+source: fortitude/src/rules/error/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/error/E001.f90:4:23: E001 Syntax error
+  |
+2 |   implicit none
+3 | contains
+4 |   subroutine bar(x, y, )
+  |                       ^ E001
+5 |     integer, intent(in) :: x, y
+6 |   end subroutine bar
+  |


### PR DESCRIPTION
Closes #384

Along with error nodes, tree-sitter will also insert "missing" nodes
to recover from "certain kinds" of syntax errors: see
[Node::is_missing](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Node.html#method.is_missing)
and [The MISSING
node](https://tree-sitter.github.io/tree-sitter/using-parsers/queries/1-syntax.html#the-missing-node).

Unlike `ERROR` nodes, missing nodes don't appear as `MISSING` and have
to be manually checked.

We _could_ also report the inserted node, but from experience this
isn't necessarily very useful information, and may be quite
misleading.