### PR TITLE
Add rule `single-quote-string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "shlex",
 ]
@@ -1308,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.4"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67baf55e7e1b6806063b1e51041069c90afff16afcbbccd278d899f9d84bca4"
+checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
 dependencies = [
  "cc",
  "regex",

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -79,6 +79,7 @@
 | S221 | [function-missing-result](rules/function-missing-result.md) | Function missing result() specifier | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 | S231 | [keywords-missing-space](rules/keywords-missing-space.md) | Missing space in '{keywords}' | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | S232 | [keyword-has-whitespace](rules/keyword-has-whitespace.md) | Whitespace included in '{keywords}' | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| S241 | [single-quote-string](rules/single-quote-string.md) | Character string uses single quotes | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 
 ### Portability (PORT)
 

--- a/docs/rules/single-quote-string.md
+++ b/docs/rules/single-quote-string.md
@@ -1,0 +1,20 @@
+# single-quote-string (S241)
+Fix is sometimes available.
+
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+This rule is turned on by default.
+
+## What does it do?
+Catches use of single-quoted strings.
+
+## Why is this bad?
+For consistency, all strings should be either single-quoted or double-quoted.
+Here, we enforce the use of double-quoted strings as this is the most common
+style in other languages.
+
+An exception is made for single-quoted strings that contain a `'"'` character,
+as this is the preferred way to include double quotes in a string.
+
+Fixes are not available for single-quoted strings containing escaped single
+quotes (`"''"`).

--- a/fortitude/resources/test/fixtures/style/S241.f90
+++ b/fortitude/resources/test/fixtures/style/S241.f90
@@ -1,0 +1,22 @@
+program p
+  implicit none (type, external)
+
+  print *, "Hello, World!"
+  print *, 'Hello, World!'
+  print *, 'Hello, "World"!'
+  print *, "Hello, ""World""!"
+  print *, 'Hello, ''World''!'
+  print *, "Hello, &
+            & World!"
+  print *, 'Hello, &
+            & World!'
+  print *, 'Hello, &
+            & "World"!'
+  print *, "Hello, &
+            & ""World""!"
+  print *, 'Hello, &
+            & ''World''!'
+
+  ! TODO: Add tests for multiline strings with a comment line in the middle
+
+end program p

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -131,6 +131,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Style, "221") => (RuleGroup::Preview, Ast, Optional, style::functions::FunctionMissingResult),
         (Style, "231") => (RuleGroup::Preview, Ast, Default, style::keywords::KeywordsMissingSpace),
         (Style, "232") => (RuleGroup::Preview, Ast, Default, style::keywords::KeywordHasWhitespace),
+        (Style, "241") => (RuleGroup::Preview, Ast, Default, style::strings::SingleQuoteString),
 
         // obsolescent
         (Obsolescent, "001") => (RuleGroup::Removed, Ast, Default, obsolescent::statement_functions::StatementFunction),

--- a/fortitude/src/rules/style/mod.rs
+++ b/fortitude/src/rules/style/mod.rs
@@ -7,6 +7,7 @@ pub mod implicit_none;
 pub mod keywords;
 pub mod line_length;
 pub mod semicolons;
+pub mod strings;
 pub mod whitespace;
 
 #[cfg(test)]
@@ -37,6 +38,7 @@ mod tests {
     #[test_case(Rule::FunctionMissingResult, Path::new("S221.f90"))]
     #[test_case(Rule::KeywordsMissingSpace, Path::new("S231.f90"))]
     #[test_case(Rule::KeywordHasWhitespace, Path::new("S231.f90"))]
+    #[test_case(Rule::SingleQuoteString, Path::new("S241.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/style/snapshots/fortitude__rules__style__tests__single-quote-string_S241.f90.snap
+++ b/fortitude/src/rules/style/snapshots/fortitude__rules__style__tests__single-quote-string_S241.f90.snap
@@ -1,0 +1,71 @@
+---
+source: fortitude/src/rules/style/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/style/S241.f90:5:12: S241 [*] Character string uses single quotes
+  |
+4 |   print *, "Hello, World!"
+5 |   print *, 'Hello, World!'
+  |            ^^^^^^^^^^^^^^^ S241
+6 |   print *, 'Hello, "World"!'
+7 |   print *, "Hello, ""World""!"
+  |
+  = help: Replace with '"'
+
+ℹ Safe fix
+2 2 |   implicit none (type, external)
+3 3 | 
+4 4 |   print *, "Hello, World!"
+5   |-  print *, 'Hello, World!'
+  5 |+  print *, "Hello, World!"
+6 6 |   print *, 'Hello, "World"!'
+7 7 |   print *, "Hello, ""World""!"
+8 8 |   print *, 'Hello, ''World''!'
+
+./resources/test/fixtures/style/S241.f90:8:12: S241 Character string uses single quotes
+   |
+ 6 |   print *, 'Hello, "World"!'
+ 7 |   print *, "Hello, ""World""!"
+ 8 |   print *, 'Hello, ''World''!'
+   |            ^^^^^^^^^^^^^^^^^^^ S241
+ 9 |   print *, "Hello, &
+10 |             & World!"
+   |
+
+./resources/test/fixtures/style/S241.f90:11:12: S241 [*] Character string uses single quotes
+   |
+ 9 |     print *, "Hello, &
+10 |               & World!"
+11 |     print *, 'Hello, &
+   |  ____________^
+12 | |             & World!'
+   | |_____________________^ S241
+13 |     print *, 'Hello, &
+14 |               & "World"!'
+   |
+   = help: Replace with '"'
+
+ℹ Safe fix
+8  8  |   print *, 'Hello, ''World''!'
+9  9  |   print *, "Hello, &
+10 10 |             & World!"
+11    |-  print *, 'Hello, &
+12    |-            & World!'
+   11 |+  print *, "Hello, &
+   12 |+            & World!"
+13 13 |   print *, 'Hello, &
+14 14 |             & "World"!'
+15 15 |   print *, "Hello, &
+
+./resources/test/fixtures/style/S241.f90:17:12: S241 Character string uses single quotes
+   |
+15 |     print *, "Hello, &
+16 |               & ""World""!"
+17 |     print *, 'Hello, &
+   |  ____________^
+18 | |             & ''World''!'
+   | |_________________________^ S241
+19 |
+20 |     ! TODO: Add tests for multiline strings with a comment line in the middle
+   |

--- a/fortitude/src/rules/style/strings.rs
+++ b/fortitude/src/rules/style/strings.rs
@@ -1,0 +1,80 @@
+use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_source_file::SourceFile;
+use ruff_text_size::TextSize;
+use tree_sitter::Node;
+
+use crate::ast::FortitudeNode;
+use crate::settings::Settings;
+use crate::{AstRule, FromAstNode};
+
+/// ## What does it do?
+/// Catches use of single-quoted strings.
+///
+/// ## Why is this bad?
+/// For consistency, all strings should be either single-quoted or double-quoted.
+/// Here, we enforce the use of double-quoted strings as this is the most common
+/// style in other languages.
+///
+/// An exception is made for single-quoted strings that contain a `'"'` character,
+/// as this is the preferred way to include double quotes in a string.
+///
+/// Fixes are not available for single-quoted strings containing escaped single
+/// quotes (`"''"`).
+#[derive(ViolationMetadata)]
+pub(crate) struct SingleQuoteString {
+    contains_escaped_quotes: bool,
+}
+
+impl Violation for SingleQuoteString {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "Character string uses single quotes".to_string()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        if self.contains_escaped_quotes {
+            return None;
+        }
+        Some("Replace with '\"'".to_string())
+    }
+}
+
+impl AstRule for SingleQuoteString {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        let text = node.to_text(src.source_text())?;
+        if text.starts_with("'") && text.ends_with("'") && !text.contains('"') {
+            // Search for occurrence of escaped single quotes within the string.
+            // These are double single quotes, e.g. "''"
+            if text.contains("''") && text.len() > 2 {
+                return Some(vec![Diagnostic::from_node(
+                    Self {
+                        contains_escaped_quotes: true,
+                    },
+                    node,
+                )]);
+            }
+
+            let start_byte = TextSize::try_from(node.start_byte()).unwrap();
+            let end_byte = TextSize::try_from(node.end_byte()).unwrap();
+            let edit_start =
+                Edit::replacement("\"".to_string(), start_byte, start_byte + TextSize::from(1));
+            let edit_end =
+                Edit::replacement("\"".to_string(), end_byte - TextSize::from(1), end_byte);
+            return some_vec!(Diagnostic::from_node(
+                Self {
+                    contains_escaped_quotes: false,
+                },
+                node,
+            )
+            .with_fix(Fix::safe_edits(edit_start, [edit_end])));
+        }
+        None
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["string_literal"]
+    }
+}


### PR DESCRIPTION
Solve https://github.com/PlasmaFAIR/fortitude/issues/422

Ignores strings containing double quotes like `'hello "world"'`, and doesn't allow fixes when single quote strings contain escaped single quotes (`'hello ''world'''`). It would be possible to go through and reduce all of them to un-escaped quotes, but I think this would be better left to a separate rule (e.g. https://docs.astral.sh/ruff/rules/avoidable-escaped-quote/).

One case I wasn't able to test for was multiline strings with comments in the middle of them, as tree-sitter-fortran doesn't support them:

```f90
print *, 'Hello, &
  ! Helpful comment
          & World!'
```

I'm not 100% sure if this is supported by the standard, but gfortran doesn't complain.