### PR TITLE
Small refactor for updated `do` loop grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-fortran"
 version = "0.5.1"
-source = "git+https://github.com/stadelmanma/tree-sitter-fortran.git?rev=a83bbe5#a83bbe5d652ccfad187d722852d3b87d44be1c17"
+source = "git+https://github.com/stadelmanma/tree-sitter-fortran.git?rev=95b728f#95b728f5aaddf5e1b3822a1d307cf386b492de20"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ textwrap = { version = "0.16.0" }
 thiserror = { version = "1.0.58" }
 tree-sitter = "~0.25.0"
 tree-sitter-cli = "~0.25.0"
-tree-sitter-fortran = { git = "https://github.com/stadelmanma/tree-sitter-fortran.git", rev = "a83bbe5" }
+tree-sitter-fortran = { git = "https://github.com/stadelmanma/tree-sitter-fortran.git", rev = "95b728f" }
 toml = "0.8.19"
 unicode-width = "0.2.0"
 url = { version = "2.5.0" }

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-end-label_C143.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-end-label_C143.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/correctness/mod.rs
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -43,7 +43,7 @@ snapshot_kind: text
 17 17 |   form team(1, parent)
 18 18 |   label4: change team(parent)
 
-./resources/test/fixtures/correctness/C143.f90:19:3: C143 [*] 'end team' statement in named 'change' block missing label
+./resources/test/fixtures/correctness/C143.f90:19:3: C143 [*] 'end team' statement in named 'change team' block missing label
    |
 17 |   form team(1, parent)
 18 |   label4: change team(parent)
@@ -124,7 +124,7 @@ snapshot_kind: text
 30 30 |   label8: select case(i)
 31 31 |   end select
 
-./resources/test/fixtures/correctness/C143.f90:31:3: C143 [*] 'end select' statement in named 'select' block missing label
+./resources/test/fixtures/correctness/C143.f90:31:3: C143 [*] 'end select' statement in named 'select case' block missing label
    |
 30 |   label8: select case(i)
 31 |   end select
@@ -144,7 +144,7 @@ snapshot_kind: text
 33 33 |   label9: select rank(i)
 34 34 |   end select
 
-./resources/test/fixtures/correctness/C143.f90:34:3: C143 [*] 'end select' statement in named 'select' block missing label
+./resources/test/fixtures/correctness/C143.f90:34:3: C143 [*] 'end select' statement in named 'select rank' block missing label
    |
 33 |   label9: select rank(i)
 34 |   end select
@@ -164,7 +164,7 @@ snapshot_kind: text
 36 36 |   label10: select type(i)
 37 37 |   end select
 
-./resources/test/fixtures/correctness/C143.f90:37:3: C143 [*] 'end select' statement in named 'select' block missing label
+./resources/test/fixtures/correctness/C143.f90:37:3: C143 [*] 'end select' statement in named 'select type' block missing label
    |
 36 |   label10: select type(i)
 37 |   end select


### PR DESCRIPTION
The current grammar struggled to deal with the two forms of `do` loops:

```f90
do
  ! ...
end do

do i = 1, 10
  ! ...
end do
```

This is particularly annoying for the format command where we want a newline at
the end of the statement, which isn't possible to capture with the query
language.

This update to the grammar adds a new node, `do_statement`, for the opening `do`
statement, and renames the block node to `do_loop`. This requires some small
refactoring to a couple of rules.

One side effect is being able to remove some allocations, which is nice.

(This is going into the `format-command` branch too, but I want to keep the two
branches from diverging too far)