### PR TITLE
Add instructions for using fortitude within the zed editor

### DIFF
--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -313,3 +313,18 @@ You can also use Fortitude in [`lsp-mode`](https://emacs-lsp.github.io/lsp-mode/
   :priority -2
   :add-on? t))
 ```
+
+## Zed
+
+1. Install the [Zed fortitude extension](https://zed.dev/extensions/fortitude)
+2. Add `fortitude` as language server in your settings. For instance, if you want to use it along `fortls` (highly recommended):
+
+```json
+{
+  "languages": {
+    "Fortran": {
+      "language_servers": ["fortls", "fortitude"]
+    },
+  }
+}
+```


### PR DESCRIPTION
Now that the fortitude-zed-extension is available in Zed's extension registry, I believe it's a great idea to include it in the documentation on how to use Fortitude within the [zed editor](https://zed.dev).

Btw, thanks a bunch for the language server in v0.8.0, it makes refactoring legacy code so much easier! :)