### PR TITLE
Add helper methods for start/end node offsets as `TextSize`

### DIFF
--- a/fortitude/src/allow_comments.rs
+++ b/fortitude/src/allow_comments.rs
@@ -54,8 +54,8 @@ pub fn gather_allow_comments<'a, 'b>(
         node.to_text(file.source_text()).unwrap()
     )?;
     let range = if let Some(next_node) = node.next_named_sibling() {
-        let start_byte = TextSize::try_from(next_node.start_byte()).unwrap();
-        let end_byte = TextSize::try_from(next_node.end_byte()).unwrap();
+        let start_byte = next_node.start_textsize();
+        let end_byte = next_node.end_textsize();
 
         // This covers the next statement _upto_ the end of the
         // line that it _ends_ on -- i.e. including trailing
@@ -75,7 +75,7 @@ pub fn gather_allow_comments<'a, 'b>(
     // Partition the found selectors into valid and invalid
     let rule_regex = regex!(r#"\w[-\w\d]*"#);
     // 8 from length of "! allow("
-    let comment_start_offset = TextSize::try_from(node.start_byte()).unwrap() + TextSize::new(8);
+    let comment_start_offset = node.start_textsize() + TextSize::new(8);
     for rule in rule_regex.find_iter(allow_comment) {
         let start = comment_start_offset + TextSize::try_from(rule.start()).unwrap();
         let end = comment_start_offset + TextSize::try_from(rule.end()).unwrap();

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -31,9 +31,9 @@ pub mod version;
 pub use crate::registry::clap_completion::RuleParser;
 pub use crate::rule_selector::clap_completion::RuleSelectorParser;
 
+use ast::FortitudeNode;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_source_file::SourceFile;
-use ruff_text_size::{TextRange, TextSize};
 use settings::Settings;
 use std::path::Path;
 use tree_sitter::Node;
@@ -47,13 +47,7 @@ pub trait FromAstNode {
 
 impl FromAstNode for Diagnostic {
     fn from_node<T: Into<DiagnosticKind>>(violation: T, node: &Node) -> Self {
-        Self::new(
-            violation,
-            TextRange::new(
-                TextSize::try_from(node.start_byte()).unwrap(),
-                TextSize::try_from(node.end_byte()).unwrap(),
-            ),
-        )
+        Self::new(violation, node.textrange())
     }
 }
 

--- a/fortitude/src/rules/correctness/derived_default_init.rs
+++ b/fortitude/src/rules/correctness/derived_default_init.rs
@@ -4,7 +4,6 @@ use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
-use ruff_text_size::TextSize;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -101,7 +100,7 @@ impl AstRule for MissingDefaultPointerInitalisation {
                 let var_name = node.to_text(src.source_text()).unwrap_or("").to_string();
 
                 let init_var = format!(" => null()");
-                let start_pos = TextSize::try_from(node.end_byte()).unwrap();
+                let start_pos = node.end_textsize();
                 let fix = Fix::unsafe_edit(Edit::insertion(init_var, start_pos));
 
                 Diagnostic::from_node(Self { var: var_name }, &node).with_fix(fix)

--- a/fortitude/src/rules/correctness/exit_labels.rs
+++ b/fortitude/src/rules/correctness/exit_labels.rs
@@ -4,7 +4,6 @@ use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
-use ruff_text_size::TextSize;
 use tree_sitter::Node;
 
 /// ## What does it do?
@@ -61,10 +60,7 @@ impl AstRule for MissingExitOrCycleLabel {
             .filter(|(_, name)| name == "exit" || name == "cycle")
             .map(|(stmt, name)| {
                 let label_with_space = format!(" {label}");
-                let edit = Edit::insertion(
-                    label_with_space,
-                    TextSize::try_from(stmt.end_byte()).unwrap(),
-                );
+                let edit = Edit::insertion(label_with_space, stmt.end_textsize());
                 let fix = Fix::unsafe_edit(edit);
 
                 Diagnostic::from_node(
@@ -204,10 +200,7 @@ impl AstRule for MissingEndLabel {
             .map(|stmt| (stmt, stmt.to_text(src).unwrap_or_default().to_lowercase()))
             .map(|(stmt, end_name)| {
                 let label_with_space = format!(" {label}");
-                let edit = Edit::insertion(
-                    label_with_space,
-                    TextSize::try_from(stmt.end_byte()).unwrap(),
-                );
+                let edit = Edit::insertion(label_with_space, stmt.end_textsize());
                 let fix = Fix::safe_edit(edit);
 
                 let start_name = node.child(1).unwrap().to_text(src).unwrap().to_lowercase();

--- a/fortitude/src/rules/correctness/implicit_typing.rs
+++ b/fortitude/src/rules/correctness/implicit_typing.rs
@@ -5,7 +5,6 @@ use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
-use ruff_text_size::TextSize;
 use tree_sitter::Node;
 
 pub fn implicit_statement_is_none(node: &Node) -> bool {
@@ -191,15 +190,9 @@ impl AstRule for ImplicitExternalProcedures {
                 // Seems unlikely someone would have `implicit none (type)`
                 // without `external` -- is that a sign they _explicitly_ don't
                 // want it? That's probably still unwise though
-                Edit::insertion(
-                    ", external".to_string(),
-                    TextSize::try_from(type_node.end_byte()).unwrap(),
-                )
+                Edit::insertion(", external".to_string(), type_node.end_textsize())
             } else {
-                Edit::insertion(
-                    " (type, external)".to_string(),
-                    TextSize::try_from(node.end_byte()).unwrap(),
-                )
+                Edit::insertion(" (type, external)".to_string(), node.end_textsize())
             };
             let fix = Fix::unsafe_edit(edit);
 

--- a/fortitude/src/rules/correctness/use_statements.rs
+++ b/fortitude/src/rules/correctness/use_statements.rs
@@ -4,7 +4,6 @@ use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
-use ruff_text_size::TextSize;
 use tree_sitter::Node;
 
 // TODO Check that 'used' entity is actually used somewhere
@@ -115,7 +114,7 @@ impl AstRule for MissingIntrinsic {
             let use_field = node
                 .children(&mut node.walk())
                 .find(|&child| child.to_text(_src.source_text()) == Some("use"))?;
-            let start_pos = TextSize::try_from(use_field.end_byte()).unwrap();
+            let start_pos = use_field.end_textsize();
             let fix = Fix::unsafe_edit(Edit::insertion(intrinsic.to_string(), start_pos));
 
             return some_vec![Diagnostic::from_node(MissingIntrinsic {}, node).with_fix(fix)];

--- a/fortitude/src/rules/modernisation/include_statement.rs
+++ b/fortitude/src/rules/modernisation/include_statement.rs
@@ -1,9 +1,9 @@
-use crate::settings::Settings;
 use crate::AstRule;
+use crate::{ast::FortitudeNode, settings::Settings};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
-use ruff_text_size::{TextRange, TextSize};
+use ruff_text_size::TextRange;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -36,8 +36,8 @@ impl AstRule for IncludeStatement {
     fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
         // tree-sitter-fortran 0.5.1 includes the end newline as part
         // of the node, so we discard that here
-        let start = TextSize::try_from(node.child(0)?.start_byte()).unwrap();
-        let end = TextSize::try_from(node.child(1)?.end_byte()).unwrap();
+        let start = node.child(0)?.start_textsize();
+        let end = node.child(1)?.end_textsize();
         let range = TextRange::new(start, end);
         some_vec![Diagnostic::new(IncludeStatement {}, range)]
     }

--- a/fortitude/src/rules/style/double_colon_in_decl.rs
+++ b/fortitude/src/rules/style/double_colon_in_decl.rs
@@ -4,7 +4,6 @@ use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
-use ruff_text_size::TextSize;
 use tree_sitter::Node;
 
 /// ## What does it do?
@@ -34,7 +33,7 @@ impl AstRule for MissingDoubleColon {
             .all(|child| child != "::")
         {
             let first_decl = node.child_by_field_name("declarator")?;
-            let start_pos = TextSize::try_from(first_decl.start_byte()).unwrap();
+            let start_pos = first_decl.start_textsize();
             let fix = Fix::safe_edit(Edit::insertion(":: ".to_string(), start_pos));
             some_vec!(Diagnostic::from_node(Self {}, node).with_fix(fix))
         } else {

--- a/fortitude/src/rules/style/keywords.rs
+++ b/fortitude/src/rules/style/keywords.rs
@@ -132,7 +132,7 @@ impl AstRule for KeywordsMissingSpace {
             return None;
         }
 
-        let space_pos = TextSize::try_from(node.start_byte() + keywords.offset()).unwrap();
+        let space_pos = node.start_textsize() + TextSize::try_from(keywords.offset()).unwrap();
         let fix = Fix::safe_edit(Edit::insertion(" ".to_string(), space_pos));
         some_vec!(Diagnostic::from_node(Self { keywords }, &first_child).with_fix(fix))
     }
@@ -233,10 +233,10 @@ impl AstRule for KeywordHasWhitespace {
         // Check if immediate sibling is 'out'/'to'
         let sibling = first_child.next_sibling()?;
         if sibling.to_text(src.source_text())?.to_lowercase() == second {
-            let start = TextSize::try_from(first_child.start_byte()).unwrap();
-            let end = TextSize::try_from(sibling.end_byte()).unwrap();
-            let fix_start = TextSize::try_from(first_child.end_byte()).unwrap();
-            let fix_end = TextSize::try_from(sibling.start_byte()).unwrap();
+            let start = first_child.start_textsize();
+            let end = sibling.end_textsize();
+            let fix_start = first_child.end_textsize();
+            let fix_end = sibling.start_textsize();
             let fix = Fix::safe_edit(Edit::deletion(fix_start, fix_end));
             return some_vec!(Diagnostic::new(violation, TextRange::new(start, end)).with_fix(fix));
         }

--- a/fortitude/src/rules/style/strings.rs
+++ b/fortitude/src/rules/style/strings.rs
@@ -57,8 +57,8 @@ impl AstRule for SingleQuoteString {
                 )]);
             }
 
-            let start_byte = TextSize::try_from(node.start_byte()).unwrap();
-            let end_byte = TextSize::try_from(node.end_byte()).unwrap();
+            let start_byte = node.start_textsize();
+            let end_byte = node.end_textsize();
             let edit_start =
                 Edit::replacement("\"".to_string(), start_byte, start_byte + TextSize::from(1));
             let edit_end =

--- a/fortitude/src/rules/style/whitespace.rs
+++ b/fortitude/src/rules/style/whitespace.rs
@@ -5,6 +5,7 @@ use ruff_source_file::{SourceFile, UniversalNewlines};
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use tree_sitter::Node;
 
+use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode, TextRule};
 
@@ -77,7 +78,7 @@ impl AlwaysFixableViolation for IncorrectSpaceBeforeComment {
 impl AstRule for IncorrectSpaceBeforeComment {
     fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
         let source = src.to_source_code();
-        let comment_start = TextSize::try_from(node.start_byte()).unwrap();
+        let comment_start = node.start_textsize();
         // Get the line up to the start of the comment
         let line_index = source.line_index(comment_start);
         let line_start = source.line_start(line_index);


### PR DESCRIPTION
Just a little quality of life thing for developers :)