### PR TITLE
Fix `non-portable-io-unit` triggering on any magic number

### DIFF
--- a/docs/rules/non-portable-io-unit.md
+++ b/docs/rules/non-portable-io-unit.md
@@ -5,6 +5,7 @@ This rule is unstable and in [preview](../preview.md). The `--preview` flag is r
 Checks for the literals `5` or `6` as units in `read`/`write` statements.
 
 ## Why is this bad?
-The Fortran standard does not specify numeric values for `stdin` or
-`stdout`. Instead, use the named constants `input_unit` and `output_unit`
-from the `iso_fortran_env` module.
+The Fortran standard does not specify numeric values for `stdin` or `stdout`, and
+although many compilers do "pre-connect" units `5` and `6` respectively, some use
+other numbers. Instead, use the named constants `input_unit` and `output_unit` from
+the `iso_fortran_env` module.

--- a/fortitude/resources/test/fixtures/portability/PORT001.f90
+++ b/fortitude/resources/test/fixtures/portability/PORT001.f90
@@ -9,4 +9,8 @@ program test
   open(newunit=named_unit, file="test.txt", action="write")
   write(named_unit, *) "i =", i
   close(named_unit)
+
+  open(unit=17, file="ok.txt")
+  write(17, *) "this is a magic number, but portable"
+  close(17)
 end program test


### PR DESCRIPTION
This rule was triggering on _any_ magic number, which a) overlaps with `magic-io-unit`, and b) isn't helpful for most cases.

It is a _bit_ weird that with this fix we only trigger on 5 or 6, but it seems most (still) existing compilers do use these units, except for Cray, which uses 100, 101, 102. Maybe we should also check for those units? Also unit 0 for `stderr`?