### PR TITLE
Don't raise `SyntaxError` for missing nodes if rule not enabled

### DIFF
--- a/fortitude/src/check.rs
+++ b/fortitude/src/check.rs
@@ -227,7 +227,7 @@ pub(crate) fn check_path(
     // Perform AST analysis
     let root = tree.root_node();
     for node in once(root).chain(root.descendants()) {
-        if node.is_missing() {
+        if rules.enabled(Rule::SyntaxError) && node.is_missing() {
             violations.push(Diagnostic::from_node(SyntaxError {}, &node));
         }
 

--- a/fortitude/tests/check.rs
+++ b/fortitude/tests/check.rs
@@ -2166,3 +2166,37 @@ end program test
 
     Ok(())
 }
+
+/// Issue 429, ignoring syntax errors from missing nodes
+#[test]
+fn ignore_syntax_errors() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f90");
+    fs::write(
+        &test_file,
+        r#"
+program foo
+  implicit none (type, external)
+  type(bar, pointer :: zing
+end program foo
+"#,
+    )?;
+
+    assert_cmd_snapshot!(Command::cargo_bin(BIN_NAME)?
+                         .arg("check")
+                         .arg("--select=C003")
+                         .arg("--ignore=E001")
+                         .arg(test_file),
+                         @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    fortitude: 1 files scanned.
+    All checks passed!
+
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #429