### PR TITLE
Add an option to exempt specific modules from rule C121

### DIFF
--- a/docs/rules/use-all.md
+++ b/docs/rules/use-all.md
@@ -3,6 +3,8 @@ This rule is turned on by default.
 
 ## What it does
 Checks whether `use` statements are used correctly.
+Specific modules may be exempted from this rule by setting the
+[`allow-mods`](../settings.md#allow-mods) option.
 
 ## Why is this bad?
 When using a module, it is recommended to add an 'only' clause to specify which

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -730,3 +730,32 @@ Quote style to prefer for string literals (either "single" or "double").
 
 ---
 
+### `check.use-all`
+
+Options for the use all rule
+
+#### [`allow-mods`](#check_use-all_allow-mods) {: #check_use-all_allow-mods }
+<span id="allow-mods"></span>
+
+Allow use all for specific modules.
+
+**Default value**: `[]`
+
+**Type**: `List[str]`
+
+**Example usage**:
+
+=== "fpm.toml"
+
+    ```toml
+    [extra.fortitude.check.use-all]
+    allow-mods = ["my_env_mod"]
+    ```
+=== "fortitude.toml"
+
+    ```toml
+    [check.use-all]
+    allow-mods = ["my_env_mod"]
+    ```
+
+---

--- a/fortitude/src/configuration.rs
+++ b/fortitude/src/configuration.rs
@@ -1,7 +1,7 @@
 use crate::cli::CheckArgs;
 use crate::fs::{FilePattern, FilePatternSet, EXCLUDE_BUILTINS, FORTRAN_EXTS};
 use crate::options::{
-    ExitUnlabelledLoopOptions, KeywordWhitespaceOptions, Options, PortabilityOptions, StringOptions,
+    ExitUnlabelledLoopOptions, KeywordWhitespaceOptions, UseAllOptions, Options, PortabilityOptions, StringOptions,
 };
 use crate::registry::RuleNamespace;
 use crate::rule_redirects::get_redirect;
@@ -170,6 +170,7 @@ pub struct Configuration {
     // Individual rules
     pub exit_unlabelled_loops: Option<ExitUnlabelledLoopOptions>,
     pub keyword_whitespace: Option<KeywordWhitespaceOptions>,
+    pub use_all: Option<UseAllOptions>,
     pub strings: Option<StringOptions>,
     pub portability: Option<PortabilityOptions>,
 }
@@ -197,6 +198,7 @@ impl Default for Configuration {
             gitignore_mode: Default::default(),
             exit_unlabelled_loops: Default::default(),
             keyword_whitespace: Default::default(),
+            use_all: Default::default(),
             strings: Default::default(),
             portability: Default::default(),
         }
@@ -270,6 +272,7 @@ impl Configuration {
             // Individual rules
             exit_unlabelled_loops: check.exit_unlabelled_loops,
             keyword_whitespace: check.keyword_whitespace,
+            use_all: check.use_all,
             strings: check.strings,
             portability: check.portability,
         }
@@ -374,6 +377,10 @@ impl Configuration {
                 keyword_whitespace: self
                     .keyword_whitespace
                     .map(KeywordWhitespaceOptions::into_settings)
+                    .unwrap_or_default(),
+                use_all: self
+                    .use_all
+                    .map(UseAllOptions::into_settings)
                     .unwrap_or_default(),
                 strings: self
                     .strings

--- a/fortitude/src/options.rs
+++ b/fortitude/src/options.rs
@@ -11,7 +11,10 @@ use serde::{Deserialize, Serialize};
 use crate::{
     rule_selector::RuleSelector,
     rules::{
-        correctness::exit_labels,
+        correctness::{
+            exit_labels,
+            use_statements,
+        },
         portability::{self},
         style::{
             keywords,
@@ -296,6 +299,10 @@ pub struct CheckOptions {
     #[option_group]
     pub keyword_whitespace: Option<KeywordWhitespaceOptions>,
 
+    /// Options for the `use-all-allow-mods` rule
+    #[option_group]
+    pub use_all: Option<UseAllOptions>,
+
     /// Options for the `bad-string-quote` rule
     #[option_group]
     pub strings: Option<StringOptions>,
@@ -364,6 +371,32 @@ impl KeywordWhitespaceOptions {
         keywords::settings::Settings {
             inout_with_space: self.inout_with_space.unwrap_or(false),
             goto_with_space: self.goto_with_space.unwrap_or(false),
+        }
+    }
+}
+
+/// Options for the `use-all-allow-mods` rules
+#[derive(
+    Clone, Debug, PartialEq, Eq, Default, OptionsMetadata, CombineOptions, Serialize, Deserialize,
+)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct UseAllOptions {
+    /// Whether to enforce the use of `in out` instead of `inout`.
+    #[option(
+        default = "[]",
+        value_type = "list[str]",
+        example = r#"
+            # In addition to the standard set of exclusions, omit all tests, plus a specific file.
+            extend-exclude = ["tests", "src/bad.f90"]
+        "#
+    )]
+    pub allow_mods: Option<Vec<String>>
+}
+
+impl UseAllOptions {
+    pub fn into_settings(self) -> use_statements::settings::Settings {
+        use_statements::settings::Settings {
+            allow_mods: self.allow_mods.unwrap_or_default()
         }
     }
 }

--- a/fortitude/src/settings.rs
+++ b/fortitude/src/settings.rs
@@ -19,7 +19,7 @@ use crate::fs::{FilePatternSet, EXCLUDE_BUILTINS, FORTRAN_EXTS};
 use crate::registry::Rule;
 use crate::rule_selector::{CompiledPerFileIgnoreList, PreviewOptions, RuleSelector};
 use crate::rule_table::RuleTable;
-use crate::rules::correctness::exit_labels;
+use crate::rules::correctness::{exit_labels, use_statements};
 use crate::rules::portability::{self};
 use crate::rules::style::{keywords, strings};
 
@@ -74,6 +74,7 @@ pub struct CheckSettings {
     // Individual rule settings
     pub exit_unlabelled_loops: exit_labels::settings::Settings,
     pub keyword_whitespace: keywords::settings::Settings,
+    pub use_all: use_statements::settings::Settings,
     pub strings: strings::settings::Settings,
     pub portability: portability::settings::Settings,
 }
@@ -98,6 +99,7 @@ impl CheckSettings {
             ignore_allow_comments: IgnoreAllowComments::default(),
             exit_unlabelled_loops: exit_labels::settings::Settings::default(),
             keyword_whitespace: keywords::settings::Settings::default(),
+            use_all: use_statements::settings::Settings::default(),
             strings: strings::settings::Settings::default(),
             portability: portability::settings::Settings::default(),
         }
@@ -130,6 +132,7 @@ impl fmt::Display for CheckSettings {
             fields = [
                 self.exit_unlabelled_loops | nested,
                 self.keyword_whitespace | nested,
+                self.use_all | nested,
                 self.strings | nested,
                 self.portability | nested,
             ]


### PR DESCRIPTION
Often I find it useful to have one or few more modules that are "safe" to `USE` without `ONLY` specification. For example a base runtime or environment set. This pull request enables exempting specific modules from [C121](https://fortitude.readthedocs.io/en/stable/rules/use-all/) by name.