### PR TITLE
Add rule `maths-missing-parentheses`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-fortran"
 version = "0.5.1"
-source = "git+https://github.com/stadelmanma/tree-sitter-fortran.git?rev=1b08f4c#1b08f4c65fb47c76d3532cd3f7432d03abb9ef69"
+source = "git+https://github.com/stadelmanma/tree-sitter-fortran.git?rev=9acc874#9acc8741cdfdfe247eb647850720343f9911a40e"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ textwrap = { version = "0.16.0" }
 thiserror = { version = "1.0.58" }
 tree-sitter = "~0.25.0"
 tree-sitter-cli = "~0.25.0"
-tree-sitter-fortran = { git = "https://github.com/stadelmanma/tree-sitter-fortran.git", rev = "1b08f4c" }
+tree-sitter-fortran = { git = "https://github.com/stadelmanma/tree-sitter-fortran.git", rev = "9acc874" }
 toml = "0.8.19"
 unicode-width = "0.2.0"
 url = { version = "2.5.0" }

--- a/crates/fortitude_linter/resources/test/fixtures/style/S251.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S251.f90
@@ -1,0 +1,13 @@
+program test
+  implicit none (type, external)
+  print*, 1. + 2. * 3. - 4. / 5.;
+  print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+  print*, 1. * 2. / 3. * 4.;
+  print*, -1.**2
+
+  ! These are all fine
+  print*, 1. + (2. * 3.) - (4. / 5.);
+  print*, (1. * 2.) / (3. * 4.);
+  print*, (-1.)**2
+
+end program test

--- a/crates/fortitude_linter/src/rules/mod.rs
+++ b/crates/fortitude_linter/src/rules/mod.rs
@@ -144,6 +144,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Style, "232") => (RuleGroup::Preview, Ast, Default, style::keywords::KeywordHasWhitespace),
         (Style, "241") => (RuleGroup::Preview, Ast, Default, style::strings::BadQuoteString),
         (Style, "242") => (RuleGroup::Preview, Ast, Optional, style::strings::AvoidableEscapedQuote),
+        (Style, "251") => (RuleGroup::Preview, Ast, Optional, style::maths_missing_parentheses::MathsMissingParentheses),
 
         // obsolescent
         (Obsolescent, "001") => (RuleGroup::Removed, Ast, Default, obsolescent::statement_functions::StatementFunction),

--- a/crates/fortitude_linter/src/rules/style/maths_missing_parentheses.rs
+++ b/crates/fortitude_linter/src/rules/style/maths_missing_parentheses.rs
@@ -1,0 +1,136 @@
+use crate::ast::FortitudeNode;
+use crate::settings::Settings;
+use crate::{AstRule, FromAstNode};
+use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_source_file::SourceFile;
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks if mathematical expressions are missing parentheses when operators have
+/// different precedences.
+///
+/// ## Why is this bad?
+/// Long or complex expressions can be difficult or confusing to read, especially when
+/// mixing operators with different precedences. Adding parentheses can clarify the code
+/// and make the author's intent clearer, reducing the likelihood of misunderstandings
+/// or bugs.
+///
+/// ## Example
+/// ```f90
+/// x = 1. + 2. * 3. - 4. / 5.
+/// ```
+///
+/// Use instead:
+/// ```f90
+/// x = 1. + (2. * 3.) - (4. / 5.)
+/// ```
+#[derive(ViolationMetadata)]
+pub(crate) struct MathsMissingParentheses {
+    op1: String,
+    op2: String,
+}
+
+impl AlwaysFixableViolation for MathsMissingParentheses {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self { op1, op2 } = &self;
+        format!("'{op1}' has higher precedence than '{op2}'; add parentheses for clarity")
+    }
+
+    fn fix_title(&self) -> String {
+        "Add parentheses".to_string()
+    }
+}
+
+#[derive(PartialEq)]
+enum Operator {
+    Exponential,
+    Multiplication,
+    Division,
+    Addition,
+    Subtraction,
+}
+
+impl Operator {
+    fn precedence(&self) -> u8 {
+        use Operator::*;
+        match self {
+            Exponential => 4,
+            Multiplication | Division => 3,
+            Addition | Subtraction => 2,
+        }
+    }
+}
+
+impl TryFrom<&str> for Operator {
+    type Error = &'static str;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        use Operator::*;
+        match value {
+            "**" => Ok(Exponential),
+            "*" => Ok(Multiplication),
+            "/" => Ok(Division),
+            "-" => Ok(Addition),
+            "+" => Ok(Subtraction),
+            _ => Err("not a maths operator"),
+        }
+    }
+}
+
+impl From<Operator> for String {
+    fn from(value: Operator) -> String {
+        use Operator::*;
+        match value {
+            Exponential => "**",
+            Multiplication => "*",
+            Division => "/",
+            Addition => "-",
+            Subtraction => "+",
+        }
+        .to_string()
+    }
+}
+
+impl AstRule for MathsMissingParentheses {
+    fn check<'a>(
+        _settings: &Settings,
+        node: &'a Node,
+        src: &'a SourceFile,
+    ) -> Option<Vec<Diagnostic>> {
+        let text = src.source_text();
+        let op: Operator = node.child(1)?.to_text(text)?.try_into().ok()?;
+
+        let parent = node.parent()?;
+        if !matches!(parent.kind(), "math_expression" | "unary_expression") {
+            return None;
+        }
+
+        let edit = node.edit_replacement(src, format!("({})", node.to_text(text)?));
+        let fix = Fix::safe_edit(edit);
+        if op == Operator::Exponential && parent.kind() == "unary_expression" {
+            let op2 = parent.child(0)?.to_text(text)?.to_string();
+            let op1: String = op.into();
+            return some_vec!(Diagnostic::from_node(Self { op1, op2 }, node).with_fix(fix));
+        }
+
+        let parent_op: Operator = parent.child(1)?.to_text(text)?.try_into().ok()?;
+
+        if op.precedence() == parent_op.precedence() {
+            return None;
+        }
+
+        let (op1, op2): (String, String) = if op.precedence() > parent_op.precedence() {
+            (op.into(), parent_op.into())
+        } else {
+            (parent_op.into(), op.into())
+        };
+
+        some_vec!(Diagnostic::from_node(Self { op1, op2 }, node).with_fix(fix))
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["math_expression"]
+    }
+}

--- a/crates/fortitude_linter/src/rules/style/mod.rs
+++ b/crates/fortitude_linter/src/rules/style/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod functions;
 pub(crate) mod implicit_none;
 pub mod keywords;
 pub(crate) mod line_length;
+pub(crate) mod maths_missing_parentheses;
 pub(crate) mod semicolons;
 pub mod strings;
 pub(crate) mod whitespace;
@@ -44,6 +45,7 @@ mod tests {
     #[test_case(Rule::KeywordHasWhitespace, Path::new("S231.f90"))]
     #[test_case(Rule::BadQuoteString, Path::new("S241.f90"))]
     #[test_case(Rule::AvoidableEscapedQuote, Path::new("S242.f90"))]
+    #[test_case(Rule::MathsMissingParentheses, Path::new("S251.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__maths-missing-parentheses_S251.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__maths-missing-parentheses_S251.f90.snap
@@ -1,0 +1,128 @@
+---
+source: crates/fortitude_linter/src/rules/style/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/style/S251.f90:3:16: S251 [*] '*' has higher precedence than '+'; add parentheses for clarity
+  |
+1 | program test
+2 |   implicit none (type, external)
+3 |   print*, 1. + 2. * 3. - 4. / 5.;
+  |                ^^^^^^^ S251
+4 |   print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+5 |   print*, 1. * 2. / 3. * 4.;
+  |
+  = help: Add parentheses
+
+ℹ Safe fix
+1 1 | program test
+2 2 |   implicit none (type, external)
+3   |-  print*, 1. + 2. * 3. - 4. / 5.;
+  3 |+  print*, 1. + (2. * 3.) - 4. / 5.;
+4 4 |   print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+5 5 |   print*, 1. * 2. / 3. * 4.;
+6 6 |   print*, -1.**2
+
+./resources/test/fixtures/style/S251.f90:3:26: S251 [*] '/' has higher precedence than '-'; add parentheses for clarity
+  |
+1 | program test
+2 |   implicit none (type, external)
+3 |   print*, 1. + 2. * 3. - 4. / 5.;
+  |                          ^^^^^^^ S251
+4 |   print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+5 |   print*, 1. * 2. / 3. * 4.;
+  |
+  = help: Add parentheses
+
+ℹ Safe fix
+1 1 | program test
+2 2 |   implicit none (type, external)
+3   |-  print*, 1. + 2. * 3. - 4. / 5.;
+  3 |+  print*, 1. + 2. * 3. - (4. / 5.);
+4 4 |   print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+5 5 |   print*, 1. * 2. / 3. * 4.;
+6 6 |   print*, -1.**2
+
+./resources/test/fixtures/style/S251.f90:4:30: S251 [*] '*' has higher precedence than '+'; add parentheses for clarity
+  |
+2 |   implicit none (type, external)
+3 |   print*, 1. + 2. * 3. - 4. / 5.;
+4 |   print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ S251
+5 |   print*, 1. * 2. / 3. * 4.;
+6 |   print*, -1.**2
+  |
+  = help: Add parentheses
+
+ℹ Safe fix
+1 1 | program test
+2 2 |   implicit none (type, external)
+3 3 |   print*, 1. + 2. * 3. - 4. / 5.;
+4   |-  print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+  4 |+  print*, 1.*(cos(2.) - 3. + ((4.*5.-6.*sin(7.))*sin(8.)))
+5 5 |   print*, 1. * 2. / 3. * 4.;
+6 6 |   print*, -1.**2
+7 7 | 
+
+./resources/test/fixtures/style/S251.f90:4:31: S251 [*] '*' has higher precedence than '-'; add parentheses for clarity
+  |
+2 |   implicit none (type, external)
+3 |   print*, 1. + 2. * 3. - 4. / 5.;
+4 |   print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+  |                               ^^^^^ S251
+5 |   print*, 1. * 2. / 3. * 4.;
+6 |   print*, -1.**2
+  |
+  = help: Add parentheses
+
+ℹ Safe fix
+1 1 | program test
+2 2 |   implicit none (type, external)
+3 3 |   print*, 1. + 2. * 3. - 4. / 5.;
+4   |-  print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+  4 |+  print*, 1.*(cos(2.) - 3. + ((4.*5.)-6.*sin(7.))*sin(8.))
+5 5 |   print*, 1. * 2. / 3. * 4.;
+6 6 |   print*, -1.**2
+7 7 | 
+
+./resources/test/fixtures/style/S251.f90:4:37: S251 [*] '*' has higher precedence than '-'; add parentheses for clarity
+  |
+2 |   implicit none (type, external)
+3 |   print*, 1. + 2. * 3. - 4. / 5.;
+4 |   print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+  |                                     ^^^^^^^^^^ S251
+5 |   print*, 1. * 2. / 3. * 4.;
+6 |   print*, -1.**2
+  |
+  = help: Add parentheses
+
+ℹ Safe fix
+1 1 | program test
+2 2 |   implicit none (type, external)
+3 3 |   print*, 1. + 2. * 3. - 4. / 5.;
+4   |-  print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+  4 |+  print*, 1.*(cos(2.) - 3. + (4.*5.-(6.*sin(7.)))*sin(8.))
+5 5 |   print*, 1. * 2. / 3. * 4.;
+6 6 |   print*, -1.**2
+7 7 | 
+
+./resources/test/fixtures/style/S251.f90:6:12: S251 [*] '**' has higher precedence than '-'; add parentheses for clarity
+  |
+4 |   print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+5 |   print*, 1. * 2. / 3. * 4.;
+6 |   print*, -1.**2
+  |            ^^^^^ S251
+7 |
+8 |   ! These are all fine
+  |
+  = help: Add parentheses
+
+ℹ Safe fix
+3 3 |   print*, 1. + 2. * 3. - 4. / 5.;
+4 4 |   print*, 1.*(cos(2.) - 3. + (4.*5.-6.*sin(7.))*sin(8.))
+5 5 |   print*, 1. * 2. / 3. * 4.;
+6   |-  print*, -1.**2
+  6 |+  print*, -(1.**2)
+7 7 | 
+8 8 |   ! These are all fine
+9 9 |   print*, 1. + (2. * 3.) - (4. / 5.);

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -90,6 +90,7 @@
 | S232 | [keyword-has-whitespace](rules/keyword-has-whitespace.md) | Whitespace included in '{keywords}' | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | S241 | [bad-quote-string](rules/bad-quote-string.md) | String uses single quotes but double quotes preferred | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | S242 | [avoidable-escaped-quote](rules/avoidable-escaped-quote.md) | Avoidable escaped quotes | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
+| S251 | [maths-missing-parentheses](rules/maths-missing-parentheses.md) | '{op1}' has higher precedence than '{op2}'; add parentheses for clarity | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 
 ### Portability (PORT)
 

--- a/docs/rules/maths-missing-parentheses.md
+++ b/docs/rules/maths-missing-parentheses.md
@@ -1,0 +1,24 @@
+# maths-missing-parentheses (S251)
+Fix is always available.
+
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks if mathematical expressions are missing parentheses when operators have
+different precedences.
+
+## Why is this bad?
+Long or complex expressions can be difficult or confusing to read, especially when
+mixing operators with different precedences. Adding parentheses can clarify the code
+and make the author's intent clearer, reducing the likelihood of misunderstandings
+or bugs.
+
+## Example
+```f90
+x = 1. + 2. * 3. - 4. / 5.
+```
+
+Use instead:
+```f90
+x = 1. + (2. * 3.) - (4. / 5.)
+```


### PR DESCRIPTION
Closes #469 

Needs a bump to `tree-sitter-fortran` because `unary_expression` had the wrong precedence.

This doesn't catch `1. * 2. / 3. * 4.` because `*` and `/` have the same precedence (and so can be simply read left-to-right), but I do think this sort of construction is a little confusing. Any suggestions on what would be sensible to flag here (presumably with a different message too)? 

Maybe just `*` with a parent of `/`? So:

```f90
1 / 2 * 3  ! warn
1 * 2 / 3  ! ok
```