### PR TITLE
docs: add search plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,4 +60,5 @@ not_in_nav: |
   /rules/*
 
 plugins:
+  - search
   - include-markdown


### PR DESCRIPTION
Fixes #474 

To quote from the `mkdocs` [documentation](https://www.mkdocs.org/user-guide/configuration/#plugins)

> If the plugins config setting is defined in the mkdocs.yml config file, then any defaults (such as search) are ignored and you need to explicitly re-enable the defaults if you would like to continue using them