### PR TITLE
Set fortitude as default crate in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["fortitude", "fortitude_macros", "fortitude_dev"]
+default-members = ["fortitude"]
 resolver = "2"
 
 [workspace.package]

--- a/README.dev.md
+++ b/README.dev.md
@@ -22,13 +22,13 @@ This will instead build an executable at `./target/release/fortitude`.
 The project can also be run without prior building using the command:
 
 ```bash
-cargo run --bin fortitude [--release]
+cargo run [--release]
 ```
 
 For example, to test Fortitude over a local project:
 
 ```bash
-cargo run --bin fortitude --release check /path/to/my/project
+cargo run [--release] check /path/to/my/project
 ```
 
 ## Installation from source


### PR DESCRIPTION
Allows running with `cargo run` instead of `cargo run --bin fortitude`. I've had a quick play around and can't immediately find any other command that behaves incorrectly as a result.