### PR TITLE
Fix broken editors link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Fortitude can be integrated into text editors and IDEs that support the
 Language Server Protocol (LSP), providing real-time diagnostics and
 code actions for applying fixes as you work.
 
-Please see the [documentation](fortitude.readthedocs.io/en/stable/editors) for
+Please see the [documentation](https://fortitude.readthedocs.io/en/latest/editors/) for
 details on setting this up for your editor.
 
 A VSCode plugin is in development, and will be released shortly.


### PR DESCRIPTION
Looking at LSP integration and noticed a broken link in the README.

I replaced what was being interpreted as a local link with https link.

This had to be pointed to latest rather than stable docs as feature/pages not yet in stable (waiting for 0.8 to be openly released post-holiday period). You may wish to amend this as you see fit to minimise your workload.