### PR TITLE
Allow some exceptions to `line-too-long`

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/style/S001_line_length_20.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S001_line_length_20.f90
@@ -1,5 +1,10 @@
+! SPDX-License-Identifier: too-long-but-dont-flag
+! This comment is too long
+! https://dont-flag-urls
 program test
   use some_really_long_module_name, only : integer_working_precision
+  use &
+    some_other_really_long_module_but_only_word_on_line_so_dont_flag
   implicit none
   integer(integer_working_precision), parameter, dimension(1) :: a = [1]
 end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__line-too-long_S001_line_length_20.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__line-too-long_S001_line_length_20.f90.snap
@@ -1,22 +1,32 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
-./resources/test/fixtures/style/S001_line_length_20.f90:2:21: S001 line length of 68, exceeds maximum 20
+./resources/test/fixtures/style/S001_line_length_20.f90:2:21: S001 line length of 26, exceeds maximum 20
   |
-1 | program test
-2 |   use some_really_long_module_name, only : integer_working_precision
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S001
-3 |   implicit none
-4 |   integer(integer_working_precision), parameter, dimension(1) :: a = [1]
+1 | ! SPDX-License-Identifier: too-long-but-dont-flag
+2 | ! This comment is too long
+  |                     ^^^^^^ S001
+3 | ! https://dont-flag-urls
+4 | program test
   |
 
-./resources/test/fixtures/style/S001_line_length_20.f90:4:21: S001 line length of 72, exceeds maximum 20
+./resources/test/fixtures/style/S001_line_length_20.f90:5:21: S001 line length of 68, exceeds maximum 20
   |
-2 |   use some_really_long_module_name, only : integer_working_precision
-3 |   implicit none
-4 |   integer(integer_working_precision), parameter, dimension(1) :: a = [1]
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S001
-5 | end program test
+3 | ! https://dont-flag-urls
+4 | program test
+5 |   use some_really_long_module_name, only : integer_working_precision
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S001
+6 |   use &
+7 |     some_other_really_long_module_but_only_word_on_line_so_dont_flag
   |
+
+./resources/test/fixtures/style/S001_line_length_20.f90:9:21: S001 line length of 72, exceeds maximum 20
+   |
+ 7 |     some_other_really_long_module_but_only_word_on_line_so_dont_flag
+ 8 |   implicit none
+ 9 |   integer(integer_working_precision), parameter, dimension(1) :: a = [1]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S001
+10 | end program test
+   |

--- a/docs/rules/line-too-long.md
+++ b/docs/rules/line-too-long.md
@@ -16,10 +16,39 @@ traditional 80, but due to the verbosity of modern Fortran it can sometimes be
 difficult to squeeze lines into that width, especially when using large indents
 and multiple levels of indentation.
 
-Some lines that are longer than the maximum length may be acceptable, such as
-long strings or comments. This is to allow for long URLs or other text that cannot
-be reasonably split across multiple lines.
+In the interest of pragmatism, this rule makes a few exceptions when
+determining whether a line is overlong. Namely, it:
 
-Note that the Fortran standard states a maximum line length of 132 characters,
-and while some modern compilers will support longer lines, for portability it
-is recommended to stay beneath this limit.
+1. Ignores lines that consist of a single "word" (that is, without any
+   whitespace between its characters).
+2. Ignores lines that end with a URL, as long as the URL starts before
+   the line-length threshold.
+3. Ignores SPDX license identifiers and copyright notices (for example, `!
+   SPDX-License-Identifier: MIT`), which are machine-readable and should
+   _not_ wrap over multiple lines.
+
+Note that the Fortran standard states a maximum line length of 132
+characters[^1], and while most modern compilers will support longer lines[^2],
+for portability it is recommended to stay beneath this limit.
+
+## Example
+```f90
+call my_long_subroutine(param1, param2, param3, param4, param5, param6, param7, param8, param9, param10)
+```
+
+Use instead:
+```f90
+call my_long_subroutine(&
+    param1, param2, param3, param4, param5, &
+    param6, param7, param8, param9, param10 &
+)
+```
+
+## Options
+- [`check.line-length`][check.line-length]
+
+[^1]: In F77 this was only 72, and in F2023 it was relaxed to 10,000.
+[^2]: Sometimes a compiler flag is required.
+
+[check.line-length]: ../settings.md#check_line-length
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - footnotes
 
 nav:
   - Overview: index.md


### PR DESCRIPTION
Follows ruff's exceptions

Closes #435