### PR TITLE
Bump `tree-sitter-fortran` (fix `fmt` argument to IO statements)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ textwrap = { version = "0.16.0" }
 thiserror = { version = "1.0.58" }
 tree-sitter = "~0.25.0"
 tree-sitter-cli = "~0.25.0"
-tree-sitter-fortran = { git = "https://github.com/stadelmanma/tree-sitter-fortran.git", rev = "8334abc" }
+tree-sitter-fortran = { git = "https://github.com/stadelmanma/tree-sitter-fortran.git", rev = "a83bbe5" }
 toml = "0.8.19"
 unicode-width = "0.2.0"
 url = { version = "2.5.0" }


### PR DESCRIPTION
Closes #490