### PR TITLE
Add rule `stat-without-message`

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -44,6 +44,7 @@
 | C171 | [split-escaped-quote](rules/split-escaped-quote.md) | line continuation in split escaped quote looks like implicit concatenation | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 | C181 | [unchecked-stat](rules/unchecked-stat.md) | {stat} argument '{name}' is {check_status} in this scope. | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | C182 | [multiple-allocations-with-stat](rules/multiple-allocations-with-stat.md) | 'stat' parameter used with multiple {allocations}. | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| C183 | [stat-without-message](rules/stat-without-message.md) | '{stat}' used without '{errmsg}'. | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 
 ### Obsolescent (OB)
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -43,6 +43,7 @@
 | C161 | [nonportable-shortcircuit-inquiry](rules/nonportable-shortcircuit-inquiry.md) | variable inquiry `{function}({arg})` and use in same logical expression | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | C171 | [split-escaped-quote](rules/split-escaped-quote.md) | line continuation in split escaped quote looks like implicit concatenation | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 | C181 | [unchecked-stat](rules/unchecked-stat.md) | {stat} argument '{name}' is {check_status} in this scope. | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| C182 | [multiple-allocations-with-stat](rules/multiple-allocations-with-stat.md) | 'stat' parameter used with multiple {allocations}. | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 
 ### Obsolescent (OB)
 

--- a/docs/rules/multiple-allocations-with-stat.md
+++ b/docs/rules/multiple-allocations-with-stat.md
@@ -8,10 +8,10 @@ This rule detects whether `stat` is used alongside multiple allocations or
 deallocations.
 
 ## Why is this bad?
-When allocating or deallocating multiple arrays at once, the use of a `stat`
+When allocating or deallocating multiple variables at once, the use of a `stat`
 parameter will permit the program to continue running even if one of the
 allocations or deallocations fails. However, it may not be clear which
 allocation or deallocation caused the error.
 
 To avoid confusion, it is recommended to use separate allocate or deallocate
-statements for each array and check the `stat` parameters individually.
+statements for each variable and check the `stat` parameters individually.

--- a/docs/rules/multiple-allocations-with-stat.md
+++ b/docs/rules/multiple-allocations-with-stat.md
@@ -1,0 +1,17 @@
+# multiple-allocations-with-stat (C182)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+This rule is turned on by default.
+
+## What does it do?
+This rule detects whether `stat` is used alongside multiple allocations or
+deallocations.
+
+## Why is this bad?
+When allocating or deallocating multiple arrays at once, the use of a `stat`
+parameter will permit the program to continue running even if one of the
+allocations or deallocations fails. However, it may not be clear which
+allocation or deallocation caused the error.
+
+To avoid confusion, it is recommended to use separate allocate or deallocate
+statements for each array and check the `stat` parameters individually.

--- a/docs/rules/stat-without-message.md
+++ b/docs/rules/stat-without-message.md
@@ -1,0 +1,24 @@
+# stat-without-message (C183)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What does it do?
+This rule detects whether `stat` is used without also setting `errmsg` when
+allocating or deallocating. Similarly checks for the use of `iostat` without
+`iomsg` with IO routines, and `cmdstat` without `cmdmsg` when using
+`execute_command_line`.
+
+## Why is this bad?
+The error codes returned when using `stat`, `iostat`, or `cmdstat` are not
+very informative on their own, and are not portable across compilers. It is
+recommended to always capture the associated error message alongside the
+error code:
+
+```f90
+real, allocatable :: x(:)
+integer :: status
+character(256) :: message
+
+allocate (x(100), stat=status, errmsg=message)
+open (unit=10, file="data.txt", iostat=status, iomsg=message)
+call execute_command_line("ls", cmdstat=status, cmdmsg=message)
+```

--- a/docs/rules/stat-without-message.md
+++ b/docs/rules/stat-without-message.md
@@ -16,7 +16,7 @@ error code:
 ```f90
 real, allocatable :: x(:)
 integer :: status
-character(256) :: message
+character(256) :: message ! N.B. Can be allocatable in F2023+
 
 allocate (x(100), stat=status, errmsg=message)
 open (unit=10, file="data.txt", iostat=status, iomsg=message)

--- a/docs/rules/unchecked-stat.md
+++ b/docs/rules/unchecked-stat.md
@@ -4,13 +4,13 @@ This rule is unstable and in [preview](../preview.md). The `--preview` flag is r
 This rule is turned on by default.
 
 ## What does it do?
-This rule detects whether a `stat`, `iostat`, and `cmdstat` variable is checked
+This rule detects whether a `stat`, `iostat`, and `cmdstat` argument is checked
 within the same scope it is set.
 
 ## Why is this bad?
-By default, `allocate` statements will crash the program if the allocation
+By default, `allocate` statements will abort the program if the allocation
 fails. This is often the desired behaviour, but to provide for cases in
-which the user wants to handle allocation errors gracefully, they may
+which the developer wants to handle allocation errors gracefully, they may
 optionally check the status of an `allocate` statement by passing a variable
 to the `stat` argument:
 

--- a/fortitude/resources/test/fixtures/correctness/C182.f90
+++ b/fortitude/resources/test/fixtures/correctness/C182.f90
@@ -1,0 +1,20 @@
+program p
+  implicit none
+  real(8), allocatable :: x(:), y(:)
+  integer :: status
+
+  ! no stat params
+  allocate (x(10), y(10))
+  deallocate (x, y)
+
+  ! stat params, but one each
+  allocate (x(10), stat=status)
+  allocate (y(10), stat=status)
+  deallocate (x, stat=status)
+  deallocate (y, stat=status)
+
+  ! stat params, combined in one statement
+  allocate (x(10), y(10), stat=status)
+  deallocate (x, y, stat=status)
+
+end program p

--- a/fortitude/resources/test/fixtures/correctness/C183.f90
+++ b/fortitude/resources/test/fixtures/correctness/C183.f90
@@ -1,0 +1,49 @@
+program p
+  implicit none
+  real(8), allocatable :: x(:)
+  integer :: status
+  character(256) :: message
+  logical :: file_exist
+
+  ! no stat params
+  allocate (x(10))
+  deallocate (x)
+  open (10, file="test.txt")
+  write (10,*) "Allocation and deallocation without stat parameters completed successfully."
+  inquire(unit=10, exist=file_exist)
+  wait (10)
+  flush(10)
+  close (10)
+  call execute_command_line("ls")
+
+  ! stat params, no message
+  allocate (x(10), Stat=status)
+  deallocate (x, &
+    stat=STATUS)
+  open (10, file="test.txt", iostat=status)
+  write (10,*,iosTAT=Status) "Allocation and deallocation without stat parameters completed successfully."
+  inquire(unit=10, &
+    iostat=status, exist=file_exist)
+  wait (10, iostat=status)
+  flush(10, IOSTAT=&
+    STATUS)
+  close (10, Iostat=Status)
+  call execute_command_line("ls", cmdstat=Status)
+
+  ! stat params, with message
+  allocate (x(10), Stat=status, errmsg=message)
+  deallocate (x, stat=STATUS, ERRMSG=Message)
+  open (10, file="test.txt", iostat=status, iomsg=message)
+  write (10,*, &
+    iosTAT=Status, &
+    IOMSG=&
+      MESSAGE) "Allocation and deallocation without stat parameters completed successfully."
+  inquire(unit=10, iostat=status, exist=file_exist, ioMsG=MesSaGe)
+  wait (10, iostat=status, iomsg=message)
+  flush(10, IOSTAT=STATUS, iomsg = Message)
+  close (10, Iostat=Status, ioMSG = &
+    Message)
+  call execute_command_line("ls", cmdstat=Status, &
+    cmdmsg=message)
+
+end program p

--- a/fortitude/src/rules/correctness/error_handling.rs
+++ b/fortitude/src/rules/correctness/error_handling.rs
@@ -348,10 +348,10 @@ impl AstRule for MultipleAllocationsWithStat {
         let stat_node = node.kwarg("stat", src)?;
 
         // Count allocations
-        let count = match node.kind() {
-            "allocate_statement" => count_allocations(node),
-            "deallocate_statement" => count_deallocations(node),
-            _ => return None,
+        let count = if node.kind() == "allocate_statement" {
+            count_allocations(node)
+        } else {
+            count_deallocations(node)
         };
         if count <= 1 {
             return None;

--- a/fortitude/src/rules/correctness/error_handling.rs
+++ b/fortitude/src/rules/correctness/error_handling.rs
@@ -54,6 +54,14 @@ impl StatType {
             _ => Err(anyhow!("Node does not have a stat type")),
         }
     }
+
+    fn errmsg(self) -> &'static str {
+        match self {
+            StatType::Stat => "errmsg",
+            StatType::IoStat => "iomsg",
+            StatType::CmdStat => "cmdmsg",
+        }
+    }
 }
 
 enum CheckStatus {
@@ -376,4 +384,73 @@ fn count_deallocations(node: &Node) -> usize {
     node.named_children(&mut node.walk())
         .filter(|c| c.kind() == "identifier")
         .count()
+}
+
+/// ## What does it do?
+/// This rule detects whether `stat` is used without also setting `errmsg` when
+/// allocating or deallocating. Similarly checks for the use of `iostat` without
+/// `iomsg` with IO routines, and `cmdstat` without `cmdmsg` when using
+/// `execute_command_line`.
+///
+/// ## Why is this bad?
+/// The error codes returned when using `stat`, `iostat`, or `cmdstat` are not
+/// very informative on their own, and are not portable across compilers. It is
+/// recommended to always capture the associated error message alongside the
+/// error code:
+///
+/// ```f90
+/// real, allocatable :: x(:)
+/// integer :: status
+/// character(256) :: message
+///
+/// allocate (x(100), stat=status, errmsg=message)
+/// open (unit=10, file="data.txt", iostat=status, iomsg=message)
+/// call execute_command_line("ls", cmdstat=status, cmdmsg=message)
+/// ```
+#[derive(ViolationMetadata)]
+pub(crate) struct StatWithoutMessage {
+    stat_type: StatType,
+}
+
+impl Violation for StatWithoutMessage {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let stat: &'static str = self.stat_type.into();
+        let errmsg = self.stat_type.errmsg();
+        format!("'{stat}' used without '{errmsg}'.")
+    }
+}
+
+impl AstRule for StatWithoutMessage {
+    fn check(_settings: &Settings, node: &Node, source: &SourceFile) -> Option<Vec<Diagnostic>> {
+        let src = source.source_text();
+
+        let stat_type = StatType::from_node(node, src).ok()?;
+        let stat_name: &'static str = stat_type.into();
+        let arg_list = if node.kind() == "subroutine_call" {
+            node.child_with_name("argument_list")?
+        } else {
+            *node
+        };
+        if let Some(kwarg) = arg_list.kwarg(stat_name, src) {
+            if !arg_list.kwarg_exists(stat_type.errmsg(), src) {
+                return some_vec!(Diagnostic::from_node(Self { stat_type }, &kwarg));
+            }
+        }
+        None
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec![
+            "allocate_statement",
+            "deallocate_statement",
+            "open_statement",
+            "close_statement",
+            "read_statement",
+            "write_statement",
+            "inquire_statement",
+            "file_position_statement",
+            "subroutine_call", // for execute_command_line
+        ]
+    }
 }

--- a/fortitude/src/rules/correctness/error_handling.rs
+++ b/fortitude/src/rules/correctness/error_handling.rs
@@ -401,7 +401,7 @@ fn count_deallocations(node: &Node) -> usize {
 /// ```f90
 /// real, allocatable :: x(:)
 /// integer :: status
-/// character(256) :: message
+/// character(256) :: message ! N.B. Can be allocatable in F2023+
 ///
 /// allocate (x(100), stat=status, errmsg=message)
 /// open (unit=10, file="data.txt", iostat=status, iomsg=message)

--- a/fortitude/src/rules/correctness/error_handling.rs
+++ b/fortitude/src/rules/correctness/error_handling.rs
@@ -63,13 +63,13 @@ enum CheckStatus {
 }
 
 /// ## What does it do?
-/// This rule detects whether a `stat`, `iostat`, and `cmdstat` variable is checked
+/// This rule detects whether a `stat`, `iostat`, and `cmdstat` argument is checked
 /// within the same scope it is set.
 ///
 /// ## Why is this bad?
-/// By default, `allocate` statements will crash the program if the allocation
+/// By default, `allocate` statements will abort the program if the allocation
 /// fails. This is often the desired behaviour, but to provide for cases in
-/// which the user wants to handle allocation errors gracefully, they may
+/// which the developer wants to handle allocation errors gracefully, they may
 /// optionally check the status of an `allocate` statement by passing a variable
 /// to the `stat` argument:
 ///
@@ -317,13 +317,13 @@ impl AllocationType {
 /// deallocations.
 ///
 /// ## Why is this bad?
-/// When allocating or deallocating multiple arrays at once, the use of a `stat`
+/// When allocating or deallocating multiple variables at once, the use of a `stat`
 /// parameter will permit the program to continue running even if one of the
 /// allocations or deallocations fails. However, it may not be clear which
 /// allocation or deallocation caused the error.
 ///
 /// To avoid confusion, it is recommended to use separate allocate or deallocate
-/// statements for each array and check the `stat` parameters individually.
+/// statements for each variable and check the `stat` parameters individually.
 #[derive(ViolationMetadata)]
 pub(crate) struct MultipleAllocationsWithStat {
     alloc_type: AllocationType,

--- a/fortitude/src/rules/correctness/error_handling.rs
+++ b/fortitude/src/rules/correctness/error_handling.rs
@@ -345,12 +345,7 @@ impl AstRule for MultipleAllocationsWithStat {
         let src = source.source_text();
 
         // Check this has a stat parameter
-        let stat_node = node.named_children(&mut node.walk()).find(|child| {
-            child.kind() == "keyword_argument"
-                && child.child_by_field_name("name").is_some_and(|n| {
-                    n.to_text(src).map(|s| s.to_lowercase()) == Some("stat".to_string())
-                })
-        })?;
+        let stat_node = node.kwarg("stat", src)?;
 
         // Count allocations
         let count = match node.kind() {

--- a/fortitude/src/rules/correctness/error_handling.rs
+++ b/fortitude/src/rules/correctness/error_handling.rs
@@ -297,3 +297,75 @@ fn new_branch(node: &Node) -> bool {
         "elseif_clause" | "else_clause" | "case_statement"
     )
 }
+
+enum AllocationType {
+    Allocate,
+    Deallocate,
+}
+impl AllocationType {
+    fn from_node(node: &Node) -> Result<Self> {
+        match node.kind() {
+            "allocate_statement" => Ok(AllocationType::Allocate),
+            "dellocate_statement" => Ok(AllocationType::Deallocate),
+            _ => Err(anyhow!("Node is not an allocation type")),
+        }
+    }
+}
+
+/// ## What does it do?
+/// This rule detects whether `stat` is used alongside multiple allocations or
+/// deallocations.
+///
+/// ## Why is this bad?
+/// When allocating or deallocating multiple arrays at once, the use of a `stat`
+/// parameter will permit the program to continue running even if one of the
+/// allocations or deallocations fails. However, it may not be clear which
+/// allocation or deallocation caused the error.
+///
+/// To avoid confusion, it is recommended to use separate allocate or deallocate
+/// statements for each array and check the `stat` parameters individually.
+#[derive(ViolationMetadata)]
+pub(crate) struct MultipleAllocationsWithStat {
+    alloc_type: AllocationType,
+}
+
+impl Violation for MultipleAllocationsWithStat {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let allocations = match self.alloc_type {
+            AllocationType::Allocate => "allocations",
+            AllocationType::Deallocate => "deallocations",
+        };
+        format!("'stat' parameter used with multiple {allocations}.")
+    }
+}
+
+impl AstRule for MultipleAllocationsWithStat {
+    fn check(_settings: &Settings, node: &Node, source: &SourceFile) -> Option<Vec<Diagnostic>> {
+        let src = source.source_text();
+
+        // Check this has a stat parameter
+        let stat_node = node.named_children(&mut node.walk()).find(|child| {
+            child.kind() == "keyword_argument"
+                && child.child_by_field_name("name").is_some_and(|n| {
+                    n.to_text(src).map(|s| s.to_lowercase()) == Some("stat".to_string())
+                })
+        })?;
+
+        // Count allocations
+        let count = node
+            .children_by_field_name("allocation", &mut node.walk())
+            .count();
+        if count <= 1 {
+            return None;
+        }
+
+        let alloc_type = AllocationType::from_node(node).ok()?;
+
+        some_vec!(Diagnostic::from_node(Self { alloc_type }, &stat_node))
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["allocate_statement", "deallocate_statement"]
+    }
+}

--- a/fortitude/src/rules/correctness/mod.rs
+++ b/fortitude/src/rules/correctness/mod.rs
@@ -67,6 +67,7 @@ mod tests {
     #[test_case(Rule::NonportableShortcircuitInquiry, Path::new("C161.f90"))]
     #[test_case(Rule::SplitEscapedQuote, Path::new("C171.f90"))]
     #[test_case(Rule::UncheckedStat, Path::new("C181.f90"))]
+    #[test_case(Rule::MultipleAllocationsWithStat, Path::new("C182.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/correctness/mod.rs
+++ b/fortitude/src/rules/correctness/mod.rs
@@ -68,6 +68,7 @@ mod tests {
     #[test_case(Rule::SplitEscapedQuote, Path::new("C171.f90"))]
     #[test_case(Rule::UncheckedStat, Path::new("C181.f90"))]
     #[test_case(Rule::MultipleAllocationsWithStat, Path::new("C182.f90"))]
+    #[test_case(Rule::StatWithoutMessage, Path::new("C183.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__multiple-allocations-with-stat_C182.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__multiple-allocations-with-stat_C182.f90.snap
@@ -1,0 +1,12 @@
+---
+source: fortitude/src/rules/correctness/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/correctness/C182.f90:17:27: C182 'stat' parameter used with multiple allocations.
+   |
+16 |   ! stat params, combined in one statement
+17 |   allocate (x(10), y(10), stat=status)
+   |                           ^^^^^^^^^^^ C182
+18 |   deallocate (x, y, stat=status)
+   |

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__multiple-allocations-with-stat_C182.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__multiple-allocations-with-stat_C182.f90.snap
@@ -10,3 +10,13 @@ snapshot_kind: text
    |                           ^^^^^^^^^^^ C182
 18 |   deallocate (x, y, stat=status)
    |
+
+./resources/test/fixtures/correctness/C182.f90:18:21: C182 'stat' parameter used with multiple deallocations.
+   |
+16 |   ! stat params, combined in one statement
+17 |   allocate (x(10), y(10), stat=status)
+18 |   deallocate (x, y, stat=status)
+   |                     ^^^^^^^^^^^ C182
+19 |
+20 | end program p
+   |

--- a/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__stat-without-message_C183.f90.snap
+++ b/fortitude/src/rules/correctness/snapshots/fortitude__rules__correctness__tests__stat-without-message_C183.f90.snap
@@ -1,0 +1,94 @@
+---
+source: fortitude/src/rules/correctness/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/correctness/C183.f90:20:20: C183 'stat' used without 'errmsg'.
+   |
+19 |   ! stat params, no message
+20 |   allocate (x(10), Stat=status)
+   |                    ^^^^^^^^^^^ C183
+21 |   deallocate (x, &
+22 |     stat=STATUS)
+   |
+
+./resources/test/fixtures/correctness/C183.f90:22:5: C183 'stat' used without 'errmsg'.
+   |
+20 |   allocate (x(10), Stat=status)
+21 |   deallocate (x, &
+22 |     stat=STATUS)
+   |     ^^^^^^^^^^^ C183
+23 |   open (10, file="test.txt", iostat=status)
+24 |   write (10,*,iosTAT=Status) "Allocation and deallocation without stat parameters completed successfully."
+   |
+
+./resources/test/fixtures/correctness/C183.f90:23:30: C183 'iostat' used without 'iomsg'.
+   |
+21 |   deallocate (x, &
+22 |     stat=STATUS)
+23 |   open (10, file="test.txt", iostat=status)
+   |                              ^^^^^^^^^^^^^ C183
+24 |   write (10,*,iosTAT=Status) "Allocation and deallocation without stat parameters completed successfully."
+25 |   inquire(unit=10, &
+   |
+
+./resources/test/fixtures/correctness/C183.f90:24:15: C183 'iostat' used without 'iomsg'.
+   |
+22 |     stat=STATUS)
+23 |   open (10, file="test.txt", iostat=status)
+24 |   write (10,*,iosTAT=Status) "Allocation and deallocation without stat parameters completed successfully."
+   |               ^^^^^^^^^^^^^ C183
+25 |   inquire(unit=10, &
+26 |     iostat=status, exist=file_exist)
+   |
+
+./resources/test/fixtures/correctness/C183.f90:26:5: C183 'iostat' used without 'iomsg'.
+   |
+24 |   write (10,*,iosTAT=Status) "Allocation and deallocation without stat parameters completed successfully."
+25 |   inquire(unit=10, &
+26 |     iostat=status, exist=file_exist)
+   |     ^^^^^^^^^^^^^ C183
+27 |   wait (10, iostat=status)
+28 |   flush(10, IOSTAT=&
+   |
+
+./resources/test/fixtures/correctness/C183.f90:27:13: C183 'iostat' used without 'iomsg'.
+   |
+25 |   inquire(unit=10, &
+26 |     iostat=status, exist=file_exist)
+27 |   wait (10, iostat=status)
+   |             ^^^^^^^^^^^^^ C183
+28 |   flush(10, IOSTAT=&
+29 |     STATUS)
+   |
+
+./resources/test/fixtures/correctness/C183.f90:28:13: C183 'iostat' used without 'iomsg'.
+   |
+26 |       iostat=status, exist=file_exist)
+27 |     wait (10, iostat=status)
+28 |     flush(10, IOSTAT=&
+   |  _____________^
+29 | |     STATUS)
+   | |__________^ C183
+30 |     close (10, Iostat=Status)
+31 |     call execute_command_line("ls", cmdstat=Status)
+   |
+
+./resources/test/fixtures/correctness/C183.f90:30:14: C183 'iostat' used without 'iomsg'.
+   |
+28 |   flush(10, IOSTAT=&
+29 |     STATUS)
+30 |   close (10, Iostat=Status)
+   |              ^^^^^^^^^^^^^ C183
+31 |   call execute_command_line("ls", cmdstat=Status)
+   |
+
+./resources/test/fixtures/correctness/C183.f90:31:35: C183 'cmdstat' used without 'cmdmsg'.
+   |
+29 |     STATUS)
+30 |   close (10, Iostat=Status)
+31 |   call execute_command_line("ls", cmdstat=Status)
+   |                                   ^^^^^^^^^^^^^^ C183
+32 |
+33 |   ! stat params, with message
+   |

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -107,6 +107,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Correctness, "161") => (RuleGroup::Preview, Ast, Default, correctness::nonportable_shortcircuit_inquiry::NonportableShortcircuitInquiry),
         (Correctness, "171") => (RuleGroup::Preview, Text, Optional, correctness::split_escaped_quote::SplitEscapedQuote),
         (Correctness, "181") => (RuleGroup::Preview, Ast, Default, correctness::error_handling::UncheckedStat),
+        (Correctness, "182") => (RuleGroup::Preview, Ast, Default, correctness::error_handling::MultipleAllocationsWithStat),
 
         // modernisation
         (Modernisation, "001") => (RuleGroup::Stable, Ast, Optional, modernisation::double_precision::DoublePrecision),

--- a/fortitude/src/rules/mod.rs
+++ b/fortitude/src/rules/mod.rs
@@ -108,6 +108,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Correctness, "171") => (RuleGroup::Preview, Text, Optional, correctness::split_escaped_quote::SplitEscapedQuote),
         (Correctness, "181") => (RuleGroup::Preview, Ast, Default, correctness::error_handling::UncheckedStat),
         (Correctness, "182") => (RuleGroup::Preview, Ast, Default, correctness::error_handling::MultipleAllocationsWithStat),
+        (Correctness, "183") => (RuleGroup::Preview, Ast, Optional, correctness::error_handling::StatWithoutMessage),
 
         // modernisation
         (Modernisation, "001") => (RuleGroup::Stable, Ast, Optional, modernisation::double_precision::DoublePrecision),


### PR DESCRIPTION
Builds on https://github.com/PlasmaFAIR/fortitude/pull/466

Ensures that an error message is always captured alongside `stat`.