### PR TITLE
Fix `missing-intent` for `external` dummy arguments

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C061.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C061.f90
@@ -20,7 +20,8 @@ contains
     integer :: g
   end subroutine bar
 
-  subroutine baz(x)
+  subroutine baz(x, y)
     integer, value :: x  ! Permitted
+    integer, external :: y ! Must not have `intent`
   end subroutine baz
 end module mod_test

--- a/crates/fortitude_linter/src/rules/correctness/intent.rs
+++ b/crates/fortitude_linter/src/rules/correctness/intent.rs
@@ -67,8 +67,8 @@ impl AstRule for MissingIntent {
                     symbol_table.get(param.to_text(src.source_text())?)
                 })
                 .filter(|param| {
-                    // Not allowed intent
-                    !param.type_().is_procedure()
+                    // Procedures are not allowed intent
+                    !(param.type_().is_procedure() || param.has_attribute(AttributeKind::External))
                 })
                 .filter(|param| {
                     // Intent only allowed on pointers after F2003


### PR DESCRIPTION
`external` is the implicit interface version of `procedure`, and so must also not have an `intent`