### PR TITLE
Fix `incorrect-space-before-comment` span to point at whitespace

### DIFF
--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-space-before-comment_S102.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-space-before-comment_S102.f90.snap
@@ -1,13 +1,14 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S102.f90:3:13: S102 [*] need at least 2 spaces before inline comment
   |
 1 | ! This is fine
 2 |  ! This isn't but we'll let it pass
 3 | module mymod! This should be given two extra spaces
-  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S102
+  |             ^ S102
 4 |   implicit none ! This should be given one extra space
 5 |   private  ! This is fine
   |
@@ -22,12 +23,12 @@ expression: diagnostics
 5 5 |   private  ! This is fine
 6 6 |   ! This is fine
 
-./resources/test/fixtures/style/S102.f90:4:17: S102 [*] need at least 2 spaces before inline comment
+./resources/test/fixtures/style/S102.f90:4:16: S102 [*] need at least 2 spaces before inline comment
   |
 2 |  ! This isn't but we'll let it pass
 3 | module mymod! This should be given two extra spaces
 4 |   implicit none ! This should be given one extra space
-  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S102
+  |                ^ S102
 5 |   private  ! This is fine
 6 |   ! This is fine
   |

--- a/crates/fortitude_linter/src/rules/style/whitespace.rs
+++ b/crates/fortitude_linter/src/rules/style/whitespace.rs
@@ -151,7 +151,14 @@ impl AstRule for IncorrectSpaceBeforeComment {
         }
         if whitespace < 2 {
             let edit = Edit::insertion("  "[whitespace..].to_string(), comment_start);
-            return some_vec!(Diagnostic::from_node(Self {}, node).with_fix(Fix::safe_edit(edit)));
+            // Unwraps are fine here because we're guaranteed to be at least 2
+            // characters into the file, and `whitespace` is at most 1
+            let span_start = comment_start
+                .checked_sub(TextSize::try_from(whitespace).unwrap())
+                .unwrap();
+
+            let span = TextRange::new(span_start, comment_start);
+            return some_vec!(Diagnostic::new(Self {}, span).with_fix(Fix::safe_edit(edit)));
         }
         None
     }


### PR DESCRIPTION
Fixes #514

Difference is this:

```diff
    |
  1 | ! This is fine
  2 |  ! This isn't but we'll let it pass
  3 | module mymod! This should be given two extra spaces
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S102
+   |             ^ S102
  4 |   implicit none ! This should be given one extra space
  5 |   private  ! This is fine
    |
    = help: Add extra whitespace
```

This is more in line with ruff