### PR TITLE
CI: Attempt to simplify build-binaries by merging arch workflows

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -249,7 +249,6 @@ jobs:
           install: |
             apt-get update
             apt-get install -y --no-install-recommends python3 python3-pip
-            pip3 install --break-system-packages -U pip
           run: |
             pip3 install --break-system-packages ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             fortitude --help


### PR DESCRIPTION
Experiment to see if we can both simplify the CI a little and also switch to `manylinux_2_28`