### PR TITLE
Fix typo in setting variable names

### DIFF
--- a/docs/rules/keyword-has-whitespace.md
+++ b/docs/rules/keyword-has-whitespace.md
@@ -8,8 +8,8 @@ This rule is turned on by default.
 ## What it does
 Checks for the use of `in out` instead of `inout` and `go to` instead of `goto`.
 Either may be exempted from this rule by setting the options
-[`inout_with_space`](../settings.md#inout-with-space) and
-[`goto_with_space`](../settings.md#goto-with-space).
+[`inout-with-space`](../settings.md#inout-with-space) and
+[`goto-with-space`](../settings.md#goto-with-space).
 
 ## Why is this bad?
 By convention, `inout` in normally preferred to `in out`. Both `go to` and

--- a/docs/rules/keywords-missing-space.md
+++ b/docs/rules/keywords-missing-space.md
@@ -10,8 +10,8 @@ Checks for the use of keywords comprised of two words where the space is
 omitted, such as `elseif` instead of `else if` and `endmodule` instead of
 `endmodule`. The keywords `inout` and `goto` are exempt from this rule by
 default, but may be included by setting the options
-[`inout_with_space`](../settings.md#inout-with-space) and
-[`goto_with_space`](../settings.md#goto-with-space).
+[`inout-with-space`](../settings.md#inout-with-space) and
+[`goto-with-space`](../settings.md#goto-with-space).
 
 ## Why is this bad?
 Contracting two keywords into one can make code less readable. Enforcing

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -628,13 +628,13 @@ Whether to enforce the use of `go to` instead of `goto`.
 
     ```toml
     [extra.fortitude.check.keyword-whitespace]
-    goto_with_space = true
+    goto-with-space = true
     ```
 === "fortitude.toml"
 
     ```toml
     [check.keyword-whitespace]
-    goto_with_space = true
+    goto-with-space = true
     ```
 
 ---
@@ -654,13 +654,13 @@ Whether to enforce the use of `in out` instead of `inout`.
 
     ```toml
     [extra.fortitude.check.keyword-whitespace]
-    inout_with_space = true
+    inout-with-space = true
     ```
 === "fortitude.toml"
 
     ```toml
     [check.keyword-whitespace]
-    inout_with_space = true
+    inout-with-space = true
     ```
 
 ---

--- a/fortitude/src/options.rs
+++ b/fortitude/src/options.rs
@@ -341,7 +341,7 @@ pub struct KeywordWhitespaceOptions {
     #[option(
         default = "false",
         value_type = "bool",
-        example = "inout_with_space = true"
+        example = "inout-with-space = true"
     )]
     pub inout_with_space: Option<bool>,
 
@@ -349,7 +349,7 @@ pub struct KeywordWhitespaceOptions {
     #[option(
         default = "false",
         value_type = "bool",
-        example = "goto_with_space = true"
+        example = "goto-with-space = true"
     )]
     pub goto_with_space: Option<bool>,
 }

--- a/fortitude/src/rules/style/keywords.rs
+++ b/fortitude/src/rules/style/keywords.rs
@@ -86,8 +86,8 @@ impl DoubleKeyword {
 /// omitted, such as `elseif` instead of `else if` and `endmodule` instead of
 /// `endmodule`. The keywords `inout` and `goto` are exempt from this rule by
 /// default, but may be included by setting the options
-/// [`inout_with_space`](../settings.md#inout-with-space) and
-/// [`goto_with_space`](../settings.md#goto-with-space).
+/// [`inout-with-space`](../settings.md#inout-with-space) and
+/// [`goto-with-space`](../settings.md#goto-with-space).
 ///
 /// ## Why is this bad?
 /// Contracting two keywords into one can make code less readable. Enforcing
@@ -171,8 +171,8 @@ impl AstRule for KeywordsMissingSpace {
 /// ## What it does
 /// Checks for the use of `in out` instead of `inout` and `go to` instead of `goto`.
 /// Either may be exempted from this rule by setting the options
-/// [`inout_with_space`](../settings.md#inout-with-space) and
-/// [`goto_with_space`](../settings.md#goto-with-space).
+/// [`inout-with-space`](../settings.md#inout-with-space) and
+/// [`goto-with-space`](../settings.md#goto-with-space).
 ///
 /// ## Why is this bad?
 /// By convention, `inout` in normally preferred to `in out`. Both `go to` and


### PR DESCRIPTION
All settings are kebab-case in the config file, although the variables are snake_case. This is just a typo in the docs, and doesn't affect the actual config files