### PR TITLE
Disable fix reports when syntax errors are present

### DIFF
--- a/crates/fortitude/tests/check.rs
+++ b/crates/fortitude/tests/check.rs
@@ -758,7 +758,7 @@ end program foo
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] S081 [*] unnecessary semicolon
+    [TEMP_FILE] S081 unnecessary semicolon
       |
     4 |   integer :: i
     5 |   integer :: j
@@ -795,10 +795,9 @@ end program foo
 
         fortitude explain X001,Y002,...
 
-    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: Syntax errors detected in file: [TEMP_FILE] Discarding subsequent violations from the AST.
+    warning: Syntax errors detected in file: [TEMP_FILE] Discarding subsequent violations from the AST and all fixes.
     ",);
     Ok(())
 }
@@ -829,7 +828,7 @@ end program foo
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] S081 [*] unnecessary semicolon
+    [TEMP_FILE] S081 unnecessary semicolon
       |
     4 |   integer :: i
     5 |   integer :: j
@@ -840,7 +839,7 @@ end program foo
       |
       = help: Remove this character
 
-    [TEMP_FILE] S081 [*] unnecessary semicolon
+    [TEMP_FILE] S081 unnecessary semicolon
       |
     6 |   i = 2;
     7 |   j = i ^ 2  ! This is a syntax error
@@ -857,9 +856,9 @@ end program foo
 
         fortitude explain X001,Y002,...
 
-    [*] 2 fixable with the `--fix` option.
 
     ----- stderr -----
+    warning: Syntax errors detected in file: [TEMP_FILE] Discarding all fixes. Some violations from the AST may be unreliable.
     ",);
     Ok(())
 }
@@ -891,7 +890,7 @@ end program foo
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] S081 [*] unnecessary semicolon
+    [TEMP_FILE] S081 unnecessary semicolon
       |
     4 |   integer :: i
     5 |   integer :: j
@@ -902,7 +901,7 @@ end program foo
       |
       = help: Remove this character
 
-    [TEMP_FILE] S081 [*] unnecessary semicolon
+    [TEMP_FILE] S081 unnecessary semicolon
        |
      7 |   ! allow(syntax-error)
      8 |   j = i ^ 2  ! This is a syntax error
@@ -919,10 +918,9 @@ end program foo
 
         fortitude explain X001,Y002,...
 
-    [*] 2 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: Syntax errors detected in file: [TEMP_FILE] Discarding subsequent violations from the AST.
+    warning: Syntax errors detected in file: [TEMP_FILE] Discarding subsequent violations from the AST and all fixes.
     ",);
     Ok(())
 }
@@ -953,7 +951,7 @@ end program foo
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] S081 [*] unnecessary semicolon
+    [TEMP_FILE] S081 unnecessary semicolon
       |
     6 |   i = 2
     7 |   j = i ^ 2  ! This is a syntax error
@@ -970,9 +968,9 @@ end program foo
 
         fortitude explain X001,Y002,...
 
-    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
+    warning: Syntax errors detected in file: [TEMP_FILE] Discarding all fixes. Some violations from the AST may be unreliable.
     warning: Syntax errors detected in file: [TEMP_FILE] No fixes will be applied.
     ",);
     Ok(())
@@ -2316,6 +2314,7 @@ end program foo
 "#,
     )?;
 
+    apply_common_filters!();
     assert_cmd_snapshot!(FortitudeCheck::default()
                          .args(["--select=C003", "--ignore=E001"])
                          .file(&test_file)
@@ -2329,6 +2328,7 @@ end program foo
 
 
     ----- stderr -----
+    warning: Syntax errors detected in file: [TEMP_FILE] Discarding all fixes. Some violations from the AST may be unreliable.
     ");
 
     Ok(())

--- a/crates/fortitude_linter/resources/test/fixtures/obsolescent/OB061.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/obsolescent/OB061.f90
@@ -27,10 +27,6 @@ contains
     character(*, c_char) :: l
     character(len=*, kind=4) :: m
 
-    ! this should raise a syntax error and otherwise be ignored
-    ! allow(syntax-error)
-    character*MAX_LEN n
-
   end subroutine char_input
 
 end program cases


### PR DESCRIPTION
Resolves https://github.com/PlasmaFAIR/fortitude/issues/571

Ensures fixes aren't reported in files containing syntax errors, as they can never be applied. I tried to think of a way to bypass the usual fix loop to apply fixes even if syntax errors were present (provided the user requests this behaviour), but couldn't think of a sensible way to do so.

I had to remove a syntax error that was deliberately inserted into the test for OB061, as otherwise there would be no way to ensure the fixes were being applied appropriately.

I'm not convinced we were handling syntax errors properly in the first place. Ruff is a lot more conservative than us, and will refuse to perform AST checks if any are present. I think our current behaviour should suffice until we implement our own pre-processor, as otherwise Fortitude won't be useful at all for a lot of codes, but after that I would lean towards bumping our Ruff dependency and 'borrowing' their solution to this problem.