### PR TITLE
Add rule `misleading-inline-if-continuation`

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -39,6 +39,7 @@
 | C142 | [exit-or-cycle-in-unlabelled-loop](rules/exit-or-cycle-in-unlabelled-loop.md) | '{name}' statement in unlabelled 'do' loop | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 | C143 | [missing-end-label](rules/missing-end-label.md) | '{end_name}' statement in named '{start_name}' block missing label | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | C151 | [if-statement-semicolon](rules/if-statement-semicolon.md) | Semicolon following inline if-statement is misleading | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| C152 | [misleading-inline-if-continuation](rules/misleading-inline-if-continuation.md) | Line continuation in inline if-statement is misleading | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 
 ### Obsolescent (OB)
 

--- a/docs/rules/misleading-inline-if-continuation.md
+++ b/docs/rules/misleading-inline-if-continuation.md
@@ -1,0 +1,37 @@
+# misleading-inline-if-continuation (C152)
+Fix is always available.
+
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+This rule is turned on by default.
+
+## What does it do?
+Checks for misleading line continuations in inline `if` statements.
+
+## Why is this bad?
+An inline `if` statement followed immediately by a line continuation
+can be easily confused for a block `if` statement:
+
+```f90
+if (condition) &
+    call a_very_long_subroutine_name(with, many, ..., arguments)
+```
+
+If a developer wishes to add a second statement to the `if` 'block',
+they may be tempted to write:
+
+```f90
+if (condition) &
+    call a_very_long_subroutine_name(with, many, ..., arguments)
+    call another_subroutine(args, ...)  ! Always executes!
+```
+
+To avoid this confusion, inline `if` statements that spill over multiple
+lines should be written as an if-then-block:
+
+```f90
+if (condition) then
+    call a_very_long_subroutine_name(with, many, ..., arguments)
+    call another_subroutine(args, ...)  ! Only executes if condition is true
+end if
+```

--- a/fortitude/resources/test/fixtures/correctness/C152.f90
+++ b/fortitude/resources/test/fixtures/correctness/C152.f90
@@ -1,0 +1,30 @@
+program p
+  implicit none (type, external)
+  logical, parameter :: condition = .false.
+  integer :: i
+
+  if (condition) &
+      print *, "Hello"
+      print *, "World!"
+
+  if (condition) &
+      print *, "Hello"; print *, "World!"
+
+  if (condition) print *, &
+    "Hello world!"
+
+  if (condition) print *, &
+     & "Hello"
+
+
+  ! Inline if statements on a single line are permitted.
+  if (condition) print *, "Hello world!"
+
+  ! We don't handle misleading semicolons here.
+  if (condition) print *, "foo"; print *, "bar"; &
+    print *, "baz"
+
+  ! Some cases might result in weird indentation.
+  do i = 1, 3; if (i == 2) &
+    print *, "foo"; end do
+end program p

--- a/fortitude/resources/test/fixtures/correctness/C152.f90
+++ b/fortitude/resources/test/fixtures/correctness/C152.f90
@@ -3,38 +3,58 @@ program p
   logical, parameter :: condition = .false.
   integer :: i
 
+  ! Inline if statements on a single line are permitted.
+  if (condition) print *, "Hello world!"
+
+  ! Should never trigger on `if then` blocks
+  if (condition) then
+    print *, "Hello"
+  end if
+
+  if (condition &
+      .and. i > 0) &
+  then
+    print *, "Hello world!"
+  end if
+
+  if (condition &
+      .and. i > 0) then; print *, &
+      "Hello world!"; end if
+
+  ! Raise an error if the body is on a new line.
   if (condition) &
       print *, "Hello"
       print *, "World!"
 
+  ! Misleading semicolons: the second statement in the body should be placed
+  ! after the `end if` in the fix.
   if (condition) &
       print *, "Hello"; print *, "World!"
 
+  ! Permit body split across multiple lines.
   if (condition) print *, &
     "Hello world!"
-
-  if (condition) print *, &
-     & "Hello"
-
-
-  ! Inline if statements on a single line are permitted.
-  if (condition) print *, "Hello world!"
-
-  ! We don't handle misleading semicolons here.
-  if (condition) print *, "foo"; print *, "bar"; &
-    print *, "baz"
-
-  ! Some cases might result in weird indentation.
-  do i = 1, 3; if (i == 2) &
-    print *, "foo"; end do
 
   ! Permit multi-line conditions
   if (condition &
       .and. i > 0) print *, "Hello world!"
 
-  ! ... but not if the body is also multi-line
   if (condition &
       .and. i > 0) print *, &
-        "Hello world!"
+                   "Hello world!"
+
+  ! ... but not if the body starts on a new line
+  if (condition &
+      .and. i > 0) &
+        print *, "Hello world!"
+
+  ! Some cases might result in weird indentation.
+  do i = 1, 3; if (i == 2) &
+    print *, "foo"; end do
+
+  ! We don't handle misleading semicolons here.
+  if (condition) print *, "foo"; print *, "bar"; &
+    print *, "baz"
+
 
 end program p

--- a/fortitude/resources/test/fixtures/correctness/C152.f90
+++ b/fortitude/resources/test/fixtures/correctness/C152.f90
@@ -27,4 +27,14 @@ program p
   ! Some cases might result in weird indentation.
   do i = 1, 3; if (i == 2) &
     print *, "foo"; end do
+
+  ! Permit multi-line conditions
+  if (condition &
+      .and. i > 0) print *, "Hello world!"
+
+  ! ... but not if the body is also multi-line
+  if (condition &
+      .and. i > 0) print *, &
+        "Hello world!"
+
 end program p

--- a/fortitude/src/rules/correctness/conditionals.rs
+++ b/fortitude/src/rules/correctness/conditionals.rs
@@ -149,13 +149,11 @@ impl AstRule for MisleadingInlineIfContinuation {
             return None;
         }
 
-        // Check if the if body is on different line than the end of the condition
-        let condition_end_line = node
+        // Check if the condition is immediately following by a continuation
+        let body_start = node
             .child_with_name("parenthesized_expression")?
-            .end_position()
-            .row;
-        let if_end_line = node.end_position().row;
-        if if_end_line > condition_end_line {
+            .next_sibling()?;
+        if body_start.kind() == "&" {
             let content = ifthenify(node, src)?;
             let start_byte = node.start_textsize();
             let end_byte = node.end_textsize();

--- a/fortitude/src/rules/correctness/conditionals.rs
+++ b/fortitude/src/rules/correctness/conditionals.rs
@@ -149,10 +149,13 @@ impl AstRule for MisleadingInlineIfContinuation {
             return None;
         }
 
-        // Check if the if statement ends on a different line than it starts.
-        let start_line = node.start_position().row;
-        let end_line = node.end_position().row;
-        if end_line > start_line {
+        // Check if the if body is on different line than the end of the condition
+        let condition_end_line = node
+            .child_with_name("parenthesized_expression")?
+            .end_position()
+            .row;
+        let if_end_line = node.end_position().row;
+        if if_end_line > condition_end_line {
             let content = ifthenify(node, src)?;
             let start_byte = node.start_textsize();
             let end_byte = node.end_textsize();

--- a/fortitude/src/rules/correctness/conditionals.rs
+++ b/fortitude/src/rules/correctness/conditionals.rs
@@ -99,7 +99,116 @@ impl AstRule for IfStatementSemicolon {
     }
 }
 
+/// ## What does it do?
+/// Checks for misleading line continuations in inline `if` statements.
+///
+/// ## Why is this bad?
+/// An inline `if` statement followed immediately by a line continuation
+/// can be easily confused for a block `if` statement:
+///
+/// ```f90
+/// if (condition) &
+///     call a_very_long_subroutine_name(with, many, ..., arguments)
+/// ```
+///
+/// If a developer wishes to add a second statement to the `if` 'block',
+/// they may be tempted to write:
+///
+/// ```f90
+/// if (condition) &
+///     call a_very_long_subroutine_name(with, many, ..., arguments)
+///     call another_subroutine(args, ...)  ! Always executes!
+/// ```
+///
+/// To avoid this confusion, inline `if` statements that spill over multiple
+/// lines should be written as an if-then-block:
+///
+/// ```f90
+/// if (condition) then
+///     call a_very_long_subroutine_name(with, many, ..., arguments)
+///     call another_subroutine(args, ...)  ! Only executes if condition is true
+/// end if
+/// ```
+#[derive(ViolationMetadata)]
+pub(crate) struct MisleadingInlineIfContinuation {}
+
+impl AlwaysFixableViolation for MisleadingInlineIfContinuation {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "Line continuation in inline if-statement is misleading".to_string()
+    }
+
+    fn fix_title(&self) -> String {
+        "Convert to `if(...) then` block".to_string()
+    }
+}
+impl AstRule for MisleadingInlineIfContinuation {
+    fn check(_settings: &Settings, node: &Node, src: &SourceFile) -> Option<Vec<Diagnostic>> {
+        // If this is an `if (...) then` construct, exit early
+        if !inline_if_statement(node) {
+            return None;
+        }
+
+        // Check if the if statement ends on a different line than it starts.
+        let start_line = node.start_position().row;
+        let end_line = node.end_position().row;
+        if end_line > start_line {
+            let content = ifthenify(node, src)?;
+            let edit = node.edit_replacement(src, content);
+            return some_vec!(
+                Diagnostic::from_node(MisleadingInlineIfContinuation {}, node)
+                    .with_fix(Fix::safe_edit(edit))
+            );
+        }
+        None
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["if_statement"]
+    }
+}
+
 /// Given an if statement, return true if it is inline.
 pub fn inline_if_statement(node: &Node) -> bool {
-    node.child(2).is_none_or(|n| n.kind() != "then")
+    node.child_with_name("end_if_statement").is_none()
+}
+
+/// Given an if statement node, convert it from a one-line if statement
+/// to a block if statement.
+/// Returns None if the node is already a block if statement.
+pub fn ifthenify(node: &Node, src: &SourceFile) -> Option<String> {
+    let source_text = src.source_text();
+    // check that the node is an if statement without an end if statement
+    if !inline_if_statement(node) {
+        return None;
+    }
+    // Divide the if statement into everything up to the end of the condition
+    // and the body.
+    let condition_node = node.child_with_name("parenthesized_expression")?;
+    let condition_end_byte = condition_node.end_byte();
+    let mut body_start_byte = condition_end_byte;
+    let source_bytes = source_text.as_bytes();
+    // Skip over any whitespace or line continuations between the condition
+    // and the body.
+    while body_start_byte < node.end_byte()
+        && (source_bytes[body_start_byte].is_ascii_whitespace()
+            || source_bytes[body_start_byte] == b'&')
+    {
+        body_start_byte += 1;
+    }
+    // Concatenate bytes to the end of the condition, " then\n", the body, and
+    // "\nend if". Take care to get the indentation right.
+    let if_start_byte = node.start_byte();
+    let if_end_byte = node.end_byte();
+    let indentation = node.indentation(src);
+    let mut correction = String::new();
+    correction.push_str(&source_text[if_start_byte..condition_end_byte]);
+    correction.push_str(" then\n");
+    correction.push_str(&indentation);
+    correction.push_str("  "); // Assume two-space indent for the if body
+    correction.push_str(&source_text[body_start_byte..if_end_byte]);
+    correction.push('\n');
+    correction.push_str(&indentation);
+    correction.push_str("end if");
+    Some(correction)
 }

--- a/fortitude/src/rules/correctness/mod.rs
+++ b/fortitude/src/rules/correctness/mod.rs
@@ -60,6 +60,7 @@ mod tests {
     #[test_case(Rule::ExitOrCycleInUnlabelledLoop, Path::new("C142.f90"))]
     #[test_case(Rule::MissingEndLabel, Path::new("C143.f90"))]
     #[test_case(Rule::IfStatementSemicolon, Path::new("C151.f90"))]
+    #[test_case(Rule::MisleadingInlineIfContinuation, Path::new("C152.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__misleading-inline-if-continuation_C152.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__misleading-inline-if-continuation_C152.f90.snap
@@ -1,0 +1,123 @@
+---
+source: fortitude/src/rules/correctness/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/correctness/C152.f90:6:3: C152 [*] Line continuation in inline if-statement is misleading
+  |
+4 |     integer :: i
+5 |
+6 | /   if (condition) &
+7 | |       print *, "Hello"
+  | |______________________^ C152
+8 |         print *, "World!"
+  |
+  = help: Convert to `if(...) then` block
+
+ℹ Safe fix
+3 3 |   logical, parameter :: condition = .false.
+4 4 |   integer :: i
+5 5 | 
+6   |-  if (condition) &
+7   |-      print *, "Hello"
+  6 |+  if (condition) then
+  7 |+    print *, "Hello"
+  8 |+  end if
+8 9 |       print *, "World!"
+9 10 | 
+10 11 |   if (condition) &
+
+./resources/test/fixtures/correctness/C152.f90:10:3: C152 [*] Line continuation in inline if-statement is misleading
+   |
+ 8 |         print *, "World!"
+ 9 |
+10 | /   if (condition) &
+11 | |       print *, "Hello"; print *, "World!"
+   | |______________________^ C152
+12 |
+13 |     if (condition) print *, &
+   |
+   = help: Convert to `if(...) then` block
+
+ℹ Safe fix
+7  7  |       print *, "Hello"
+8  8  |       print *, "World!"
+9  9  | 
+10    |-  if (condition) &
+11    |-      print *, "Hello"; print *, "World!"
+   10 |+  if (condition) then
+   11 |+    print *, "Hello"
+   12 |+  end if; print *, "World!"
+12 13 | 
+13 14 |   if (condition) print *, &
+14 15 |     "Hello world!"
+
+./resources/test/fixtures/correctness/C152.f90:13:3: C152 [*] Line continuation in inline if-statement is misleading
+   |
+11 |         print *, "Hello"; print *, "World!"
+12 |
+13 | /   if (condition) print *, &
+14 | |     "Hello world!"
+   | |__________________^ C152
+15 |
+16 |     if (condition) print *, &
+   |
+   = help: Convert to `if(...) then` block
+
+ℹ Safe fix
+10 10 |   if (condition) &
+11 11 |       print *, "Hello"; print *, "World!"
+12 12 | 
+13    |-  if (condition) print *, &
+   13 |+  if (condition) then
+   14 |+    print *, &
+14 15 |     "Hello world!"
+   16 |+  end if
+15 17 | 
+16 18 |   if (condition) print *, &
+17 19 |      & "Hello"
+
+./resources/test/fixtures/correctness/C152.f90:16:3: C152 [*] Line continuation in inline if-statement is misleading
+   |
+14 |       "Hello world!"
+15 |
+16 | /   if (condition) print *, &
+17 | |      & "Hello"
+   | |______________^ C152
+   |
+   = help: Convert to `if(...) then` block
+
+ℹ Safe fix
+13 13 |   if (condition) print *, &
+14 14 |     "Hello world!"
+15 15 | 
+16    |-  if (condition) print *, &
+   16 |+  if (condition) then
+   17 |+    print *, &
+17 18 |      & "Hello"
+   19 |+  end if
+18 20 | 
+19 21 | 
+20 22 |   ! Inline if statements on a single line are permitted.
+
+./resources/test/fixtures/correctness/C152.f90:28:16: C152 [*] Line continuation in inline if-statement is misleading
+   |
+27 |     ! Some cases might result in weird indentation.
+28 |     do i = 1, 3; if (i == 2) &
+   |  ________________^
+29 | |     print *, "foo"; end do
+   | |__________________^ C152
+30 |   end program p
+   |
+   = help: Convert to `if(...) then` block
+
+ℹ Safe fix
+25 25 |     print *, "baz"
+26 26 | 
+27 27 |   ! Some cases might result in weird indentation.
+28    |-  do i = 1, 3; if (i == 2) &
+29    |-    print *, "foo"; end do
+   28 |+  do i = 1, 3; if (i == 2) then
+   29 |+    print *, "foo"
+   30 |+  end if; end do
+30 31 | end program p

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__misleading-inline-if-continuation_C152.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__misleading-inline-if-continuation_C152.f90.snap
@@ -3,148 +3,100 @@ source: fortitude/src/rules/correctness/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
-./resources/test/fixtures/correctness/C152.f90:6:3: C152 [*] Line continuation in inline if-statement is misleading
-  |
-4 |     integer :: i
-5 |
-6 | /   if (condition) &
-7 | |       print *, "Hello"
-  | |______________________^ C152
-8 |         print *, "World!"
-  |
-  = help: Convert to `if(...) then` block
-
-ℹ Safe fix
-3 3 |   logical, parameter :: condition = .false.
-4 4 |   integer :: i
-5 5 | 
-6   |-  if (condition) &
-7   |-      print *, "Hello"
-  6 |+  if (condition) then
-  7 |+    print *, "Hello"
-  8 |+  end if
-8 9 |       print *, "World!"
-9 10 | 
-10 11 |   if (condition) &
-
-./resources/test/fixtures/correctness/C152.f90:10:3: C152 [*] Line continuation in inline if-statement is misleading
+./resources/test/fixtures/correctness/C152.f90:25:3: C152 [*] Line continuation in inline if-statement is misleading
    |
- 8 |         print *, "World!"
- 9 |
-10 | /   if (condition) &
-11 | |       print *, "Hello"; print *, "World!"
+24 |     ! Raise an error if the body is on a new line.
+25 | /   if (condition) &
+26 | |       print *, "Hello"
    | |______________________^ C152
-12 |
-13 |     if (condition) print *, &
+27 |         print *, "World!"
    |
    = help: Convert to `if(...) then` block
 
 ℹ Safe fix
-7  7  |       print *, "Hello"
-8  8  |       print *, "World!"
-9  9  | 
-10    |-  if (condition) &
-11    |-      print *, "Hello"; print *, "World!"
-   10 |+  if (condition) then
-   11 |+    print *, "Hello"
-   12 |+  end if; print *, "World!"
-12 13 | 
-13 14 |   if (condition) print *, &
-14 15 |     "Hello world!"
+22 22 |       "Hello world!"; end if
+23 23 | 
+24 24 |   ! Raise an error if the body is on a new line.
+25    |-  if (condition) &
+26    |-      print *, "Hello"
+   25 |+  if (condition) then
+   26 |+    print *, "Hello"
+   27 |+  end if
+27 28 |       print *, "World!"
+28 29 | 
+29 30 |   ! Misleading semicolons: the second statement in the body should be placed
 
-./resources/test/fixtures/correctness/C152.f90:13:3: C152 [*] Line continuation in inline if-statement is misleading
+./resources/test/fixtures/correctness/C152.f90:31:3: C152 [*] Line continuation in inline if-statement is misleading
    |
-11 |         print *, "Hello"; print *, "World!"
-12 |
-13 | /   if (condition) print *, &
-14 | |     "Hello world!"
-   | |__________________^ C152
-15 |
-16 |     if (condition) print *, &
-   |
-   = help: Convert to `if(...) then` block
-
-ℹ Safe fix
-10 10 |   if (condition) &
-11 11 |       print *, "Hello"; print *, "World!"
-12 12 | 
-13    |-  if (condition) print *, &
-   13 |+  if (condition) then
-   14 |+    print *, &
-14 15 |     "Hello world!"
-   16 |+  end if
-15 17 | 
-16 18 |   if (condition) print *, &
-17 19 |      & "Hello"
-
-./resources/test/fixtures/correctness/C152.f90:16:3: C152 [*] Line continuation in inline if-statement is misleading
-   |
-14 |       "Hello world!"
-15 |
-16 | /   if (condition) print *, &
-17 | |      & "Hello"
-   | |______________^ C152
+29 |     ! Misleading semicolons: the second statement in the body should be placed
+30 |     ! after the `end if` in the fix.
+31 | /   if (condition) &
+32 | |       print *, "Hello"; print *, "World!"
+   | |______________________^ C152
+33 |
+34 |     ! Permit body split across multiple lines.
    |
    = help: Convert to `if(...) then` block
 
 ℹ Safe fix
-13 13 |   if (condition) print *, &
-14 14 |     "Hello world!"
-15 15 | 
-16    |-  if (condition) print *, &
-   16 |+  if (condition) then
-   17 |+    print *, &
-17 18 |      & "Hello"
-   19 |+  end if
-18 20 | 
-19 21 | 
-20 22 |   ! Inline if statements on a single line are permitted.
+28 28 | 
+29 29 |   ! Misleading semicolons: the second statement in the body should be placed
+30 30 |   ! after the `end if` in the fix.
+31    |-  if (condition) &
+32    |-      print *, "Hello"; print *, "World!"
+   31 |+  if (condition) then
+   32 |+    print *, "Hello"
+   33 |+  end if; print *, "World!"
+33 34 | 
+34 35 |   ! Permit body split across multiple lines.
+35 36 |   if (condition) print *, &
 
-./resources/test/fixtures/correctness/C152.f90:28:16: C152 [*] Line continuation in inline if-statement is misleading
+./resources/test/fixtures/correctness/C152.f90:47:3: C152 [*] Line continuation in inline if-statement is misleading
    |
-27 |     ! Some cases might result in weird indentation.
-28 |     do i = 1, 3; if (i == 2) &
+46 |     ! ... but not if the body starts on a new line
+47 | /   if (condition &
+48 | |       .and. i > 0) &
+49 | |         print *, "Hello world!"
+   | |_______________________________^ C152
+50 |
+51 |     ! Some cases might result in weird indentation.
+   |
+   = help: Convert to `if(...) then` block
+
+ℹ Safe fix
+45 45 | 
+46 46 |   ! ... but not if the body starts on a new line
+47 47 |   if (condition &
+48    |-      .and. i > 0) &
+49    |-        print *, "Hello world!"
+   48 |+      .and. i > 0) then
+   49 |+    print *, "Hello world!"
+   50 |+  end if
+50 51 | 
+51 52 |   ! Some cases might result in weird indentation.
+52 53 |   do i = 1, 3; if (i == 2) &
+
+./resources/test/fixtures/correctness/C152.f90:52:16: C152 [*] Line continuation in inline if-statement is misleading
+   |
+51 |     ! Some cases might result in weird indentation.
+52 |     do i = 1, 3; if (i == 2) &
    |  ________________^
-29 | |     print *, "foo"; end do
+53 | |     print *, "foo"; end do
    | |__________________^ C152
-30 |
-31 |     ! Permit multi-line conditions
+54 |
+55 |     ! We don't handle misleading semicolons here.
    |
    = help: Convert to `if(...) then` block
 
 ℹ Safe fix
-25 25 |     print *, "baz"
-26 26 | 
-27 27 |   ! Some cases might result in weird indentation.
-28    |-  do i = 1, 3; if (i == 2) &
-29    |-    print *, "foo"; end do
-   28 |+  do i = 1, 3; if (i == 2) then
-   29 |+    print *, "foo"
-   30 |+  end if; end do
-30 31 | 
-31 32 |   ! Permit multi-line conditions
-32 33 |   if (condition &
-
-./resources/test/fixtures/correctness/C152.f90:36:3: C152 [*] Line continuation in inline if-statement is misleading
-   |
-35 |     ! ... but not if the body is also multi-line
-36 | /   if (condition &
-37 | |       .and. i > 0) print *, &
-38 | |         "Hello world!"
-   | |______________________^ C152
-39 |
-40 |   end program p
-   |
-   = help: Convert to `if(...) then` block
-
-ℹ Safe fix
-34 34 | 
-35 35 |   ! ... but not if the body is also multi-line
-36 36 |   if (condition &
-37    |-      .and. i > 0) print *, &
-   37 |+      .and. i > 0) then
-   38 |+    print *, &
-38 39 |         "Hello world!"
-   40 |+  end if
-39 41 | 
-40 42 | end program p
+49 49 |         print *, "Hello world!"
+50 50 | 
+51 51 |   ! Some cases might result in weird indentation.
+52    |-  do i = 1, 3; if (i == 2) &
+53    |-    print *, "foo"; end do
+   52 |+  do i = 1, 3; if (i == 2) then
+   53 |+    print *, "foo"
+   54 |+  end if; end do
+54 55 | 
+55 56 |   ! We don't handle misleading semicolons here.
+56 57 |   if (condition) print *, "foo"; print *, "bar"; &

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__misleading-inline-if-continuation_C152.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__misleading-inline-if-continuation_C152.f90.snap
@@ -107,7 +107,8 @@ snapshot_kind: text
    |  ________________^
 29 | |     print *, "foo"; end do
    | |__________________^ C152
-30 |   end program p
+30 |
+31 |     ! Permit multi-line conditions
    |
    = help: Convert to `if(...) then` block
 
@@ -120,4 +121,30 @@ snapshot_kind: text
    28 |+  do i = 1, 3; if (i == 2) then
    29 |+    print *, "foo"
    30 |+  end if; end do
-30 31 | end program p
+30 31 | 
+31 32 |   ! Permit multi-line conditions
+32 33 |   if (condition &
+
+./resources/test/fixtures/correctness/C152.f90:36:3: C152 [*] Line continuation in inline if-statement is misleading
+   |
+35 |     ! ... but not if the body is also multi-line
+36 | /   if (condition &
+37 | |       .and. i > 0) print *, &
+38 | |         "Hello world!"
+   | |______________________^ C152
+39 |
+40 |   end program p
+   |
+   = help: Convert to `if(...) then` block
+
+ℹ Safe fix
+34 34 | 
+35 35 |   ! ... but not if the body is also multi-line
+36 36 |   if (condition &
+37    |-      .and. i > 0) print *, &
+   37 |+      .and. i > 0) then
+   38 |+    print *, &
+38 39 |         "Hello world!"
+   40 |+  end if
+39 41 | 
+40 42 | end program p

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod portability;
 pub(crate) mod style;
 pub(crate) mod testing;
 pub mod utilities;
+
 use crate::registry::{AsRule, Category};
 
 use std::fmt::Formatter;
@@ -102,6 +103,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Correctness, "142") => (RuleGroup::Preview, Ast, Optional, correctness::exit_labels::ExitOrCycleInUnlabelledLoop),
         (Correctness, "143") => (RuleGroup::Preview, Ast, Default, correctness::exit_labels::MissingEndLabel),
         (Correctness, "151") => (RuleGroup::Preview, Ast, Default, correctness::conditionals::IfStatementSemicolon),
+        (Correctness, "152") => (RuleGroup::Preview, Ast, Default, correctness::conditionals::MisleadingInlineIfContinuation),
 
         // modernisation
         (Modernisation, "001") => (RuleGroup::Stable, Ast, Optional, modernisation::double_precision::DoublePrecision),


### PR DESCRIPTION
Solves https://github.com/PlasmaFAIR/fortitude/issues/65

Partly.

Rather than flagging up all inline if statements, which would be a fairly controversial style rule, this solves the subset of cases where an inline if statement spills over multiple lines.
I decided to go for the reduced problem, as I would prefer not to flag up things like:

```f90
if (allocated(A)) deallocate(A)
```

However, I would argue code like the following goes beyond a style violation and becomes a correctness problem:

```f90
if (condition) &
  call do_something()
```