### PR TITLE
Ensure an empty space between brackets is only raised once

### DIFF
--- a/fortitude/resources/test/fixtures/style/S104.f90
+++ b/fortitude/resources/test/fixtures/style/S104.f90
@@ -17,7 +17,10 @@ contains
     a &
   ) ! This should be unchanged
     implicit none
-    integer :: a = (1 + 1 &
+    integer :: a
+    a = (1 + 1 &
     & ) ! This should be unchanged
   end subroutine myothersub
+  subroutine emptyparantesessub( ) ! This should remove the space between the brackets
+  end subroutine emptyparantesessub
 end program myprog

--- a/fortitude/src/rules/style/snapshots/fortitude__rules__style__tests__incorrect-space-between-brackets_S104.f90.snap
+++ b/fortitude/src/rules/style/snapshots/fortitude__rules__style__tests__incorrect-space-between-brackets_S104.f90.snap
@@ -190,3 +190,23 @@ expression: diagnostics
 15 15 |   end subroutine mysub
 16 16 |   subroutine myothersub( & ! This should be allowed for long parameter lists
 17 17 |     a &
+
+./resources/test/fixtures/style/S104.f90:24:33: S104 [*] Should be 0 space before the closing bracket
+   |
+22 |     & ) ! This should be unchanged
+23 |   end subroutine myothersub
+24 |   subroutine emptyparantesessub( ) ! This should remove the space between the brackets
+   |                                 ^ S104
+25 |   end subroutine emptyparantesessub
+26 | end program myprog
+   |
+   = help: remove extra whitespace
+
+ℹ Safe fix
+21 21 |     a = (1 + 1 &
+22 22 |     & ) ! This should be unchanged
+23 23 |   end subroutine myothersub
+24    |-  subroutine emptyparantesessub( ) ! This should remove the space between the brackets
+   24 |+  subroutine emptyparantesessub() ! This should remove the space between the brackets
+25 25 |   end subroutine emptyparantesessub
+26 26 | end program myprog

--- a/fortitude/src/rules/style/whitespace.rs
+++ b/fortitude/src/rules/style/whitespace.rs
@@ -237,6 +237,18 @@ impl AstRule for IncorrectSpaceBetweenBrackets {
             return None; // No whitespace to fix
         }
         let whitespace_range = TextRange::new(whitespace_start, whitespace_end);
+
+        // If the space is between empty brackets only raise for closing bracket
+        let whitespace_range_plus_one_char = source.slice(whitespace_range + TextSize::from(1));
+        if !whitespace_range_plus_one_char
+            .find(|c: char| c == ')' || c == ']')
+            .is_none()
+        {
+            if is_open_bracket {
+                return None;
+            }
+        }
+
         some_vec!(Diagnostic::new(Self { is_open_bracket }, whitespace_range)
             .with_fix(Fix::safe_edit(Edit::range_deletion(whitespace_range))))
     }

--- a/fortitude/src/rules/style/whitespace.rs
+++ b/fortitude/src/rules/style/whitespace.rs
@@ -239,14 +239,9 @@ impl AstRule for IncorrectSpaceBetweenBrackets {
         let whitespace_range = TextRange::new(whitespace_start, whitespace_end);
 
         // If the space is between empty brackets only raise for closing bracket
-        let whitespace_range_plus_one_char = source.slice(whitespace_range + TextSize::from(1));
-        if !whitespace_range_plus_one_char
-            .find(|c: char| c == ')' || c == ']')
-            .is_none()
-        {
-            if is_open_bracket {
-                return None;
-            }
+        let after = source.after(whitespace_end);
+        if is_open_bracket && (after.starts_with(")") || after.starts_with("]")) {
+            return None;
         }
 
         some_vec!(Diagnostic::new(Self { is_open_bracket }, whitespace_range)


### PR DESCRIPTION
The edge case of empty brackets with whitespace was being caught by both the opening bracket and the closing bracket. 

This change ensure that this is only raised for the closing bracket. This could also be done for only the opening bracket, the logic is pretty much the same. I made an arbitrary decision, so happy to change it if opening is preferred.