### PR TITLE
Fix `version` command for changed `crates/` layout

### DIFF
--- a/crates/fortitude/build.rs
+++ b/crates/fortitude/build.rs
@@ -11,7 +11,9 @@ use std::{
 fn main() {
     // The workspace root directory is not available without walking up the tree
     // https://github.com/rust-lang/cargo/issues/3946
-    let workspace_root = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("..");
+    let workspace_root = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("..")
+        .join("..");
 
     commit_info(&workspace_root);
 


### PR DESCRIPTION
With the move to the additional layer of `crates/`, we missed updating
the `build.rs` script and so weren't finding the `.git`
directory and thus the commit info. The end result is that `fortitude
version` on non-release builds wasn't getting the additional commit info.