### PR TITLE
Add rule `multiple-allocations-with-stat`

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -43,6 +43,7 @@
 | C161 | [nonportable-shortcircuit-inquiry](rules/nonportable-shortcircuit-inquiry.md) | variable inquiry `{function}({arg})` and use in same logical expression | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | C171 | [split-escaped-quote](rules/split-escaped-quote.md) | line continuation in split escaped quote looks like implicit concatenation | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 | C181 | [unchecked-stat](rules/unchecked-stat.md) | {stat} argument '{name}' is {check_status} in this scope. | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| C182 | [multiple-allocations-with-stat](rules/multiple-allocations-with-stat.md) | 'stat' parameter used with multiple {allocations}. | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 
 ### Obsolescent (OB)
 

--- a/docs/rules/multiple-allocations-with-stat.md
+++ b/docs/rules/multiple-allocations-with-stat.md
@@ -8,10 +8,10 @@ This rule detects whether `stat` is used alongside multiple allocations or
 deallocations.
 
 ## Why is this bad?
-When allocating or deallocating multiple arrays at once, the use of a `stat`
+When allocating or deallocating multiple variables at once, the use of a `stat`
 parameter will permit the program to continue running even if one of the
 allocations or deallocations fails. However, it may not be clear which
 allocation or deallocation caused the error.
 
 To avoid confusion, it is recommended to use separate allocate or deallocate
-statements for each array and check the `stat` parameters individually.
+statements for each variable and check the `stat` parameters individually.

--- a/docs/rules/multiple-allocations-with-stat.md
+++ b/docs/rules/multiple-allocations-with-stat.md
@@ -1,0 +1,17 @@
+# multiple-allocations-with-stat (C182)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+This rule is turned on by default.
+
+## What does it do?
+This rule detects whether `stat` is used alongside multiple allocations or
+deallocations.
+
+## Why is this bad?
+When allocating or deallocating multiple arrays at once, the use of a `stat`
+parameter will permit the program to continue running even if one of the
+allocations or deallocations fails. However, it may not be clear which
+allocation or deallocation caused the error.
+
+To avoid confusion, it is recommended to use separate allocate or deallocate
+statements for each array and check the `stat` parameters individually.

--- a/docs/rules/unchecked-stat.md
+++ b/docs/rules/unchecked-stat.md
@@ -4,13 +4,13 @@ This rule is unstable and in [preview](../preview.md). The `--preview` flag is r
 This rule is turned on by default.
 
 ## What does it do?
-This rule detects whether a `stat`, `iostat`, and `cmdstat` variable is checked
+This rule detects whether a `stat`, `iostat`, and `cmdstat` argument is checked
 within the same scope it is set.
 
 ## Why is this bad?
-By default, `allocate` statements will crash the program if the allocation
+By default, `allocate` statements will abort the program if the allocation
 fails. This is often the desired behaviour, but to provide for cases in
-which the user wants to handle allocation errors gracefully, they may
+which the developer wants to handle allocation errors gracefully, they may
 optionally check the status of an `allocate` statement by passing a variable
 to the `stat` argument:
 

--- a/fortitude/resources/test/fixtures/correctness/C182.f90
+++ b/fortitude/resources/test/fixtures/correctness/C182.f90
@@ -1,0 +1,20 @@
+program p
+  implicit none
+  real(8), allocatable :: x(:), y(:)
+  integer :: status
+
+  ! no stat params
+  allocate (x(10), y(10))
+  deallocate (x, y)
+
+  ! stat params, but one each
+  allocate (x(10), stat=status)
+  allocate (y(10), stat=status)
+  deallocate (x, stat=status)
+  deallocate (y, stat=status)
+
+  ! stat params, combined in one statement
+  allocate (x(10), y(10), stat=status)
+  deallocate (x, y, stat=status)
+
+end program p

--- a/fortitude/src/rules/correctness/error_handling.rs
+++ b/fortitude/src/rules/correctness/error_handling.rs
@@ -348,10 +348,10 @@ impl AstRule for MultipleAllocationsWithStat {
         let stat_node = node.kwarg("stat", src)?;
 
         // Count allocations
-        let count = match node.kind() {
-            "allocate_statement" => count_allocations(node),
-            "deallocate_statement" => count_deallocations(node),
-            _ => return None,
+        let count = if node.kind() == "allocate_statement" {
+            count_allocations(node)
+        } else {
+            count_deallocations(node)
         };
         if count <= 1 {
             return None;

--- a/fortitude/src/rules/correctness/error_handling.rs
+++ b/fortitude/src/rules/correctness/error_handling.rs
@@ -63,13 +63,13 @@ enum CheckStatus {
 }
 
 /// ## What does it do?
-/// This rule detects whether a `stat`, `iostat`, and `cmdstat` variable is checked
+/// This rule detects whether a `stat`, `iostat`, and `cmdstat` argument is checked
 /// within the same scope it is set.
 ///
 /// ## Why is this bad?
-/// By default, `allocate` statements will crash the program if the allocation
+/// By default, `allocate` statements will abort the program if the allocation
 /// fails. This is often the desired behaviour, but to provide for cases in
-/// which the user wants to handle allocation errors gracefully, they may
+/// which the developer wants to handle allocation errors gracefully, they may
 /// optionally check the status of an `allocate` statement by passing a variable
 /// to the `stat` argument:
 ///
@@ -317,13 +317,13 @@ impl AllocationType {
 /// deallocations.
 ///
 /// ## Why is this bad?
-/// When allocating or deallocating multiple arrays at once, the use of a `stat`
+/// When allocating or deallocating multiple variables at once, the use of a `stat`
 /// parameter will permit the program to continue running even if one of the
 /// allocations or deallocations fails. However, it may not be clear which
 /// allocation or deallocation caused the error.
 ///
 /// To avoid confusion, it is recommended to use separate allocate or deallocate
-/// statements for each array and check the `stat` parameters individually.
+/// statements for each variable and check the `stat` parameters individually.
 #[derive(ViolationMetadata)]
 pub(crate) struct MultipleAllocationsWithStat {
     alloc_type: AllocationType,

--- a/fortitude/src/rules/correctness/error_handling.rs
+++ b/fortitude/src/rules/correctness/error_handling.rs
@@ -345,12 +345,7 @@ impl AstRule for MultipleAllocationsWithStat {
         let src = source.source_text();
 
         // Check this has a stat parameter
-        let stat_node = node.named_children(&mut node.walk()).find(|child| {
-            child.kind() == "keyword_argument"
-                && child.child_by_field_name("name").is_some_and(|n| {
-                    n.to_text(src).map(|s| s.to_lowercase()) == Some("stat".to_string())
-                })
-        })?;
+        let stat_node = node.kwarg("stat", src)?;
 
         // Count allocations
         let count = match node.kind() {

--- a/fortitude/src/rules/correctness/error_handling.rs
+++ b/fortitude/src/rules/correctness/error_handling.rs
@@ -297,3 +297,75 @@ fn new_branch(node: &Node) -> bool {
         "elseif_clause" | "else_clause" | "case_statement"
     )
 }
+
+enum AllocationType {
+    Allocate,
+    Deallocate,
+}
+impl AllocationType {
+    fn from_node(node: &Node) -> Result<Self> {
+        match node.kind() {
+            "allocate_statement" => Ok(AllocationType::Allocate),
+            "dellocate_statement" => Ok(AllocationType::Deallocate),
+            _ => Err(anyhow!("Node is not an allocation type")),
+        }
+    }
+}
+
+/// ## What does it do?
+/// This rule detects whether `stat` is used alongside multiple allocations or
+/// deallocations.
+///
+/// ## Why is this bad?
+/// When allocating or deallocating multiple arrays at once, the use of a `stat`
+/// parameter will permit the program to continue running even if one of the
+/// allocations or deallocations fails. However, it may not be clear which
+/// allocation or deallocation caused the error.
+///
+/// To avoid confusion, it is recommended to use separate allocate or deallocate
+/// statements for each array and check the `stat` parameters individually.
+#[derive(ViolationMetadata)]
+pub(crate) struct MultipleAllocationsWithStat {
+    alloc_type: AllocationType,
+}
+
+impl Violation for MultipleAllocationsWithStat {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let allocations = match self.alloc_type {
+            AllocationType::Allocate => "allocations",
+            AllocationType::Deallocate => "deallocations",
+        };
+        format!("'stat' parameter used with multiple {allocations}.")
+    }
+}
+
+impl AstRule for MultipleAllocationsWithStat {
+    fn check(_settings: &Settings, node: &Node, source: &SourceFile) -> Option<Vec<Diagnostic>> {
+        let src = source.source_text();
+
+        // Check this has a stat parameter
+        let stat_node = node.named_children(&mut node.walk()).find(|child| {
+            child.kind() == "keyword_argument"
+                && child.child_by_field_name("name").is_some_and(|n| {
+                    n.to_text(src).map(|s| s.to_lowercase()) == Some("stat".to_string())
+                })
+        })?;
+
+        // Count allocations
+        let count = node
+            .children_by_field_name("allocation", &mut node.walk())
+            .count();
+        if count <= 1 {
+            return None;
+        }
+
+        let alloc_type = AllocationType::from_node(node).ok()?;
+
+        some_vec!(Diagnostic::from_node(Self { alloc_type }, &stat_node))
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["allocate_statement", "deallocate_statement"]
+    }
+}

--- a/fortitude/src/rules/correctness/mod.rs
+++ b/fortitude/src/rules/correctness/mod.rs
@@ -67,6 +67,7 @@ mod tests {
     #[test_case(Rule::NonportableShortcircuitInquiry, Path::new("C161.f90"))]
     #[test_case(Rule::SplitEscapedQuote, Path::new("C171.f90"))]
     #[test_case(Rule::UncheckedStat, Path::new("C181.f90"))]
+    #[test_case(Rule::MultipleAllocationsWithStat, Path::new("C182.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__multiple-allocations-with-stat_C182.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__multiple-allocations-with-stat_C182.f90.snap
@@ -1,0 +1,12 @@
+---
+source: fortitude/src/rules/correctness/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/correctness/C182.f90:17:27: C182 'stat' parameter used with multiple allocations.
+   |
+16 |   ! stat params, combined in one statement
+17 |   allocate (x(10), y(10), stat=status)
+   |                           ^^^^^^^^^^^ C182
+18 |   deallocate (x, y, stat=status)
+   |

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__multiple-allocations-with-stat_C182.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__multiple-allocations-with-stat_C182.f90.snap
@@ -10,3 +10,13 @@ snapshot_kind: text
    |                           ^^^^^^^^^^^ C182
 18 |   deallocate (x, y, stat=status)
    |
+
+./resources/test/fixtures/correctness/C182.f90:18:21: C182 'stat' parameter used with multiple deallocations.
+   |
+16 |   ! stat params, combined in one statement
+17 |   allocate (x(10), y(10), stat=status)
+18 |   deallocate (x, y, stat=status)
+   |                     ^^^^^^^^^^^ C182
+19 |
+20 | end program p
+   |

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -107,6 +107,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Correctness, "161") => (RuleGroup::Preview, Ast, Default, correctness::nonportable_shortcircuit_inquiry::NonportableShortcircuitInquiry),
         (Correctness, "171") => (RuleGroup::Preview, Text, Optional, correctness::split_escaped_quote::SplitEscapedQuote),
         (Correctness, "181") => (RuleGroup::Preview, Ast, Default, correctness::error_handling::UncheckedStat),
+        (Correctness, "182") => (RuleGroup::Preview, Ast, Default, correctness::error_handling::MultipleAllocationsWithStat),
 
         // modernisation
         (Modernisation, "001") => (RuleGroup::Stable, Ast, Optional, modernisation::double_precision::DoublePrecision),


### PR DESCRIPTION
Fixes https://github.com/PlasmaFAIR/fortitude/issues/461

Builds on https://github.com/PlasmaFAIR/fortitude/pull/458

Not yet ready to merge, as the rule has been written in anticipation of updates to the tree-sitter grammar, and currently is not catching deallocate statements.