### PR TITLE
Clarify `line-too-long` behaviour for long strings and comments

### DIFF
--- a/docs/rules/line-too-long.md
+++ b/docs/rules/line-too-long.md
@@ -16,6 +16,10 @@ traditional 80, but due to the verbosity of modern Fortran it can sometimes be
 difficult to squeeze lines into that width, especially when using large indents
 and multiple levels of indentation.
 
+Some lines that are longer than the maximum length may be acceptable, such as
+long strings or comments. This is to allow for long URLs or other text that cannot
+be reasonably split across multiple lines.
+
 Note that the Fortran standard states a maximum line length of 132 characters,
 and while some modern compilers will support longer lines, for portability it
 is recommended to stay beneath this limit.

--- a/fortitude/src/rules/style/line_length.rs
+++ b/fortitude/src/rules/style/line_length.rs
@@ -23,6 +23,10 @@ use ruff_text_size::{TextLen, TextRange, TextSize};
 /// difficult to squeeze lines into that width, especially when using large indents
 /// and multiple levels of indentation.
 ///
+/// Some lines that are longer than the maximum length may be acceptable, such as
+/// long strings or comments. This is to allow for long URLs or other text that cannot
+/// be reasonably split across multiple lines.
+///
 /// Note that the Fortran standard states a maximum line length of 132 characters,
 /// and while some modern compilers will support longer lines, for portability it
 /// is recommended to stay beneath this limit.


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/432

In future, we should look to Ruff's line-length rule and try to include the same nuance in ours.