### PR TITLE
Bump to latest tree-sitter-fortran

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,8 +2065,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-fortran"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce58ab374a2cc3a2ff8a5dab2e5230530dbfcb439475afa75233f59d1d115b40"
+source = "git+https://github.com/stadelmanma/tree-sitter-fortran.git?branch=recent-changes#c2a0fc779a30a51f5a8f883ddb17c28a9a2c6c95"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ strum_macros = { version = "0.27.1" }
 textwrap = { version = "0.16.0" }
 tree-sitter = "~0.25.0"
 tree-sitter-cli = "~0.25.0"
-tree-sitter-fortran = "0.5.1"
+tree-sitter-fortran = { git = "https://github.com/stadelmanma/tree-sitter-fortran.git", branch = "recent-changes" }
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/fortitude/src/rules/obsolescent/computed_goto.rs
+++ b/fortitude/src/rules/obsolescent/computed_goto.rs
@@ -81,10 +81,10 @@ impl Violation for ComputedGoTo {
 
 impl AstRule for ComputedGoTo {
     fn check(_settings: &Settings, node: &Node, _src: &SourceFile) -> Option<Vec<Diagnostic>> {
-        if node.child(0)?.kind() == "goto"
+        if matches!(node.child(0)?.kind(), "goto" | "go")
             && node
                 .children(&mut node.walk())
-                .filter(|node| node.kind() != "goto")
+                .filter(|node| !matches!(node.kind(), "go" | "to" | "goto"))
                 .count()
                 > 1
         {


### PR DESCRIPTION
Couple of fixes required because space-separated-keywords now appear with their actual names, rather than whole keyword doubled e.g. previously `end if` was ("endif" "endif"), now it's ("end" "if")

Should be a new release of the grammar soon, but I want to get this in so we can start using other changes sooner. We should switch back to released version before our next release