### PR TITLE
Add rule for misleading semicolon following if statement

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -38,6 +38,7 @@
 | C141 | [missing-exit-or-cycle-label](rules/missing-exit-or-cycle-label.md) | '{name}' statement in named 'do' loop missing label '{label}' | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | C142 | [exit-or-cycle-in-unlabelled-loop](rules/exit-or-cycle-in-unlabelled-loop.md) | '{name}' statement in unlabelled 'do' loop | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 | C143 | [missing-end-label](rules/missing-end-label.md) | '{end_name}' statement in named '{start_name}' block missing label | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| C151 | [if-statement-semicolon](rules/if-statement-semicolon.md) | Semicolon following inline if-statement is misleading | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 
 ### Obsolescent (OB)
 

--- a/docs/rules/if-statement-semicolon.md
+++ b/docs/rules/if-statement-semicolon.md
@@ -20,11 +20,17 @@ if (condition) print *, "Hello"; print *, "World"
 It is equivalent to:
 
 ```f90
-if (condition) then
-   print *, "Hello"
-end if
+if (condition) print *, "Hello"
 print *, "World"
 ```
 
-When applying fixes, the if statement is converted to the second form and
-the semicolon is removed.
+Users should be cautious applying this fix. If the intent was to have
+both statements execute only if the condition is true, then the user
+should rewrite the code to use an `if` statement with a block:
+
+```f90
+if (condition) then
+    print *, "Hello"
+    print *, "World"
+end if
+```

--- a/docs/rules/if-statement-semicolon.md
+++ b/docs/rules/if-statement-semicolon.md
@@ -1,0 +1,30 @@
+# if-statement-semicolon (C151)
+Fix is always available.
+
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+This rule is turned on by default.
+
+## What does it do?
+Checks for misleading semicolons in `if` statements.
+
+## Why is this bad?
+The following code may appear to execute two statements only if the `if`
+condition is true, but in actuality the second statement will always be
+executed:
+
+```f90
+if (condition) print *, "Hello"; print *, "World"
+```
+
+It is equivalent to:
+
+```f90
+if (condition) then
+   print *, "Hello"
+end if
+print *, "World"
+```
+
+When applying fixes, the if statement is converted to the second form and
+the semicolon is removed.

--- a/fortitude/resources/test/fixtures/correctness/C151.f90
+++ b/fortitude/resources/test/fixtures/correctness/C151.f90
@@ -1,0 +1,30 @@
+program p
+  implicit none (type, external)
+  logical, parameter :: condition = .false.
+
+  if (condition) print *, "Hello"; print *, "World!"
+
+  if (condition) print * , &
+    "Hello"; print *, "World!"
+
+  ! The following is bad practice, but shouldn't trigger
+  if (condition) then
+    print *, "Hello"
+  end if; print *, "World!"
+
+  ! The following are also allowed
+  if (condition) print *, "Hello";
+
+  if (condition) print *, "Hello";
+  print *, "World!"
+
+  if (condition) print *, &
+    "Hello";
+  print *, "World!"
+
+  ! Comments are fine
+  if (condition) print *, "Hello"; ! comment
+
+  if (condition) print *, &
+    "Hello"; ! comment
+end program p

--- a/fortitude/resources/test/fixtures/correctness/C151.f90
+++ b/fortitude/resources/test/fixtures/correctness/C151.f90
@@ -27,4 +27,9 @@ program p
 
   if (condition) print *, &
     "Hello"; ! comment
+
+  ! For multiple inline if statements, each should be moved to its own line.
+  ! To confirm that the fixes work when combined, see the test
+  ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
 end program p

--- a/fortitude/resources/test/fixtures/correctness/C151.f90
+++ b/fortitude/resources/test/fixtures/correctness/C151.f90
@@ -1,6 +1,7 @@
 program p
   implicit none (type, external)
   logical, parameter :: condition = .false.
+  integer :: i
 
   if (condition) print *, "Hello"; print *, "World!"
 
@@ -32,4 +33,7 @@ program p
   ! To confirm that the fixes work when combined, see the test
   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+
+  ! The indentation will get a little weird in some cases:
+  do i = 1, 3; if (i == 2) print *, "foo"; end do
 end program p

--- a/fortitude/src/rules/correctness/conditionals.rs
+++ b/fortitude/src/rules/correctness/conditionals.rs
@@ -1,0 +1,134 @@
+use crate::ast::FortitudeNode;
+use crate::settings::Settings;
+use crate::{AstRule, FromAstNode};
+use anyhow::{Context, Result};
+use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_source_file::SourceFile;
+use ruff_text_size::TextSize;
+use tree_sitter::Node;
+
+/// ## What does it do?
+/// Checks for misleading semicolons in `if` statements.
+///
+/// ## Why is this bad?
+/// The following code may appear to execute two statements only if the `if`
+/// condition is true, but in actuality the second statement will always be
+/// executed:
+///
+/// ```f90
+/// if (condition) print *, "Hello"; print *, "World"
+/// ```
+///
+/// It is equivalent to:
+///
+/// ```f90
+/// if (condition) then
+///    print *, "Hello"
+/// end if
+/// print *, "World"
+/// ```
+///
+/// When applying fixes, the if statement is converted to the second form and
+/// the semicolon is removed.
+#[derive(ViolationMetadata)]
+pub(crate) struct IfStatementSemicolon {}
+
+impl AlwaysFixableViolation for IfStatementSemicolon {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "Semicolon following inline if-statement is misleading".to_string()
+    }
+
+    fn fix_title(&self) -> String {
+        "Convert to `if(...) then` statement".to_string()
+    }
+}
+impl AstRule for IfStatementSemicolon {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        // If this is an `if (...) then` construct, exit early
+        if node
+            .named_descendants()
+            .any(|n| n.kind() == "end_if_statement")
+        {
+            return None;
+        }
+
+        // Check that the if statement is followed directly by a semicolon
+        if let Some(semicolon_node) = node.next_sibling().filter(|n| n.kind() == ";") {
+            // Find the first following non-semicolon node, and check that it's
+            // on the same line as the first semicolon node.
+            // Comments on the same line are permitted.
+            let mut current_node = semicolon_node;
+            while let Some(next) = current_node.next_sibling() {
+                if next.kind() == ";" {
+                    current_node = next;
+                    continue;
+                }
+                if next.start_position().row != semicolon_node.start_position().row
+                    || next.kind() == "comment"
+                {
+                    return None;
+                }
+                break;
+            }
+            let if_edit = node.edit_replacement(src, ifthenify(node, src).ok()?);
+            let indentation = node.indentation(src);
+            // To replace the semicolon node, we should also replace all
+            // trailing whitespace.
+            let semicolon_start = semicolon_node.start_textsize();
+            let mut semicolon_end = semicolon_node.end_byte();
+            let text = src.source_text().as_bytes();
+            while text[semicolon_end] == b' ' || text[semicolon_end] == b'\t' {
+                semicolon_end += 1;
+            }
+            let semicolon_end = TextSize::try_from(semicolon_end).unwrap();
+            let semicolon_edit =
+                Edit::replacement(format!("\n{indentation}"), semicolon_start, semicolon_end);
+            return some_vec!(
+                Diagnostic::from_node(IfStatementSemicolon {}, &semicolon_node)
+                    .with_fix(Fix::safe_edits(if_edit, [semicolon_edit]))
+            );
+        }
+        None
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["if_statement"]
+    }
+}
+
+/// Given an if statement node, convert it from a one-line if statement
+/// to a block if statement.
+/// This is a no-op if the node is already a block if statement.
+pub fn ifthenify(node: &Node, src: &SourceFile) -> Result<String> {
+    let source_text = src.source_text();
+    // check that the node is an if statement without an end if statement
+    if node
+        .named_descendants()
+        .any(|n| n.kind() == "end_if_statement")
+    {
+        return Ok(source_text.to_string());
+    }
+    // Divide the if statement into everything up to the end of the condition
+    // and the body.
+    let condition_node = node
+        .child_with_name("parenthesized_expression")
+        .context("If statement missing conditional")?;
+    let condition_end_byte = condition_node.end_byte();
+    // Concatenate bytes to the end of the condition, " then\n", the body, and
+    // "\nend if". Take care to get the indentation right.
+    let if_start_byte = node.start_byte();
+    let if_end_byte = node.end_byte();
+    let indentation = node.indentation(src);
+    let mut correction = String::new();
+    correction.push_str(&source_text[if_start_byte..condition_end_byte]);
+    correction.push_str(" then\n");
+    correction.push_str(&indentation);
+    correction.push_str("  "); // Assume two-space indent for the if body
+    correction.push_str(&source_text[condition_end_byte..if_end_byte]);
+    correction.push('\n');
+    correction.push_str(&indentation);
+    correction.push_str("end if");
+    Ok(correction)
+}

--- a/fortitude/src/rules/correctness/conditionals.rs
+++ b/fortitude/src/rules/correctness/conditionals.rs
@@ -107,6 +107,11 @@ pub fn ifthenify(node: &Node, src: &SourceFile) -> Option<String> {
     // and the body.
     let condition_node = node.child_with_name("parenthesized_expression")?;
     let condition_end_byte = condition_node.end_byte();
+    let mut body_start_byte = condition_end_byte;
+    let source_bytes = source_text.as_bytes();
+    while body_start_byte < node.end_byte() && source_bytes[body_start_byte].is_ascii_whitespace() {
+        body_start_byte += 1;
+    }
     // Concatenate bytes to the end of the condition, " then\n", the body, and
     // "\nend if". Take care to get the indentation right.
     let if_start_byte = node.start_byte();
@@ -117,7 +122,7 @@ pub fn ifthenify(node: &Node, src: &SourceFile) -> Option<String> {
     correction.push_str(" then\n");
     correction.push_str(&indentation);
     correction.push_str("  "); // Assume two-space indent for the if body
-    correction.push_str(&source_text[condition_end_byte..if_end_byte]);
+    correction.push_str(&source_text[body_start_byte..if_end_byte]);
     correction.push('\n');
     correction.push_str(&indentation);
     correction.push_str("end if");

--- a/fortitude/src/rules/correctness/conditionals.rs
+++ b/fortitude/src/rules/correctness/conditionals.rs
@@ -61,9 +61,6 @@ impl AstRule for IfStatementSemicolon {
             // Find the first following non-semicolon node, and check that it's
             // on the same line as the first semicolon node.
             // Comments on the same line are permitted.
-            // Also permit the following node kind being an end statement, as
-            // this permits lines such as:
-            // do i = 1, 10; if (i == 5) print *, "Hello"; end do
             let mut current_node = semicolon_node;
             while let Some(next) = current_node.next_sibling() {
                 if next.kind() == ";" {
@@ -72,7 +69,6 @@ impl AstRule for IfStatementSemicolon {
                 }
                 if next.start_position().row != semicolon_node.start_position().row
                     || next.kind() == "comment"
-                    || next.kind().starts_with("end_")
                 {
                     return None;
                 }

--- a/fortitude/src/rules/correctness/mod.rs
+++ b/fortitude/src/rules/correctness/mod.rs
@@ -1,5 +1,6 @@
 pub mod accessibility_statements;
 pub mod assumed_size;
+pub mod conditionals;
 pub mod derived_default_init;
 pub mod exit_labels;
 pub mod external;
@@ -54,6 +55,7 @@ mod tests {
     #[test_case(Rule::MissingExitOrCycleLabel, Path::new("C141.f90"))]
     #[test_case(Rule::ExitOrCycleInUnlabelledLoop, Path::new("C142.f90"))]
     #[test_case(Rule::MissingEndLabel, Path::new("C143.f90"))]
+    #[test_case(Rule::IfStatementSemicolon, Path::new("C151.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__c151_fix_multiple_inline_if.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__c151_fix_multiple_inline_if.snap
@@ -1,0 +1,16 @@
+---
+source: fortitude/src/rules/correctness/mod.rs
+expression: fixed
+snapshot_kind: text
+---
+        program test
+            implicit none
+            integer :: i
+            if (i == 1) then
+              print *, "foo"
+            end if
+            if (i == 2) then
+              print *, "bar"
+            end if
+            if (i == 3) print *, "baz"
+        end program test

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__c151_fix_multiple_inline_if.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__c151_fix_multiple_inline_if.snap
@@ -6,11 +6,7 @@ snapshot_kind: text
         program test
             implicit none
             integer :: i
-            if (i == 1) then
-              print *, "foo"
-            end if
-            if (i == 2) then
-              print *, "bar"
-            end if
+            if (i == 1) print *, "foo"
+            if (i == 2) print *, "bar"
             if (i == 3) print *, "baz"
         end program test

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
@@ -12,20 +12,18 @@ snapshot_kind: text
 7 |
 8 |   if (condition) print * , &
   |
-  = help: Convert to `if(...) then` statement
+  = help: Replace with newline, or convert to `if(...) then` statement
 
 ℹ Safe fix
-3  3  |   logical, parameter :: condition = .false.
-4  4  |   integer :: i
-5  5  | 
-6     |-  if (condition) print *, "Hello"; print *, "World!"
-   6  |+  if (condition) then
-   7  |+    print *, "Hello"
-   8  |+  end if
-   9  |+  print *, "World!"
-7  10 | 
-8  11 |   if (condition) print * , &
-9  12 |     "Hello"; print *, "World!"
+3 3 |   logical, parameter :: condition = .false.
+4 4 |   integer :: i
+5 5 | 
+6   |-  if (condition) print *, "Hello"; print *, "World!"
+  6 |+  if (condition) print *, "Hello"
+  7 |+  print *, "World!"
+7 8 | 
+8 9 |   if (condition) print * , &
+9 10 |     "Hello"; print *, "World!"
 
 ./resources/test/fixtures/correctness/C151.f90:9:12: C151 [*] Semicolon following inline if-statement is misleading
    |
@@ -35,22 +33,18 @@ snapshot_kind: text
 10 |
 11 |   ! The following is bad practice, but shouldn't trigger
    |
-   = help: Convert to `if(...) then` statement
+   = help: Replace with newline, or convert to `if(...) then` statement
 
 ℹ Safe fix
-5  5  | 
 6  6  |   if (condition) print *, "Hello"; print *, "World!"
 7  7  | 
-8     |-  if (condition) print * , &
+8  8  |   if (condition) print * , &
 9     |-    "Hello"; print *, "World!"
-   8  |+  if (condition) then
-   9  |+    print * , &
-   10 |+    "Hello"
-   11 |+  end if
-   12 |+  print *, "World!"
-10 13 | 
-11 14 |   ! The following is bad practice, but shouldn't trigger
-12 15 |   if (condition) then
+   9  |+    "Hello"
+   10 |+  print *, "World!"
+10 11 | 
+11 12 |   ! The following is bad practice, but shouldn't trigger
+12 13 |   if (condition) then
 
 ./resources/test/fixtures/correctness/C151.f90:35:32: C151 [*] Semicolon following inline if-statement is misleading
    |
@@ -61,20 +55,18 @@ snapshot_kind: text
 36 |
 37 |   ! The indentation will get a little weird in some cases:
    |
-   = help: Convert to `if(...) then` statement
+   = help: Replace with newline, or convert to `if(...) then` statement
 
 ℹ Safe fix
 32 32 |   ! For multiple inline if statements, each should be moved to its own line.
 33 33 |   ! To confirm that the fixes work when combined, see the test
 34 34 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
 35    |-  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
-   35 |+  if (condition) then
-   36 |+    print *, "foo"
-   37 |+  end if
-   38 |+  if(.true.) print *, "bar"; if(.false.) print *, "baz";
-36 39 | 
-37 40 |   ! The indentation will get a little weird in some cases:
-38 41 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
+   35 |+  if (condition) print *, "foo"
+   36 |+  if(.true.) print *, "bar"; if(.false.) print *, "baz";
+36 37 | 
+37 38 |   ! The indentation will get a little weird in some cases:
+38 39 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
 
 ./resources/test/fixtures/correctness/C151.f90:35:59: C151 [*] Semicolon following inline if-statement is misleading
    |
@@ -85,37 +77,15 @@ snapshot_kind: text
 36 |
 37 |   ! The indentation will get a little weird in some cases:
    |
-   = help: Convert to `if(...) then` statement
+   = help: Replace with newline, or convert to `if(...) then` statement
 
 ℹ Safe fix
 32 32 |   ! For multiple inline if statements, each should be moved to its own line.
 33 33 |   ! To confirm that the fixes work when combined, see the test
 34 34 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
 35    |-  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
-   35 |+  if (condition) print *, "foo"; if(.true.) then
-   36 |+    print *, "bar"
-   37 |+  end if
-   38 |+  if(.false.) print *, "baz";
-36 39 | 
-37 40 |   ! The indentation will get a little weird in some cases:
-38 41 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
-
-./resources/test/fixtures/correctness/C151.f90:38:42: C151 [*] Semicolon following inline if-statement is misleading
-   |
-37 |   ! The indentation will get a little weird in some cases:
-38 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
-   |                                          ^ C151
-39 | end program p
-   |
-   = help: Convert to `if(...) then` statement
-
-ℹ Safe fix
-35 35 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
-36 36 | 
-37 37 |   ! The indentation will get a little weird in some cases:
-38    |-  do i = 1, 3; if (i == 2) print *, "foo"; end do
-   38 |+  do i = 1, 3; if (i == 2) then
-   39 |+    print *, "foo"
-   40 |+  end if
-   41 |+  end do
-39 42 | end program p
+   35 |+  if (condition) print *, "foo"; if(.true.) print *, "bar"
+   36 |+  if(.false.) print *, "baz";
+36 37 | 
+37 38 |   ! The indentation will get a little weird in some cases:
+38 39 |   do i = 1, 3; if (i == 2) print *, "foo"; end do

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
@@ -1,0 +1,53 @@
+---
+source: fortitude/src/rules/correctness/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/correctness/C151.f90:5:34: C151 [*] Semicolon following inline if-statement is misleading
+  |
+3 |   logical, parameter :: condition = .false.
+4 |
+5 |   if (condition) print *, "Hello"; print *, "World!"
+  |                                  ^ C151
+6 |
+7 |   if (condition) print * , &
+  |
+  = help: Convert to `if(...) then` statement
+
+ℹ Safe fix
+2 2 |   implicit none (type, external)
+3 3 |   logical, parameter :: condition = .false.
+4 4 | 
+5   |-  if (condition) print *, "Hello"; print *, "World!"
+  5 |+  if (condition) then
+  6 |+     print *, "Hello"
+  7 |+  end if
+  8 |+  print *, "World!"
+6 9 | 
+7 10 |   if (condition) print * , &
+8 11 |     "Hello"; print *, "World!"
+
+./resources/test/fixtures/correctness/C151.f90:8:12: C151 [*] Semicolon following inline if-statement is misleading
+   |
+ 7 |   if (condition) print * , &
+ 8 |     "Hello"; print *, "World!"
+   |            ^ C151
+ 9 |
+10 |   ! The following is bad practice, but shouldn't trigger
+   |
+   = help: Convert to `if(...) then` statement
+
+ℹ Safe fix
+4  4  | 
+5  5  |   if (condition) print *, "Hello"; print *, "World!"
+6  6  | 
+7     |-  if (condition) print * , &
+8     |-    "Hello"; print *, "World!"
+   7  |+  if (condition) then
+   8  |+     print * , &
+   9  |+    "Hello"
+   10 |+  end if
+   11 |+  print *, "World!"
+9  12 | 
+10 13 |   ! The following is bad practice, but shouldn't trigger
+11 14 |   if (condition) then

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
@@ -3,93 +3,119 @@ source: fortitude/src/rules/correctness/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
-./resources/test/fixtures/correctness/C151.f90:5:34: C151 [*] Semicolon following inline if-statement is misleading
+./resources/test/fixtures/correctness/C151.f90:6:34: C151 [*] Semicolon following inline if-statement is misleading
   |
-3 |   logical, parameter :: condition = .false.
-4 |
-5 |   if (condition) print *, "Hello"; print *, "World!"
+4 |   integer :: i
+5 |
+6 |   if (condition) print *, "Hello"; print *, "World!"
   |                                  ^ C151
-6 |
-7 |   if (condition) print * , &
+7 |
+8 |   if (condition) print * , &
   |
   = help: Convert to `if(...) then` statement
 
 ℹ Safe fix
-2 2 |   implicit none (type, external)
-3 3 |   logical, parameter :: condition = .false.
-4 4 | 
-5   |-  if (condition) print *, "Hello"; print *, "World!"
-  5 |+  if (condition) then
-  6 |+    print *, "Hello"
-  7 |+  end if
-  8 |+  print *, "World!"
-6 9 | 
-7 10 |   if (condition) print * , &
-8 11 |     "Hello"; print *, "World!"
+3  3  |   logical, parameter :: condition = .false.
+4  4  |   integer :: i
+5  5  | 
+6     |-  if (condition) print *, "Hello"; print *, "World!"
+   6  |+  if (condition) then
+   7  |+    print *, "Hello"
+   8  |+  end if
+   9  |+  print *, "World!"
+7  10 | 
+8  11 |   if (condition) print * , &
+9  12 |     "Hello"; print *, "World!"
 
-./resources/test/fixtures/correctness/C151.f90:8:12: C151 [*] Semicolon following inline if-statement is misleading
+./resources/test/fixtures/correctness/C151.f90:9:12: C151 [*] Semicolon following inline if-statement is misleading
    |
- 7 |   if (condition) print * , &
- 8 |     "Hello"; print *, "World!"
+ 8 |   if (condition) print * , &
+ 9 |     "Hello"; print *, "World!"
    |            ^ C151
- 9 |
-10 |   ! The following is bad practice, but shouldn't trigger
+10 |
+11 |   ! The following is bad practice, but shouldn't trigger
    |
    = help: Convert to `if(...) then` statement
 
 ℹ Safe fix
-4  4  | 
-5  5  |   if (condition) print *, "Hello"; print *, "World!"
-6  6  | 
-7     |-  if (condition) print * , &
-8     |-    "Hello"; print *, "World!"
-   7  |+  if (condition) then
-   8  |+    print * , &
-   9  |+    "Hello"
-   10 |+  end if
-   11 |+  print *, "World!"
-9  12 | 
-10 13 |   ! The following is bad practice, but shouldn't trigger
-11 14 |   if (condition) then
+5  5  | 
+6  6  |   if (condition) print *, "Hello"; print *, "World!"
+7  7  | 
+8     |-  if (condition) print * , &
+9     |-    "Hello"; print *, "World!"
+   8  |+  if (condition) then
+   9  |+    print * , &
+   10 |+    "Hello"
+   11 |+  end if
+   12 |+  print *, "World!"
+10 13 | 
+11 14 |   ! The following is bad practice, but shouldn't trigger
+12 15 |   if (condition) then
 
-./resources/test/fixtures/correctness/C151.f90:34:32: C151 [*] Semicolon following inline if-statement is misleading
+./resources/test/fixtures/correctness/C151.f90:35:32: C151 [*] Semicolon following inline if-statement is misleading
    |
-32 |   ! To confirm that the fixes work when combined, see the test
-33 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
-34 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+33 |   ! To confirm that the fixes work when combined, see the test
+34 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+35 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
    |                                ^ C151
-35 | end program p
+36 |
+37 |   ! The indentation will get a little weird in some cases:
    |
    = help: Convert to `if(...) then` statement
 
 ℹ Safe fix
-31 31 |   ! For multiple inline if statements, each should be moved to its own line.
-32 32 |   ! To confirm that the fixes work when combined, see the test
-33 33 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
-34    |-  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
-   34 |+  if (condition) then
-   35 |+    print *, "foo"
-   36 |+  end if
-   37 |+  if(.true.) print *, "bar"; if(.false.) print *, "baz";
-35 38 | end program p
+32 32 |   ! For multiple inline if statements, each should be moved to its own line.
+33 33 |   ! To confirm that the fixes work when combined, see the test
+34 34 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+35    |-  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+   35 |+  if (condition) then
+   36 |+    print *, "foo"
+   37 |+  end if
+   38 |+  if(.true.) print *, "bar"; if(.false.) print *, "baz";
+36 39 | 
+37 40 |   ! The indentation will get a little weird in some cases:
+38 41 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
 
-./resources/test/fixtures/correctness/C151.f90:34:59: C151 [*] Semicolon following inline if-statement is misleading
+./resources/test/fixtures/correctness/C151.f90:35:59: C151 [*] Semicolon following inline if-statement is misleading
    |
-32 |   ! To confirm that the fixes work when combined, see the test
-33 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
-34 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+33 |   ! To confirm that the fixes work when combined, see the test
+34 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+35 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
    |                                                           ^ C151
-35 | end program p
+36 |
+37 |   ! The indentation will get a little weird in some cases:
    |
    = help: Convert to `if(...) then` statement
 
 ℹ Safe fix
-31 31 |   ! For multiple inline if statements, each should be moved to its own line.
-32 32 |   ! To confirm that the fixes work when combined, see the test
-33 33 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
-34    |-  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
-   34 |+  if (condition) print *, "foo"; if(.true.) then
-   35 |+    print *, "bar"
-   36 |+  end if
-   37 |+  if(.false.) print *, "baz";
-35 38 | end program p
+32 32 |   ! For multiple inline if statements, each should be moved to its own line.
+33 33 |   ! To confirm that the fixes work when combined, see the test
+34 34 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+35    |-  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+   35 |+  if (condition) print *, "foo"; if(.true.) then
+   36 |+    print *, "bar"
+   37 |+  end if
+   38 |+  if(.false.) print *, "baz";
+36 39 | 
+37 40 |   ! The indentation will get a little weird in some cases:
+38 41 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
+
+./resources/test/fixtures/correctness/C151.f90:38:42: C151 [*] Semicolon following inline if-statement is misleading
+   |
+37 |   ! The indentation will get a little weird in some cases:
+38 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
+   |                                          ^ C151
+39 | end program p
+   |
+   = help: Convert to `if(...) then` statement
+
+ℹ Safe fix
+35 35 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+36 36 | 
+37 37 |   ! The indentation will get a little weird in some cases:
+38    |-  do i = 1, 3; if (i == 2) print *, "foo"; end do
+   38 |+  do i = 1, 3; if (i == 2) then
+   39 |+    print *, "foo"
+   40 |+  end if
+   41 |+  end do
+39 42 | end program p

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
@@ -89,3 +89,21 @@ snapshot_kind: text
 36 37 | 
 37 38 |   ! The indentation will get a little weird in some cases:
 38 39 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
+
+./resources/test/fixtures/correctness/C151.f90:38:42: C151 [*] Semicolon following inline if-statement is misleading
+   |
+37 |   ! The indentation will get a little weird in some cases:
+38 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
+   |                                          ^ C151
+39 | end program p
+   |
+   = help: Replace with newline, or convert to `if(...) then` statement
+
+ℹ Safe fix
+35 35 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+36 36 | 
+37 37 |   ! The indentation will get a little weird in some cases:
+38    |-  do i = 1, 3; if (i == 2) print *, "foo"; end do
+   38 |+  do i = 1, 3; if (i == 2) print *, "foo"
+   39 |+  end do
+39 40 | end program p

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
@@ -20,7 +20,7 @@ snapshot_kind: text
 4 4 | 
 5   |-  if (condition) print *, "Hello"; print *, "World!"
   5 |+  if (condition) then
-  6 |+     print *, "Hello"
+  6 |+    print *, "Hello"
   7 |+  end if
   8 |+  print *, "World!"
 6 9 | 
@@ -44,7 +44,7 @@ snapshot_kind: text
 7     |-  if (condition) print * , &
 8     |-    "Hello"; print *, "World!"
    7  |+  if (condition) then
-   8  |+     print * , &
+   8  |+    print * , &
    9  |+    "Hello"
    10 |+  end if
    11 |+  print *, "World!"

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__if-statement-semicolon_C151.f90.snap
@@ -51,3 +51,45 @@ snapshot_kind: text
 9  12 | 
 10 13 |   ! The following is bad practice, but shouldn't trigger
 11 14 |   if (condition) then
+
+./resources/test/fixtures/correctness/C151.f90:34:32: C151 [*] Semicolon following inline if-statement is misleading
+   |
+32 |   ! To confirm that the fixes work when combined, see the test
+33 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+34 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+   |                                ^ C151
+35 | end program p
+   |
+   = help: Convert to `if(...) then` statement
+
+ℹ Safe fix
+31 31 |   ! For multiple inline if statements, each should be moved to its own line.
+32 32 |   ! To confirm that the fixes work when combined, see the test
+33 33 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+34    |-  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+   34 |+  if (condition) then
+   35 |+    print *, "foo"
+   36 |+  end if
+   37 |+  if(.true.) print *, "bar"; if(.false.) print *, "baz";
+35 38 | end program p
+
+./resources/test/fixtures/correctness/C151.f90:34:59: C151 [*] Semicolon following inline if-statement is misleading
+   |
+32 |   ! To confirm that the fixes work when combined, see the test
+33 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+34 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+   |                                                           ^ C151
+35 | end program p
+   |
+   = help: Convert to `if(...) then` statement
+
+ℹ Safe fix
+31 31 |   ! For multiple inline if statements, each should be moved to its own line.
+32 32 |   ! To confirm that the fixes work when combined, see the test
+33 33 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+34    |-  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+   34 |+  if (condition) print *, "foo"; if(.true.) then
+   35 |+    print *, "bar"
+   36 |+  end if
+   37 |+  if(.false.) print *, "baz";
+35 38 | end program p

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -101,6 +101,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Correctness, "141") => (RuleGroup::Stable, Ast, Default, correctness::exit_labels::MissingExitOrCycleLabel),
         (Correctness, "142") => (RuleGroup::Preview, Ast, Optional, correctness::exit_labels::ExitOrCycleInUnlabelledLoop),
         (Correctness, "143") => (RuleGroup::Preview, Ast, Default, correctness::exit_labels::MissingEndLabel),
+        (Correctness, "151") => (RuleGroup::Preview, Ast, Default, correctness::conditionals::IfStatementSemicolon),
 
         // modernisation
         (Modernisation, "001") => (RuleGroup::Stable, Ast, Optional, modernisation::double_precision::DoublePrecision),


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/406

I'm not sure of the name for this one.

The added `ifthenify` function could also be used to easily implement https://github.com/PlasmaFAIR/fortitude/issues/65