### PR TITLE
Add rule for nonconforming tab characters

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/portability/PORT031.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/portability/PORT031.f90
@@ -1,0 +1,12 @@
+! If you touch this flie, be careful your editor doesn't auto-correct
+! the horrible whitespace!
+program invalid_tab
+	implicit none
+    print*, "Don't flag this:	"
+    ! Or this:|	|
+    if	(.true.)	then
+    	print*, "Mixed tab/space"
+    else
+		print*, "Two tabs"
+    end if
+end program invalid_tab

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -26,7 +26,7 @@ use fix::{FixResult, fix_file};
 use locator::Locator;
 use registry::AsRule;
 use rule_table::RuleTable;
-use rules::Rule;
+use rules::{portability::invalid_tab::check_invalid_tab, Rule};
 use rules::error::syntax_error::SyntaxError;
 #[cfg(any(feature = "test-rules", test))]
 use rules::testing::test_rules::{self, TEST_RULES, TestRule};
@@ -265,6 +265,10 @@ pub(crate) fn check_path(
         if let Some(allow_rules) = gather_allow_comments(&node, file) {
             allow_comments.push(allow_rules);
         };
+    }
+
+    if rules.enabled(Rule::InvalidTab) {
+        violations.append(&mut check_invalid_tab(&root, file));
     }
 
     // Raise violations for internal test rules

--- a/crates/fortitude_linter/src/rules/mod.rs
+++ b/crates/fortitude_linter/src/rules/mod.rs
@@ -124,6 +124,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Portability, "011") => (RuleGroup::Stable, Ast, Default, portability::literal_kinds::LiteralKind),
         (Portability, "012") => (RuleGroup::Stable, Ast, Default, portability::literal_kinds::LiteralKindSuffix),
         (Portability, "021") => (RuleGroup::Stable, Ast, Default, portability::star_kinds::StarKind),
+        (Portability, "031") => (RuleGroup::Preview, None, Optional, portability::invalid_tab::InvalidTab),
 
         // style
         (Style, "001") => (RuleGroup::Stable, Text, Default, style::line_length::LineTooLong),

--- a/crates/fortitude_linter/src/rules/portability/invalid_tab.rs
+++ b/crates/fortitude_linter/src/rules/portability/invalid_tab.rs
@@ -1,0 +1,51 @@
+use itertools::Itertools;
+use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_source_file::SourceFile;
+use ruff_text_size::{TextRange, TextSize};
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks for the use of tab characters as whitespace
+///
+/// ## Why is this bad?
+/// Tabs are not part of the Fortran standard, and compilers may
+/// reject the source if using a strict conformance mode (for example,
+/// `gfortran -std=f2023 -Werror`).
+#[derive(ViolationMetadata)]
+pub(crate) struct InvalidTab;
+
+impl Violation for InvalidTab {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "Invalid tab character".to_string()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Replace with spaces".to_string())
+    }
+}
+
+pub fn check_invalid_tab(root: &Node, src: &SourceFile) -> Vec<Diagnostic> {
+    src.source_text()
+        .char_indices()
+        .filter(|(_, c)| *c == '\t')
+        .filter(|(index, _)| {
+            if let Some(node) = root.named_descendant_for_byte_range(*index, *index) {
+                !matches!(node.kind(), "comment" | "string_literal")
+            } else {
+                false
+            }
+        })
+        .map(|(index, _)| {
+            // TODO(peter): This doesn't render particularly well,
+            // might be an issue with annotate-snippets?
+            let start = TextSize::try_from(index).unwrap();
+            let end = start + TextSize::new(1);
+            let edit = Edit::replacement("    ".to_string(), start, start + TextSize::new(1));
+            Diagnostic::new(InvalidTab, TextRange::new(start, end))
+                .with_fix(Fix::unsafe_edit(edit))
+        })
+        .collect_vec()
+}

--- a/crates/fortitude_linter/src/rules/portability/literal_kinds.rs
+++ b/crates/fortitude_linter/src/rules/portability/literal_kinds.rs
@@ -1,9 +1,9 @@
-use crate::ast::{FortitudeNode, dtype_is_plain_number};
+use crate::ast::{dtype_is_plain_number, FortitudeNode};
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use lazy_regex::regex_is_match;
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/portability/mod.rs
+++ b/crates/fortitude_linter/src/rules/portability/mod.rs
@@ -1,3 +1,4 @@
+pub mod invalid_tab;
 pub(crate) mod literal_kinds;
 pub(crate) mod non_portable_io_unit;
 pub(crate) mod star_kinds;
@@ -21,6 +22,7 @@ mod tests {
     #[test_case(Rule::LiteralKind, Path::new("PORT011.f90"))]
     #[test_case(Rule::LiteralKindSuffix, Path::new("PORT012.f90"))]
     #[test_case(Rule::StarKind, Path::new("PORT021.f90"))]
+    #[test_case(Rule::InvalidTab, Path::new("PORT031.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/fortitude_linter/src/rules/portability/non_portable_io_unit.rs
+++ b/crates/fortitude_linter/src/rules/portability/non_portable_io_unit.rs
@@ -3,7 +3,7 @@ use crate::rules::utilities::literal_as_io_unit;
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/crates/fortitude_linter/src/rules/portability/snapshots/fortitude_linter__rules__portability__tests__invalid-tab_PORT031.f90.snap
+++ b/crates/fortitude_linter/src/rules/portability/snapshots/fortitude_linter__rules__portability__tests__invalid-tab_PORT031.f90.snap
@@ -1,0 +1,128 @@
+---
+source: crates/fortitude_linter/src/rules/portability/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/portability/PORT031.f90:4:1: PORT031 [*] Invalid tab character
+  |
+2 | ! the horrible whitespace!
+3 | program invalid_tab
+4 |     implicit none
+  | ^ PORT031
+5 |     print*, "Don't flag this:    "
+6 |     ! Or this:|    |
+  |
+  = help: Replace with spaces
+
+ℹ Unsafe fix
+1 1 | ! If you touch this flie, be careful your editor doesn't auto-correct
+2 2 | ! the horrible whitespace!
+3 3 | program invalid_tab
+4   |-	implicit none
+  4 |+    implicit none
+5 5 |     print*, "Don't flag this:	"
+6 6 |     ! Or this:|	|
+7 7 |     if	(.true.)	then
+
+./resources/test/fixtures/portability/PORT031.f90:7:7: PORT031 [*] Invalid tab character
+  |
+5 |     print*, "Don't flag this:    "
+6 |     ! Or this:|    |
+7 |     if    (.true.)    then
+  |       ^ PORT031
+8 |         print*, "Mixed tab/space"
+9 |     else
+  |
+  = help: Replace with spaces
+
+ℹ Unsafe fix
+4 4 | 	implicit none
+5 5 |     print*, "Don't flag this:	"
+6 6 |     ! Or this:|	|
+7   |-    if	(.true.)	then
+  7 |+    if    (.true.)	then
+8 8 |     	print*, "Mixed tab/space"
+9 9 |     else
+10 10 | 		print*, "Two tabs"
+
+./resources/test/fixtures/portability/PORT031.f90:7:16: PORT031 [*] Invalid tab character
+  |
+5 |     print*, "Don't flag this:    "
+6 |     ! Or this:|    |
+7 |     if    (.true.)    then
+  |               ^ PORT031
+8 |         print*, "Mixed tab/space"
+9 |     else
+  |
+  = help: Replace with spaces
+
+ℹ Unsafe fix
+4 4 | 	implicit none
+5 5 |     print*, "Don't flag this:	"
+6 6 |     ! Or this:|	|
+7   |-    if	(.true.)	then
+  7 |+    if	(.true.)    then
+8 8 |     	print*, "Mixed tab/space"
+9 9 |     else
+10 10 | 		print*, "Two tabs"
+
+./resources/test/fixtures/portability/PORT031.f90:8:5: PORT031 [*] Invalid tab character
+   |
+ 6 |     ! Or this:|    |
+ 7 |     if    (.true.)    then
+ 8 |         print*, "Mixed tab/space"
+   |     ^ PORT031
+ 9 |     else
+10 |         print*, "Two tabs"
+   |
+   = help: Replace with spaces
+
+ℹ Unsafe fix
+5 5 |     print*, "Don't flag this:	"
+6 6 |     ! Or this:|	|
+7 7 |     if	(.true.)	then
+8   |-    	print*, "Mixed tab/space"
+  8 |+        print*, "Mixed tab/space"
+9 9 |     else
+10 10 | 		print*, "Two tabs"
+11 11 |     end if
+
+./resources/test/fixtures/portability/PORT031.f90:10:1: PORT031 [*] Invalid tab character
+   |
+ 8 |         print*, "Mixed tab/space"
+ 9 |     else
+10 |         print*, "Two tabs"
+   | ^ PORT031
+11 |     end if
+12 | end program invalid_tab
+   |
+   = help: Replace with spaces
+
+ℹ Unsafe fix
+7  7  |     if	(.true.)	then
+8  8  |     	print*, "Mixed tab/space"
+9  9  |     else
+10    |-		print*, "Two tabs"
+   10 |+    	print*, "Two tabs"
+11 11 |     end if
+12 12 | end program invalid_tab
+
+./resources/test/fixtures/portability/PORT031.f90:10:2: PORT031 [*] Invalid tab character
+   |
+ 8 |         print*, "Mixed tab/space"
+ 9 |     else
+10 |         print*, "Two tabs"
+   | ^ PORT031
+11 |     end if
+12 | end program invalid_tab
+   |
+   = help: Replace with spaces
+
+ℹ Unsafe fix
+7  7  |     if	(.true.)	then
+8  8  |     	print*, "Mixed tab/space"
+9  9  |     else
+10    |-		print*, "Two tabs"
+   10 |+	    print*, "Two tabs"
+11 11 |     end if
+12 12 | end program invalid_tab

--- a/crates/fortitude_linter/src/rules/portability/star_kinds.rs
+++ b/crates/fortitude_linter/src/rules/portability/star_kinds.rs
@@ -1,8 +1,8 @@
-use crate::ast::{FortitudeNode, dtype_is_plain_number, strip_line_breaks};
+use crate::ast::{dtype_is_plain_number, strip_line_breaks, FortitudeNode};
 use crate::settings::Settings;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{Diagnostic, Fix, FixAvailability, Violation};
-use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -102,6 +102,7 @@
 | PORT011 | [literal-kind](rules/literal-kind.md) | {dtype} kind set with number literal '{literal}' | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | PORT012 | [literal-kind-suffix](rules/literal-kind-suffix.md) | '{literal}' has literal kind suffix '{suffix}' | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | PORT021 | [star-kind](rules/star-kind.md) | '{dtype}{size}' uses non-standard syntax | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| PORT031 | [invalid-tab](rules/invalid-tab.md) | Invalid tab character | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 
 ### Fortitude (FORT)
 

--- a/docs/rules/invalid-tab.md
+++ b/docs/rules/invalid-tab.md
@@ -1,0 +1,12 @@
+# invalid-tab (PORT031)
+Fix is sometimes available.
+
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for the use of tab characters as whitespace
+
+## Why is this bad?
+Tabs are not part of the Fortran standard, and compilers may
+reject the source if using a strict conformance mode (for example,
+`gfortran -std=f2023 -Werror`).


### PR DESCRIPTION
Rendering currently is not great:

```
crates/fortitude_linter/resources/test/fixtures/portability/PORT031.f90:4:1: PORT031 Invalid tab character
  |
2 | ! the horrible whitespace!
3 | program invalid_tab
4 |     implicit none
  | ^ PORT031
5 |     print*, "Don't flag this:    "
6 |     ! Or this:|    |
  |
  = help: Replace with spaces

crates/fortitude_linter/resources/test/fixtures/portability/PORT031.f90:7:7: PORT031 Invalid tab character
  |
5 |     print*, "Don't flag this:    "
6 |     ! Or this:|    |
7 |     if    (.true.)    then
  |       ^ PORT031
8 |         print*, "Mixed tab/space"
9 |     else
  |
  = help: Replace with spaces

crates/fortitude_linter/resources/test/fixtures/portability/PORT031.f90:7:16: PORT031 Invalid tab character
  |
5 |     print*, "Don't flag this:    "
6 |     ! Or this:|    |
7 |     if    (.true.)    then
  |               ^ PORT031
8 |         print*, "Mixed tab/space"
9 |     else
  |
  = help: Replace with spaces

crates/fortitude_linter/resources/test/fixtures/portability/PORT031.f90:8:5: PORT031 Invalid tab character
   |
 6 |     ! Or this:|    |
 7 |     if    (.true.)    then
 8 |         print*, "Mixed tab/space"
   |     ^ PORT031
 9 |     else
10 |         print*, "Two tabs"
   |
   = help: Replace with spaces

crates/fortitude_linter/resources/test/fixtures/portability/PORT031.f90:10:1: PORT031 Invalid tab character
   |
 8 |         print*, "Mixed tab/space"
 9 |     else
10 |         print*, "Two tabs"
   | ^ PORT031
11 |     end if
12 | end program invalid_tab
   |
   = help: Replace with spaces

crates/fortitude_linter/resources/test/fixtures/portability/PORT031.f90:10:2: PORT031 Invalid tab character
   |
 8 |         print*, "Mixed tab/space"
 9 |     else
10 |         print*, "Two tabs"
   | ^ PORT031
11 |     end if
12 | end program invalid_tab
   |
   = help: Replace with spaces
```

I think this is maybe at least partly an `annotate-snippets` issue. Might need to either bump the version or switch to `ruff-annotate-snippets`.

Possibly something even worse, and fix something our side.

The unsafe fix could also be improved with:

a) getting that `Stylist` struct in to improve the tab size,
b) work out if we're indentation and if not, replace with a single space