### PR TITLE
Prepare for v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.5
+
+### Bug fixes
+
+- Fix `fmt` argument in IO statements ([#491](https://github.com/PlasmaFAIR/fortitude/pull/491))
+
 ## 0.7.4
 
 ### Rule changes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,6 @@ authors:
   given-names: Peter
   orcid: "https://orcid.org/0000-0003-3092-1858"
 title: "fortitude"
-version: 0.7.4
-date-released: 2025-08-14
+version: 0.7.5
+date-released: 2025-08-18
 url: "https://github.com/PlasmaFAIR/fortitude"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "fortitude"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2081,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-fortran"
 version = "0.5.1"
-source = "git+https://github.com/stadelmanma/tree-sitter-fortran.git?rev=8334abc#8334abca785db3a041292e3b3b818a82a55b238f"
+source = "git+https://github.com/stadelmanma/tree-sitter-fortran.git?rev=a83bbe5#a83bbe5d652ccfad187d722852d3b87d44be1c17"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/fortitude/Cargo.toml
+++ b/crates/fortitude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortitude"
-version = "0.7.4"
+version = "0.7.5"
 publish = true
 description = "A Fortran linter, written in Rust and installable with Python"
 edition = { workspace = true }

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -9,7 +9,7 @@ Fortitude can be used as a [pre-commit](https://pre-commit.com/) hook via
 repos:
 - repo: https://github.com/PlasmaFAIR/fortitude-pre-commit
   # Fortitude version.
-  rev: v0.7.4
+  rev: v0.7.5
   hooks:
     - id: fortitude
 ```
@@ -20,7 +20,7 @@ To enable fixes, add the [`--fix`](settings.md#fix) argument:
 repos:
 - repo: https://github.com/PlasmaFAIR/fortitude-pre-commit
   # Fortitude version.
-  rev: v0.7.4
+  rev: v0.7.5
   hooks:
     - id: fortitude
       args: ["--fix"]
@@ -32,7 +32,7 @@ Other additional arguments are also accepted:
 repos:
 - repo: https://github.com/PlasmaFAIR/fortitude-pre-commit
   # Fortitude version.
-  rev: v0.7.4
+  rev: v0.7.5
   hooks:
     - id: fortitude
       args: ["--fix", "--preview", "--unsafe-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "fortitude-lint"
-version = "0.7.4"
+version = "0.7.5"
 description = "A Fortran linter, written in Rust and installable with Python"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
I was getting `502: Bad gateway` when trying to run `scripts/release.sh`, so I've tried to set this up manually. 