### PR TITLE
Enable fat LTO for dist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,4 +73,5 @@ similar.opt-level = 3
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
Here, I have enabled fat LTO for dist builds

There is some comparison on my a quite old laptop:

| Build type | Compilation time | Binary size (in bytes) |
| :---: | :---: | ---: |
| Release | 1m30s | 14114056 |
| dist (current) | 1m55s | 14125272 |
| dist (updated) | 2m05s | 12091748 |

I've run all compiled fortitudes on xtb codebase and there is almost no difference on check time. It takes about 1.2 s. So, the main benefit here is only binary size without any significant increasing of compilation time. 