### PR TITLE
Bump Rust Edition and MSRV

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformat with newer MSRV
+911b108

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ default-members = ["crates/fortitude"]
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
-rust-version = "1.80"
+edition = "2024"
+rust-version = "1.87"
 homepage = "https://fortitude.readthedocs.io/"
 documentation = "https://fortitude.readthedocs.io/"
 repository = "https://github.com/PlasmaFAIR/fortitude"

--- a/crates/fortitude/src/check.rs
+++ b/crates/fortitude/src/check.rs
@@ -418,11 +418,7 @@ fn check_stdin(
     let source_file = SourceFileBuilder::new(path.to_str().unwrap_or("-"), stdin.as_str()).finish();
 
     let (mut messages, fixed) = if matches!(fix_mode, FixMode::Apply | FixMode::Diff) {
-        if let Ok(FixerResult {
-            result,
-            transformed,
-            fixed,
-        }) = check_and_fix_file(
+        match check_and_fix_file(
             rules,
             path_rules,
             text_rules,
@@ -431,7 +427,11 @@ fn check_stdin(
             &source_file,
             settings,
             ignore_allow_comments,
-        ) {
+        ) { Ok(FixerResult {
+            result,
+            transformed,
+            fixed,
+        }) => {
             match fix_mode {
                 FixMode::Apply => {
                     // Write the contents to stdout, regardless of whether any errors were fixed.
@@ -446,7 +446,7 @@ fn check_stdin(
             }
 
             (result, fixed)
-        } else {
+        } _ => {
             // Failed to fix, so just lint the original source
             let result = check_only_file(
                 rules,
@@ -470,7 +470,7 @@ fn check_stdin(
 
             let fixed = FxHashMap::default();
             (result, fixed)
-        }
+        }}
     } else {
         let result = check_only_file(
             rules,

--- a/crates/fortitude/src/cli.rs
+++ b/crates/fortitude/src/cli.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use fortitude_linter::{
     fs::FilePattern,
     logging::LogLevel,
-    rule_selector::{clap_completion::RuleSelectorParser, collect_per_file_ignores, RuleSelector},
+    rule_selector::{RuleSelector, clap_completion::RuleSelectorParser, collect_per_file_ignores},
     settings::{
         IgnoreAllowComments, OutputFormat, PatternPrefixPair, PreviewMode, ProgressBar, UnsafeFixes,
     },

--- a/crates/fortitude/src/main.rs
+++ b/crates/fortitude/src/main.rs
@@ -1,4 +1,4 @@
-use std::io::{stdout, Write};
+use std::io::{Write, stdout};
 use std::process::ExitCode;
 
 use anyhow::Result;

--- a/crates/fortitude/src/main.rs
+++ b/crates/fortitude/src/main.rs
@@ -34,10 +34,10 @@ fn main() -> Result<ExitCode> {
                 //
                 // See: https://github.com/BurntSushi/ripgrep/blob/bf63fe8f258afc09bae6caa48f0ae35eaf115005/crates/core/main.rs#L47C1-L61C14
                 for cause in err.chain() {
-                    if let Some(ioerr) = cause.downcast_ref::<std::io::Error>() {
-                        if ioerr.kind() == std::io::ErrorKind::BrokenPipe {
-                            return Ok(ExitCode::from(0));
-                        }
+                    if let Some(ioerr) = cause.downcast_ref::<std::io::Error>()
+                        && ioerr.kind() == std::io::ErrorKind::BrokenPipe
+                    {
+                        return Ok(ExitCode::from(0));
                     }
                 }
 

--- a/crates/fortitude/src/printer.rs
+++ b/crates/fortitude/src/printer.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use anyhow::Result;
 use bitflags::bitflags;
 use colored::Colorize;
-use itertools::{iterate, Itertools};
+use itertools::{Itertools, iterate};
 use serde::Serialize;
 
 use crate::check::CheckResults;
@@ -165,7 +165,10 @@ impl Printer {
                 format!("For more information about specific rules, run:\n\n    {explain}\n");
 
             if fixed > 0 {
-                writeln!(writer, "Number of errors: {total_txt} ({fixed_txt} fixed, {remaining_txt} remaining)\n\n{info}")?;
+                writeln!(
+                    writer,
+                    "Number of errors: {total_txt} ({fixed_txt} fixed, {remaining_txt} remaining)\n\n{info}"
+                )?;
             } else if remaining > 0 {
                 writeln!(writer, "Number of errors: {remaining_txt}\n\n{info}")?;
             } else {
@@ -183,10 +186,11 @@ impl Printer {
                         } else {
                             "es"
                         };
-                        writeln!(writer,
-                                    "{fix_prefix} {} fixable with the `--fix` option ({} hidden fix{es} can be enabled with the `--unsafe-fixes` option).",
-                                    fixables.applicable, fixables.inapplicable_unsafe
-                                )?;
+                        writeln!(
+                            writer,
+                            "{fix_prefix} {} fixable with the `--fix` option ({} hidden fix{es} can be enabled with the `--unsafe-fixes` option).",
+                            fixables.applicable, fixables.inapplicable_unsafe
+                        )?;
                     } else if fixables.applicable > 0 {
                         // Only applicable fixes
                         writeln!(
@@ -201,10 +205,11 @@ impl Printer {
                         } else {
                             "es"
                         };
-                        writeln!(writer,
-                                    "No fixes available ({} hidden fix{es} can be enabled with the `--unsafe-fixes` option).",
-                                    fixables.inapplicable_unsafe
-                                )?;
+                        writeln!(
+                            writer,
+                            "No fixes available ({} hidden fix{es} can be enabled with the `--unsafe-fixes` option).",
+                            fixables.inapplicable_unsafe
+                        )?;
                     }
                 } else if fixables.applicable > 0 {
                     writeln!(
@@ -230,9 +235,15 @@ impl Printer {
                 if fixed > 0 {
                     let s = if fixed == 1 { "" } else { "s" };
                     if self.fix_mode.is_apply() {
-                        writeln!(writer, "Fixed {fixed} error{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`).")?;
+                        writeln!(
+                            writer,
+                            "Fixed {fixed} error{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`)."
+                        )?;
                     } else {
-                        writeln!(writer, "Would fix {fixed} error{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`).")?;
+                        writeln!(
+                            writer,
+                            "Would fix {fixed} error{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`)."
+                        )?;
                     }
                 } else if self.fix_mode.is_apply() {
                     writeln!(
@@ -240,7 +251,10 @@ impl Printer {
                         "No errors fixed ({unapplied} fix{es} available with `--unsafe-fixes`)."
                     )?;
                 } else {
-                    writeln!(writer, "No errors would be fixed ({unapplied} fix{es} available with `--unsafe-fixes`).")?;
+                    writeln!(
+                        writer,
+                        "No errors would be fixed ({unapplied} fix{es} available with `--unsafe-fixes`)."
+                    )?;
                 }
             } else if fixed > 0 {
                 let s = if fixed == 1 { "" } else { "s" };

--- a/crates/fortitude/src/printer.rs
+++ b/crates/fortitude/src/printer.rs
@@ -359,11 +359,11 @@ impl Printer {
             .fold(
                 vec![],
                 |mut acc: Vec<(&DiagnosticMessage, usize)>, message| {
-                    if let Some((prev_message, count)) = acc.last_mut() {
-                        if prev_message.rule() == message.rule() {
-                            *count += 1;
-                            return acc;
-                        }
+                    if let Some((prev_message, count)) = acc.last_mut()
+                        && prev_message.rule() == message.rule()
+                    {
+                        *count += 1;
+                        return acc;
                     }
                     acc.push((message, 1));
                     acc

--- a/crates/fortitude/src/version.rs
+++ b/crates/fortitude/src/version.rs
@@ -70,7 +70,7 @@ impl fmt::Display for VersionInfo {
 pub(crate) fn version() -> VersionInfo {
     // Environment variables are only read at compile-time
     macro_rules! option_env_str {
-        ($name:expr) => {
+        ($name:expr_2021) => {
             option_env!($name).map(|s| s.to_string())
         };
     }

--- a/crates/fortitude_dev/src/generate_cli_help.rs
+++ b/crates/fortitude_dev/src/generate_cli_help.rs
@@ -4,13 +4,13 @@
 use std::path::PathBuf;
 use std::{fs, str};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::CommandFactory;
 use fortitude::cli;
 use pretty_assertions::StrComparison;
 
-use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
 use crate::ROOT_DIR;
+use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
 
 const COMMAND_HELP_BEGIN_PRAGMA: &str = "<!-- Begin auto-generated command help. -->\n";
 const COMMAND_HELP_END_PRAGMA: &str = "<!-- End auto-generated command help. -->";

--- a/crates/fortitude_dev/src/generate_docs.rs
+++ b/crates/fortitude_dev/src/generate_docs.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use pretty_assertions::StrComparison;
 use regex::{Captures, Regex};
 use strum::IntoEnumIterator;
@@ -23,8 +23,9 @@ use fortitude_workspace::{
 };
 
 use crate::{
+    ROOT_DIR,
     generate_all::{Mode, REGENERATE_ALL_COMMAND},
-    generate_rules_table, ROOT_DIR,
+    generate_rules_table,
 };
 
 #[derive(clap::Args)]
@@ -107,7 +108,9 @@ pub(crate) fn main(args: &Args) -> Result<()> {
                         println!("up-to-date: docs/rules/{rule_name}.md");
                     } else {
                         let comparison = StrComparison::new(&existing, &output);
-                        bail!("docs/rules/{rule_name}.md changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}");
+                        bail!(
+                            "docs/rules/{rule_name}.md changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}"
+                        );
                     }
                 }
                 Mode::Write => {

--- a/crates/fortitude_dev/src/generate_options.rs
+++ b/crates/fortitude_dev/src/generate_options.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 //! Generate a Markdown-compatible listing of configuration options for `fpm.toml`.
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use itertools::Itertools;
 use pretty_assertions::StrComparison;
 use std::fmt::Write;
@@ -13,8 +13,8 @@ use std::path::PathBuf;
 use fortitude_workspace::options::Options;
 use fortitude_workspace::options_base::{OptionField, OptionSet, OptionsMetadata, Visit};
 
-use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
 use crate::ROOT_DIR;
+use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
 
 #[derive(clap::Args)]
 pub(crate) struct Args {

--- a/crates/fortitude_dev/src/generate_rules_table.rs
+++ b/crates/fortitude_dev/src/generate_rules_table.rs
@@ -55,7 +55,9 @@ fn generate_table(
                 format!("<span title='Automatic fix available'>{FIX_SYMBOL}</span>")
             }
             FixAvailability::None => {
-                format!("<span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>{FIX_SYMBOL}</span>")
+                format!(
+                    "<span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>{FIX_SYMBOL}</span>"
+                )
             }
         };
 

--- a/crates/fortitude_dev/src/parse.rs
+++ b/crates/fortitude_dev/src/parse.rs
@@ -1,9 +1,9 @@
 use std::{env, path::PathBuf};
 
 use anyhow::Result;
-use tree_sitter::{ffi, Parser};
+use tree_sitter::{Parser, ffi};
 use tree_sitter_cli::{
-    parse::{parse_file_at_path, ParseFileOptions, ParseOutput, ParseStats, ParseTheme},
+    parse::{ParseFileOptions, ParseOutput, ParseStats, ParseTheme, parse_file_at_path},
     util,
 };
 

--- a/crates/fortitude_linter/src/allow_comments.rs
+++ b/crates/fortitude_linter/src/allow_comments.rs
@@ -2,11 +2,11 @@ use crate::ast::FortitudeNode;
 use crate::registry::AsRule;
 use crate::rule_redirects::get_redirect_target;
 use crate::rule_table::RuleTable;
+use crate::rules::Rule;
 use crate::rules::fortitude::allow_comments::{
     DisabledAllowComment, DuplicatedAllowComment, InvalidRuleCodeOrName, RedirectedAllowComment,
     UnusedAllowComment,
 };
-use crate::rules::Rule;
 
 use itertools::Itertools;
 use lazy_regex::{regex, regex_captures};

--- a/crates/fortitude_linter/src/fix/mod.rs
+++ b/crates/fortitude_linter/src/fix/mod.rs
@@ -149,7 +149,7 @@ mod tests {
     use ruff_diagnostics::{Diagnostic, Edit, Fix, SourceMarker};
     use ruff_text_size::{Ranged, TextSize};
 
-    use crate::fix::{apply_fixes, FixResult};
+    use crate::fix::{FixResult, apply_fixes};
     use crate::locator::Locator;
     use crate::rules::correctness::use_statements::UseAll;
 

--- a/crates/fortitude_linter/src/fs.rs
+++ b/crates/fortitude_linter/src/fs.rs
@@ -5,13 +5,13 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use globset::{Glob, GlobSet, GlobSetBuilder};
-use ignore::{types::TypesBuilder, WalkBuilder};
+use ignore::{WalkBuilder, types::TypesBuilder};
 use itertools::Itertools;
 use log::debug;
 use path_absolutize::Absolutize;
 use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_macros::CacheKey;
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 
 use crate::registry::Rule;
 use crate::rule_selector::CompiledPerFileIgnoreList;

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -22,18 +22,18 @@ use allow_comments::{check_allow_comments, gather_allow_comments};
 use ast::FortitudeNode;
 use diagnostic_message::DiagnosticMessage;
 use diagnostics::{Diagnostics, FixMap};
-use fix::{fix_file, FixResult};
+use fix::{FixResult, fix_file};
 use locator::Locator;
 use registry::AsRule;
 use rule_table::RuleTable;
+use rules::Rule;
 use rules::error::syntax_error::SyntaxError;
 #[cfg(any(feature = "test-rules", test))]
-use rules::testing::test_rules::{self, TestRule, TEST_RULES};
-use rules::Rule;
+use rules::testing::test_rules::{self, TEST_RULES, TestRule};
 use rules::{AstRuleEnum, PathRuleEnum, TextRuleEnum};
 use settings::{FixMode, Settings};
 
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use colored::Colorize;
 use itertools::Itertools;
 use log::warn;

--- a/crates/fortitude_linter/src/message/azure.rs
+++ b/crates/fortitude_linter/src/message/azure.rs
@@ -44,8 +44,8 @@ impl Emitter for AzureEmitter {
 mod tests {
     use insta::assert_snapshot;
 
-    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::AzureEmitter;
+    use crate::message::tests::{capture_emitter_output, create_messages};
 
     #[test]
     fn output() {

--- a/crates/fortitude_linter/src/message/github.rs
+++ b/crates/fortitude_linter/src/message/github.rs
@@ -29,7 +29,9 @@ impl Emitter for GithubEmitter {
             write!(
                 writer,
                 "::error title=Fortitude{code},file={file},line={row},col={column},endLine={end_row},endColumn={end_column}::",
-                code = message.rule().map_or_else(String::new, |rule| format!(" ({})", rule.noqa_code())),
+                code = message
+                    .rule()
+                    .map_or_else(String::new, |rule| format!(" ({})", rule.noqa_code())),
                 file = message.filename(),
                 row = source_location.row,
                 column = source_location.column,
@@ -60,8 +62,8 @@ impl Emitter for GithubEmitter {
 mod tests {
     use insta::assert_snapshot;
 
-    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::GithubEmitter;
+    use crate::message::tests::{capture_emitter_output, create_messages};
 
     #[test]
     fn output() {

--- a/crates/fortitude_linter/src/message/gitlab.rs
+++ b/crates/fortitude_linter/src/message/gitlab.rs
@@ -2,8 +2,8 @@
 // Copyright 2022 Charles Marsh
 // SPDX-License-Identifier: MIT
 
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 
@@ -125,8 +125,8 @@ fn fingerprint(message: &DiagnosticMessage, project_path: &str, salt: u64) -> u6
 mod tests {
     use insta::assert_snapshot;
 
-    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::GitlabEmitter;
+    use crate::message::tests::{capture_emitter_output, create_messages};
 
     #[test]
     fn output() {

--- a/crates/fortitude_linter/src/message/grouped.rs
+++ b/crates/fortitude_linter/src/message/grouped.rs
@@ -13,7 +13,7 @@ use ruff_source_file::OneIndexed;
 use crate::fs::relativize_path;
 use crate::message::diff::calculate_print_width;
 use crate::message::text::{MessageCodeFrame, RuleCodeAndBody};
-use crate::message::{group_messages_by_filename, Emitter, MessageWithLocation};
+use crate::message::{Emitter, MessageWithLocation, group_messages_by_filename};
 use crate::settings::UnsafeFixes;
 
 use super::DiagnosticMessage;
@@ -183,8 +183,8 @@ impl std::fmt::Write for PadAdapter<'_> {
 mod tests {
     use insta::assert_snapshot;
 
-    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::GroupedEmitter;
+    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::settings::UnsafeFixes;
 
     #[test]

--- a/crates/fortitude_linter/src/message/json.rs
+++ b/crates/fortitude_linter/src/message/json.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use ruff_diagnostics::Edit;
 use ruff_source_file::SourceCode;
@@ -106,8 +106,8 @@ impl Serialize for ExpandedEdits<'_> {
 mod tests {
     use insta::assert_snapshot;
 
-    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::JsonEmitter;
+    use crate::message::tests::{capture_emitter_output, create_messages};
 
     #[test]
     fn output() {

--- a/crates/fortitude_linter/src/message/json_lines.rs
+++ b/crates/fortitude_linter/src/message/json_lines.rs
@@ -4,8 +4,8 @@
 
 use std::io::Write;
 
-use crate::message::json::message_to_json_value;
 use crate::message::Emitter;
+use crate::message::json::message_to_json_value;
 
 use super::DiagnosticMessage;
 

--- a/crates/fortitude_linter/src/message/junit.rs
+++ b/crates/fortitude_linter/src/message/junit.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite, XmlString};
 
-use crate::message::{group_messages_by_filename, Emitter, MessageWithLocation};
+use crate::message::{Emitter, MessageWithLocation, group_messages_by_filename};
 
 use super::DiagnosticMessage;
 
@@ -92,8 +92,8 @@ impl Emitter for JunitEmitter {
 mod tests {
     use insta::assert_snapshot;
 
-    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::JunitEmitter;
+    use crate::message::tests::{capture_emitter_output, create_messages};
 
     #[test]
     fn output() {

--- a/crates/fortitude_linter/src/message/pylint.rs
+++ b/crates/fortitude_linter/src/message/pylint.rs
@@ -48,8 +48,8 @@ impl Emitter for PylintEmitter {
 mod tests {
     use insta::assert_snapshot;
 
-    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::PylintEmitter;
+    use crate::message::tests::{capture_emitter_output, create_messages};
 
     #[test]
     fn output() {

--- a/crates/fortitude_linter/src/message/rdjson.rs
+++ b/crates/fortitude_linter/src/message/rdjson.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use ruff_diagnostics::Edit;
 use ruff_source_file::SourceCode;
@@ -129,8 +129,8 @@ fn rdjson_range(start: &SourceLocation, end: &SourceLocation) -> Value {
 mod tests {
     use insta::assert_snapshot;
 
-    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::RdjsonEmitter;
+    use crate::message::tests::{capture_emitter_output, create_messages};
 
     #[test]
     fn output() {

--- a/crates/fortitude_linter/src/message/sarif.rs
+++ b/crates/fortitude_linter/src/message/sarif.rs
@@ -11,11 +11,11 @@ use serde_json::json;
 
 use ruff_source_file::OneIndexed;
 
+use crate::VERSION;
 use crate::fs::normalize_path;
 use crate::message::Emitter;
 use crate::registry::{Category, RuleNamespace};
 use crate::rules::Rule;
-use crate::VERSION;
 
 use super::DiagnosticMessage;
 
@@ -187,8 +187,8 @@ impl Serialize for SarifResult {
 
 #[cfg(test)]
 mod tests {
-    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::SarifEmitter;
+    use crate::message::tests::{capture_emitter_output, create_messages};
 
     fn get_output() -> String {
         let mut emitter = SarifEmitter {};

--- a/crates/fortitude_linter/src/message/text.rs
+++ b/crates/fortitude_linter/src/message/text.rs
@@ -15,8 +15,8 @@ use ruff_text_size::{Ranged, TextRange};
 use crate::fs::relativize_path;
 use crate::settings::UnsafeFixes;
 // use crate::line_width::{IndentWidth, LineWidthBuilder};
-use crate::message::diff::Diff;
 use crate::message::Emitter;
+use crate::message::diff::Diff;
 use crate::text_helpers::ShowNonprinting;
 
 use super::DiagnosticMessage;
@@ -237,8 +237,8 @@ impl Display for MessageCodeFrame<'_> {
 mod tests {
     use insta::assert_snapshot;
 
-    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::TextEmitter;
+    use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::settings::UnsafeFixes;
 
     #[test]

--- a/crates/fortitude_linter/src/rule_selector.rs
+++ b/crates/fortitude_linter/src/rule_selector.rs
@@ -224,7 +224,10 @@ impl RuleSelector {
     }
 
     /// Returns rules matching the selector, taking into account rule groups like preview and deprecated.
-    pub fn rules<'a>(&'a self, preview: &PreviewOptions) -> impl Iterator<Item = Rule> + 'a + use<'a> {
+    pub fn rules<'a>(
+        &'a self,
+        preview: &PreviewOptions,
+    ) -> impl Iterator<Item = Rule> + 'a + use<'a> {
         let preview_enabled = preview.mode.is_enabled();
         let preview_require_explicit = preview.require_explicit;
 
@@ -289,7 +292,9 @@ impl RuleSelector {
                     2 => Specificity::Prefix2Chars,
                     3 => Specificity::Prefix3Chars,
                     4 => Specificity::Prefix4Chars,
-                    _ => panic!("RuleSelector::specificity doesn't yet support codes with so many characters"),
+                    _ => panic!(
+                        "RuleSelector::specificity doesn't yet support codes with so many characters"
+                    ),
                 }
             }
             RuleSelector::DeprecatedCategory {
@@ -368,8 +373,8 @@ pub mod clap_completion {
 
     use crate::{
         registry::{Category, RuleNamespace},
-        rule_selector::is_single_rule_selector,
         rule_selector::RuleSelector,
+        rule_selector::is_single_rule_selector,
         rules::RuleCodePrefix,
     };
 

--- a/crates/fortitude_linter/src/rule_selector.rs
+++ b/crates/fortitude_linter/src/rule_selector.rs
@@ -224,7 +224,7 @@ impl RuleSelector {
     }
 
     /// Returns rules matching the selector, taking into account rule groups like preview and deprecated.
-    pub fn rules<'a>(&'a self, preview: &PreviewOptions) -> impl Iterator<Item = Rule> + 'a {
+    pub fn rules<'a>(&'a self, preview: &PreviewOptions) -> impl Iterator<Item = Rule> + 'a + use<'a> {
         let preview_enabled = preview.mode.is_enabled();
         let preview_require_explicit = preview.require_explicit;
 

--- a/crates/fortitude_linter/src/rules/correctness/accessibility_statements.rs
+++ b/crates/fortitude_linter/src/rules/correctness/accessibility_statements.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/assumed_size.rs
+++ b/crates/fortitude_linter/src/rules/correctness/assumed_size.rs
@@ -3,7 +3,7 @@ use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use itertools::Itertools;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/conditionals.rs
+++ b/crates/fortitude_linter/src/rules/correctness/conditionals.rs
@@ -2,8 +2,8 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
-use ruff_source_file::{find_newline, LineEnding, SourceFile};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_source_file::{LineEnding, SourceFile, find_newline};
 use ruff_text_size::TextSize;
 use tree_sitter::Node;
 
@@ -86,11 +86,10 @@ impl AstRule for MisleadingInlineIfSemicolon {
             let end = TextSize::try_from(end).unwrap();
             let indentation = node.indentation(src);
             let edit = Edit::replacement(format!("\n{indentation}"), start, end);
-            return some_vec!(Diagnostic::from_node(
-                MisleadingInlineIfSemicolon {},
-                &semicolon_node
-            )
-            .with_fix(Fix::safe_edit(edit)));
+            return some_vec!(
+                Diagnostic::from_node(MisleadingInlineIfSemicolon {}, &semicolon_node)
+                    .with_fix(Fix::safe_edit(edit))
+            );
         }
         None
     }

--- a/crates/fortitude_linter/src/rules/correctness/derived_default_init.rs
+++ b/crates/fortitude_linter/src/rules/correctness/derived_default_init.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Edit, Fix, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/error_handling.rs
+++ b/crates/fortitude_linter/src/rules/correctness/error_handling.rs
@@ -3,9 +3,9 @@ use std::iter::once;
 use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
+++ b/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix, FixAvailability, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/external.rs
+++ b/crates/fortitude_linter/src/rules/correctness/external.rs
@@ -1,9 +1,9 @@
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
-use crate::{ast::FortitudeNode, settings::Settings, AstRule, FromAstNode};
+use crate::{AstRule, FromAstNode, ast::FortitudeNode, settings::Settings};
 
 /// ## What does it do?
 /// Checks for procedures declared with just `external`

--- a/crates/fortitude_linter/src/rules/correctness/implicit_kinds.rs
+++ b/crates/fortitude_linter/src/rules/correctness/implicit_kinds.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
+++ b/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
@@ -3,7 +3,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Edit, Fix, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/init_decls.rs
+++ b/crates/fortitude_linter/src/rules/correctness/init_decls.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -74,7 +74,9 @@ impl Violation for InitialisationInDeclaration {
     #[derive_message_formats]
     fn message(&self) -> String {
         let Self { name } = self;
-        format!("'{name}' is initialised in its declaration and has no explicit `save` or `parameter` attribute")
+        format!(
+            "'{name}' is initialised in its declaration and has no explicit `save` or `parameter` attribute"
+        )
     }
 }
 
@@ -199,7 +201,9 @@ impl Violation for PointerInitialisationInDeclaration {
     #[derive_message_formats]
     fn message(&self) -> String {
         let Self { name } = self;
-        format!("Pointer '{name}' is initialized in its declaration and has no explicit `save` attribute")
+        format!(
+            "Pointer '{name}' is initialized in its declaration and has no explicit `save` attribute"
+        )
     }
 }
 

--- a/crates/fortitude_linter/src/rules/correctness/intent.rs
+++ b/crates/fortitude_linter/src/rules/correctness/intent.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/kind_suffixes.rs
+++ b/crates/fortitude_linter/src/rules/correctness/kind_suffixes.rs
@@ -3,7 +3,7 @@ use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/magic_numbers.rs
+++ b/crates/fortitude_linter/src/rules/correctness/magic_numbers.rs
@@ -4,7 +4,7 @@ use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use itertools::Itertools;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/missing_io_specifier.rs
+++ b/crates/fortitude_linter/src/rules/correctness/missing_io_specifier.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/nonportable_shortcircuit_inquiry.rs
+++ b/crates/fortitude_linter/src/rules/correctness/nonportable_shortcircuit_inquiry.rs
@@ -1,9 +1,9 @@
-use crate::settings::Settings;
 use crate::AstRule;
-use crate::{ast::FortitudeNode, FromAstNode};
+use crate::settings::Settings;
+use crate::{FromAstNode, ast::FortitudeNode};
 use itertools::Itertools;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 use tree_sitter::Node;

--- a/crates/fortitude_linter/src/rules/correctness/select_default.rs
+++ b/crates/fortitude_linter/src/rules/correctness/select_default.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/correctness/split_escaped_quote.rs
+++ b/crates/fortitude_linter/src/rules/correctness/split_escaped_quote.rs
@@ -1,8 +1,8 @@
-use crate::settings::Settings;
 use crate::TextRule;
+use crate::settings::Settings;
 use lazy_regex::regex;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 

--- a/crates/fortitude_linter/src/rules/correctness/trailing_backslash.rs
+++ b/crates/fortitude_linter/src/rules/correctness/trailing_backslash.rs
@@ -1,10 +1,10 @@
+use crate::AstRule;
 use crate::ast::FortitudeNode;
 /// Defines rules that govern line length.
 use crate::settings::Settings;
-use crate::AstRule;
 use lazy_regex::regex;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 use tree_sitter::Node;

--- a/crates/fortitude_linter/src/rules/correctness/use_statements.rs
+++ b/crates/fortitude_linter/src/rules/correctness/use_statements.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Edit, Fix, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/error/ioerror.rs
+++ b/crates/fortitude_linter/src/rules/error/ioerror.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use ruff_diagnostics::Violation;
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 
 /// ## What it does
 /// This is not a regular diagnostic; instead, it's raised when a file cannot be read

--- a/crates/fortitude_linter/src/rules/error/syntax_error.rs
+++ b/crates/fortitude_linter/src/rules/error/syntax_error.rs
@@ -1,8 +1,8 @@
 use crate::settings::Settings;
-use crate::{some_vec, AstRule, FromAstNode};
+use crate::{AstRule, FromAstNode, some_vec};
 
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/fortitude/allow_comments.rs
+++ b/crates/fortitude_linter/src/rules/fortitude/allow_comments.rs
@@ -1,5 +1,5 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 
 /// ## What it does
 /// Checks for invalid rules in allow comments.

--- a/crates/fortitude_linter/src/rules/modernisation/double_precision.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/double_precision.rs
@@ -3,7 +3,7 @@ use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use lazy_regex::regex_captures;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/modernisation/include_statement.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/include_statement.rs
@@ -1,7 +1,7 @@
 use crate::AstRule;
 use crate::{ast::FortitudeNode, settings::Settings};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 use tree_sitter::Node;

--- a/crates/fortitude_linter/src/rules/modernisation/mpi.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/mpi.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/modernisation/old_style_array_literal.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/old_style_array_literal.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/modernisation/relational_operators.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/relational_operators.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/obsolescent/common_blocks.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/common_blocks.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/obsolescent/computed_goto.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/computed_goto.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/obsolescent/deprecated_character_syntax.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/deprecated_character_syntax.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -76,15 +76,17 @@ impl AstRule for DeprecatedCharacterSyntax {
         let dtype = dtype.to_text(src)?.to_string();
         let replacement = format!("{dtype}(len={length})");
         let fix = Fix::safe_edit(node.edit_replacement(source_file, replacement));
-        some_vec![Diagnostic::from_node(
-            Self {
-                original,
-                dtype,
-                length
-            },
-            node
-        )
-        .with_fix(fix)]
+        some_vec![
+            Diagnostic::from_node(
+                Self {
+                    original,
+                    dtype,
+                    length
+                },
+                node
+            )
+            .with_fix(fix)
+        ]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/obsolescent/entry_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/entry_statement.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/obsolescent/mpi.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/mpi.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use std::path::Path;
 use tree_sitter::Node;

--- a/crates/fortitude_linter/src/rules/obsolescent/openmp.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/openmp.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use std::path::Path;
 use tree_sitter::Node;

--- a/crates/fortitude_linter/src/rules/obsolescent/pause_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/pause_statement.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Fix, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/obsolescent/specific_names.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/specific_names.rs
@@ -3,7 +3,7 @@ use crate::rules::utilities;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Fix, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
@@ -96,14 +96,16 @@ impl AstRule for SpecificName {
         let matched_case = utilities::match_original_case(func, new_func)?;
 
         let fix = Fix::unsafe_edit(name_node.edit_replacement(src, matched_case.clone()));
-        some_vec![Diagnostic::from_node(
-            Self {
-                func: func.to_string(),
-                new_func: matched_case
-            },
-            &name_node
-        )
-        .with_fix(fix)]
+        some_vec![
+            Diagnostic::from_node(
+                Self {
+                    func: func.to_string(),
+                    new_func: matched_case
+                },
+                &name_node
+            )
+            .with_fix(fix)
+        ]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/obsolescent/statement_functions.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/statement_functions.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/portability/literal_kinds.rs
+++ b/crates/fortitude_linter/src/rules/portability/literal_kinds.rs
@@ -1,9 +1,9 @@
-use crate::ast::{dtype_is_plain_number, FortitudeNode};
+use crate::ast::{FortitudeNode, dtype_is_plain_number};
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/portability/non_portable_io_unit.rs
+++ b/crates/fortitude_linter/src/rules/portability/non_portable_io_unit.rs
@@ -3,7 +3,7 @@ use crate::rules::utilities::literal_as_io_unit;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/portability/star_kinds.rs
+++ b/crates/fortitude_linter/src/rules/portability/star_kinds.rs
@@ -1,8 +1,8 @@
-use crate::ast::{dtype_is_plain_number, strip_line_breaks, FortitudeNode};
+use crate::ast::{FortitudeNode, dtype_is_plain_number, strip_line_breaks};
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Fix, FixAvailability, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/style/double_colon_in_decl.rs
+++ b/crates/fortitude_linter/src/rules/style/double_colon_in_decl.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/style/end_statements.rs
+++ b/crates/fortitude_linter/src/rules/style/end_statements.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/style/file_contents.rs
+++ b/crates/fortitude_linter/src/rules/style/file_contents.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/style/file_extensions.rs
+++ b/crates/fortitude_linter/src/rules/style/file_extensions.rs
@@ -1,9 +1,9 @@
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::TextRange;
 
-use crate::settings::Settings;
 use crate::PathRule;
+use crate::settings::Settings;
 use std::path::Path;
 
 /// ## What it does

--- a/crates/fortitude_linter/src/rules/style/functions.rs
+++ b/crates/fortitude_linter/src/rules/style/functions.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/style/implicit_none.rs
+++ b/crates/fortitude_linter/src/rules/style/implicit_none.rs
@@ -6,7 +6,7 @@ use crate::rules::correctness::implicit_typing::{
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/style/keywords.rs
+++ b/crates/fortitude_linter/src/rules/style/keywords.rs
@@ -3,7 +3,7 @@ use crate::ast::FortitudeNode;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix, FixAvailability, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 use std::str::FromStr;

--- a/crates/fortitude_linter/src/rules/style/line_length.rs
+++ b/crates/fortitude_linter/src/rules/style/line_length.rs
@@ -1,9 +1,9 @@
+use crate::TextRule;
 /// Defines rules that govern line length.
 use crate::settings::Settings;
-use crate::TextRule;
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{TextLen, TextRange, TextSize};

--- a/crates/fortitude_linter/src/rules/style/semicolons.rs
+++ b/crates/fortitude_linter/src/rules/style/semicolons.rs
@@ -1,5 +1,5 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextSize;
 use tree_sitter::Node;

--- a/crates/fortitude_linter/src/rules/style/strings.rs
+++ b/crates/fortitude_linter/src/rules/style/strings.rs
@@ -1,5 +1,5 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix, FixAvailability, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use ruff_text_size::{TextLen, TextSize};
 use settings::Quote;
@@ -92,14 +92,16 @@ impl AstRule for BadQuoteString {
                 end_byte - TextSize::from(1),
                 end_byte,
             );
-            return some_vec!(Diagnostic::from_node(
-                Self {
-                    preferred_quote,
-                    contains_escaped_quotes: false,
-                },
-                node,
-            )
-            .with_fix(Fix::safe_edits(edit_start, [edit_end])));
+            return some_vec!(
+                Diagnostic::from_node(
+                    Self {
+                        preferred_quote,
+                        contains_escaped_quotes: false,
+                    },
+                    node,
+                )
+                .with_fix(Fix::safe_edits(edit_start, [edit_end]))
+            );
         }
         None
     }

--- a/crates/fortitude_linter/src/rules/style/whitespace.rs
+++ b/crates/fortitude_linter/src/rules/style/whitespace.rs
@@ -1,6 +1,6 @@
 /// Defines rules that enforce widely accepted whitespace rules.
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::{SourceFile, UniversalNewlines};
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use tree_sitter::Node;
@@ -142,8 +142,10 @@ impl AstRule for IncorrectSpaceAroundDoubleColon {
 
         if !has_space_before {
             if !has_space_after {
-                return some_vec!(Diagnostic::from_node(Self {}, node)
-                    .with_fix(Fix::safe_edits(before_edit, [after_edit])));
+                return some_vec!(
+                    Diagnostic::from_node(Self {}, node)
+                        .with_fix(Fix::safe_edits(before_edit, [after_edit]))
+                );
             }
             return some_vec!(
                 Diagnostic::from_node(Self {}, node).with_fix(Fix::safe_edit(before_edit))
@@ -244,8 +246,10 @@ impl AstRule for IncorrectSpaceBetweenBrackets {
             return None;
         }
 
-        some_vec!(Diagnostic::new(Self { is_open_bracket }, whitespace_range)
-            .with_fix(Fix::safe_edit(Edit::range_deletion(whitespace_range))))
+        some_vec!(
+            Diagnostic::new(Self { is_open_bracket }, whitespace_range)
+                .with_fix(Fix::safe_edit(Edit::range_deletion(whitespace_range)))
+        )
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/testing/test_rules.rs
+++ b/crates/fortitude_linter/src/rules/testing/test_rules.rs
@@ -4,7 +4,7 @@
 
 /// Fake rules for testing fortitude's behaviour
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
-use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::rules::Rule;

--- a/crates/fortitude_linter/src/settings.rs
+++ b/crates/fortitude_linter/src/settings.rs
@@ -11,11 +11,11 @@ use lazy_static::lazy_static;
 use path_absolutize::path_dedot;
 use ruff_diagnostics::Applicability;
 use ruff_macros::CacheKey;
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use strum::IntoEnumIterator;
 
 use crate::display_settings;
-use crate::fs::{FilePatternSet, EXCLUDE_BUILTINS, FORTRAN_EXTS};
+use crate::fs::{EXCLUDE_BUILTINS, FORTRAN_EXTS, FilePatternSet};
 use crate::registry::Rule;
 use crate::rule_selector::{CompiledPerFileIgnoreList, PreviewOptions, RuleSelector};
 use crate::rule_table::RuleTable;
@@ -333,11 +333,7 @@ pub enum ExcludeMode {
 
 impl From<bool> for ExcludeMode {
     fn from(b: bool) -> Self {
-        if b {
-            Self::Force
-        } else {
-            Self::NoForce
-        }
+        if b { Self::Force } else { Self::NoForce }
     }
 }
 

--- a/crates/fortitude_macros/src/lib.rs
+++ b/crates/fortitude_macros/src/lib.rs
@@ -3,7 +3,7 @@ mod rule_code_prefix;
 mod rule_namespace;
 
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, DeriveInput, ItemFn};
+use syn::{DeriveInput, ItemFn, parse_macro_input};
 
 #[proc_macro_derive(RuleNamespace, attributes(prefix))]
 pub fn derive_rule_namespace(input: TokenStream) -> TokenStream {

--- a/crates/fortitude_macros/src/map_codes.rs
+++ b/crates/fortitude_macros/src/map_codes.rs
@@ -6,10 +6,10 @@ use std::collections::{BTreeMap, HashMap};
 
 use itertools::Itertools;
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use quote::{ToTokens, quote};
 use syn::{
-    parenthesized, parse::Parse, spanned::Spanned, Attribute, Error, Expr, ExprCall, ExprMatch,
-    Ident, ItemFn, LitStr, Pat, Path, Stmt, Token,
+    Attribute, Error, Expr, ExprCall, ExprMatch, Ident, ItemFn, LitStr, Pat, Path, Stmt, Token,
+    parenthesized, parse::Parse, spanned::Spanned,
 };
 
 use crate::rule_code_prefix::{get_prefix_ident, intersection_all};

--- a/crates/fortitude_workspace/src/configuration.rs
+++ b/crates/fortitude_workspace/src/configuration.rs
@@ -1,7 +1,7 @@
 use crate::options::{
     ExitUnlabelledLoopOptions, KeywordWhitespaceOptions, Options, PortabilityOptions, StringOptions,
 };
-use fortitude_linter::fs::{FilePattern, FilePatternSet, EXCLUDE_BUILTINS, FORTRAN_EXTS};
+use fortitude_linter::fs::{EXCLUDE_BUILTINS, FORTRAN_EXTS, FilePattern, FilePatternSet};
 use fortitude_linter::registry::RuleNamespace;
 use fortitude_linter::rule_redirects::get_redirect;
 use fortitude_linter::rule_selector::{
@@ -10,12 +10,12 @@ use fortitude_linter::rule_selector::{
 use fortitude_linter::rule_table::RuleTable;
 use fortitude_linter::rules::Rule;
 use fortitude_linter::settings::{
-    CheckSettings, ExcludeMode, FileResolverSettings, GitignoreMode, OutputFormat, PreviewMode,
-    ProgressBar, Settings, UnsafeFixes, DEFAULT_SELECTORS,
+    CheckSettings, DEFAULT_SELECTORS, ExcludeMode, FileResolverSettings, GitignoreMode,
+    OutputFormat, PreviewMode, ProgressBar, Settings, UnsafeFixes,
 };
 use fortitude_linter::{fs, warn_user_once_by_id, warn_user_once_by_message};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use itertools::Itertools;
 use log::warn;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -500,7 +500,9 @@ pub fn to_rule_table(args: RuleSelection, preview: &PreviewMode) -> anyhow::Resu
             [] => (),
             [selection] => {
                 let (prefix, code) = selection.prefix_and_code();
-                return Err(anyhow!("Selection of deprecated rule `{prefix}{code}` is not allowed when preview is enabled."));
+                return Err(anyhow!(
+                    "Selection of deprecated rule `{prefix}{code}` is not allowed when preview is enabled."
+                ));
             }
             [..] => {
                 let mut message = "Selection of deprecated rules is not allowed when preview is enabled. Remove selection of:".to_string();


### PR DESCRIPTION
First commit bumps the edition and applies `cargo fix --edition`. Nothing major, just a couple of lifetime things, mostly around `if let Some(...)`.

Second commit applies new formatting. This is a much bigger change, but mostly looks pretty sensible.

Third commit just ignores the previous commit for `git blame` (as it's changed a lot of lines)