### PR TITLE
Add rule S271 `unsorted-uses`

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/style/S271.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S271.f90
@@ -1,24 +1,23 @@
 module test_module
+	use module_z_with_tab, only: fun_z_with_tab
   use module_c, only: fun_c3, &
-                      fun_c2, & !! some_comments
+                      fun_c2, & !! fun_c2 comments
                       fun_c1
-                                use, intrinsic :: iso_fortran_env, ONLY: int32
-    USE module_a, only: fun_a !! some_comments
-    use module_no_only
-					use module_b_with_tab, only: fun_b
-    USE module_z_last, only: fun_z
+  use, intrinsic :: iso_fortran_env, ONLY: int32
+    USE module_a, only: fun_a !! module_a inline comments
+  USE module_z, only: fun_z
+  use module_no_only
 
   use module_single, only: fun_single
 
-use, intrinsic :: iso_fortran_env, only: real64
-        use aa_non_intrinsic_module_d, only: fun_d
-        use, intrinsic :: iso_c_binding, only: fun_i
+  use, intrinsic :: iso_fortran_env, only: real64
+  use aa_non_intrinsic_module_d, only: fun_d
+  use, intrinsic :: iso_c_binding, only: fun_i
 
   implicit none (type, external)
 
   private
   contains
-
   real function compute_something(x, y)
     use custom_math, only: fun_m
     use another_package, only: helper, util
@@ -29,13 +28,11 @@ use, intrinsic :: iso_fortran_env, only: real64
     compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)
   end function compute_something
 
-  subroutine test_comments()
+  subroutine test_comments_as_separator()
     !! fun_c is used for...
-    !! and also for..
     use module_c, only: fun_c
-    ! fun_a is used for...
     use module_a, only: fun_a
     ! fun_b is used for...
     use module_b, only: fun_b
-  end subroutine test_comments
+  end subroutine test_comments_as_separator
 end module test_module

--- a/crates/fortitude_linter/resources/test/fixtures/style/S271.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S271.f90
@@ -35,4 +35,11 @@ module test_module
     ! fun_b is used for...
     use module_b, only: fun_b
   end subroutine test_comments_as_separator
+
+  subroutine test_freeform()
+    use module_f, only: fun_f
+    use module_a
+    use module_z, only: fun_z; use module_b; use module_c, only: fun_c
+    use module_e
+  end subroutine test_freeform
 end module test_module

--- a/crates/fortitude_linter/resources/test/fixtures/style/S271.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S271.f90
@@ -1,0 +1,41 @@
+module test_module
+  use module_c, only: fun_c3, &
+                      fun_c2, & !! some_comments
+                      fun_c1
+                                use, intrinsic :: iso_fortran_env, ONLY: int32
+    USE module_a, only: fun_a !! some_comments
+    use module_no_only
+					use module_b_with_tab, only: fun_b
+    USE module_z_last, only: fun_z
+
+  use module_single, only: fun_single
+
+use, intrinsic :: iso_fortran_env, only: real64
+        use aa_non_intrinsic_module_d, only: fun_d
+        use, intrinsic :: iso_c_binding, only: fun_i
+
+  implicit none (type, external)
+
+  private
+  contains
+
+  real function compute_something(x, y)
+    use custom_math, only: fun_m
+    use another_package, only: helper, util
+    use, intrinsic :: iso_fortran_env, only: real64, int32
+    use, intrinsic :: ieee_arithmetic, only: fun_a
+    real(real64), intent(in) :: x, y
+
+    compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)
+  end function compute_something
+
+  subroutine test_comments()
+    !! fun_c is used for...
+    !! and also for..
+    use module_c, only: fun_c
+    ! fun_a is used for...
+    use module_a, only: fun_a
+    ! fun_b is used for...
+    use module_b, only: fun_b
+  end subroutine test_comments
+end module test_module

--- a/crates/fortitude_linter/resources/test/fixtures/style/S271_ok.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S271_ok.f90
@@ -28,14 +28,6 @@ module test_module
     compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)
   end function compute_something
 
-  subroutine test_comments_as_separator()
-    !! fun_c is used for...
-    use module_a, only: fun_a
-    use module_c, only: fun_c
-    ! fun_b is used for...
-    use module_b, only: fun_b
-  end subroutine test_comments_as_separator
-
   subroutine test_freeform()
     use module_a
     use module_e

--- a/crates/fortitude_linter/resources/test/fixtures/style/S271_ok.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S271_ok.f90
@@ -35,4 +35,11 @@ module test_module
     ! fun_b is used for...
     use module_b, only: fun_b
   end subroutine test_comments_as_separator
+
+  subroutine test_freeform()
+    use module_a
+    use module_e
+    use module_f, only: fun_f
+    use module_z, only: fun_z; use module_b; use module_c, only: fun_c
+  end subroutine test_freeform
 end module test_module

--- a/crates/fortitude_linter/resources/test/fixtures/style/S271_ok.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S271_ok.f90
@@ -1,0 +1,41 @@
+module test_module
+                                use, intrinsic :: iso_fortran_env, ONLY: int32
+    USE module_a, only: fun_a !! some_comments
+					use module_b_with_tab, only: fun_b
+  use module_c, only: fun_c3, &
+                      fun_c2, & !! some_comments
+                      fun_c1
+    use module_no_only
+    USE module_z_last, only: fun_z
+
+  use module_single, only: fun_single
+
+        use, intrinsic :: iso_c_binding, only: fun_i
+use, intrinsic :: iso_fortran_env, only: real64
+        use aa_non_intrinsic_module_d, only: fun_d
+
+  implicit none (type, external)
+
+  private
+  contains
+
+  real function compute_something(x, y)
+    use, intrinsic :: ieee_arithmetic, only: fun_a
+    use, intrinsic :: iso_fortran_env, only: real64, int32
+    use another_package, only: helper, util
+    use custom_math, only: fun_m
+    real(real64), intent(in) :: x, y
+
+    compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)
+  end function compute_something
+
+  subroutine test_comments()
+    ! fun_a is used for...
+    use module_a, only: fun_a
+    ! fun_b is used for...
+    use module_b, only: fun_b
+    !! fun_c is used for...
+    !! and also for..
+    use module_c, only: fun_c
+  end subroutine test_comments
+end module test_module

--- a/crates/fortitude_linter/resources/test/fixtures/style/S271_ok.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S271_ok.f90
@@ -1,24 +1,23 @@
 module test_module
-                                use, intrinsic :: iso_fortran_env, ONLY: int32
-    USE module_a, only: fun_a !! some_comments
-					use module_b_with_tab, only: fun_b
+  use, intrinsic :: iso_fortran_env, ONLY: int32
+    USE module_a, only: fun_a !! module_a inline comments
   use module_c, only: fun_c3, &
-                      fun_c2, & !! some_comments
+                      fun_c2, & !! fun_c2 comments
                       fun_c1
-    use module_no_only
-    USE module_z_last, only: fun_z
+  use module_no_only
+  USE module_z, only: fun_z
+	use module_z_with_tab, only: fun_z_with_tab
 
   use module_single, only: fun_single
 
-        use, intrinsic :: iso_c_binding, only: fun_i
-use, intrinsic :: iso_fortran_env, only: real64
-        use aa_non_intrinsic_module_d, only: fun_d
+  use, intrinsic :: iso_c_binding, only: fun_i
+  use, intrinsic :: iso_fortran_env, only: real64
+  use aa_non_intrinsic_module_d, only: fun_d
 
   implicit none (type, external)
 
   private
   contains
-
   real function compute_something(x, y)
     use, intrinsic :: ieee_arithmetic, only: fun_a
     use, intrinsic :: iso_fortran_env, only: real64, int32
@@ -29,13 +28,11 @@ use, intrinsic :: iso_fortran_env, only: real64
     compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)
   end function compute_something
 
-  subroutine test_comments()
-    ! fun_a is used for...
+  subroutine test_comments_as_separator()
+    !! fun_c is used for...
     use module_a, only: fun_a
+    use module_c, only: fun_c
     ! fun_b is used for...
     use module_b, only: fun_b
-    !! fun_c is used for...
-    !! and also for..
-    use module_c, only: fun_c
-  end subroutine test_comments
+  end subroutine test_comments_as_separator
 end module test_module

--- a/crates/fortitude_linter/src/ast.rs
+++ b/crates/fortitude_linter/src/ast.rs
@@ -100,7 +100,7 @@ pub trait FortitudeNode<'tree> {
     fn ancestors(&self) -> impl Iterator<Item = Node<'_>>;
 
     /// Get the first child with a given name. Returns None if not found.
-    fn child_with_name(&self, name: &str) -> Option<Node<'_>>;
+    fn child_with_name(&self, name: &str) -> Option<Node<'tree>>;
 
     /// Get a named `keyword_argument` child node, if it exists.
     fn kwarg<S: AsRef<str>>(&self, keyword: S, src: &str) -> Option<Node<'_>>;
@@ -175,7 +175,7 @@ impl<'tree1> FortitudeNode<'tree1> for Node<'tree1> {
         AncestorsIterator { node: *self }
     }
 
-    fn child_with_name(&self, name: &str) -> Option<Self> {
+    fn child_with_name(&self, name: &str) -> Option<Node<'tree1>> {
         self.named_children(&mut self.walk())
             .find(|x| x.kind() == name)
     }

--- a/crates/fortitude_linter/src/ast.rs
+++ b/crates/fortitude_linter/src/ast.rs
@@ -136,6 +136,10 @@ pub trait FortitudeNode<'tree> {
 
     /// Check if the node is an if_statement and lacks an end_if_statement child
     fn inline_if_statement(&self) -> bool;
+
+    /// Get the module name from a use statement node.
+    /// Returns None if the node is not a use statement or has no module_name child.
+    fn module_name(&self, src: &str) -> Option<String>;
 }
 
 impl<'tree1> FortitudeNode<'tree1> for Node<'tree1> {
@@ -278,6 +282,15 @@ impl<'tree1> FortitudeNode<'tree1> for Node<'tree1> {
 
     fn inline_if_statement(&self) -> bool {
         self.kind() == "if_statement" && self.child_with_name("end_if_statement").is_none()
+    }
+
+    fn module_name(&self, src: &str) -> Option<String> {
+        if self.kind() != "use_statement" {
+            return None;
+        }
+        self.child_with_name("module_name")?
+            .to_text(src)
+            .map(|s| s.to_string())
     }
 }
 

--- a/crates/fortitude_linter/src/ast.rs
+++ b/crates/fortitude_linter/src/ast.rs
@@ -1,6 +1,8 @@
 pub mod symbol_table;
 pub mod types;
 
+use anyhow::{Result, anyhow};
+use itertools::Itertools;
 use ruff_diagnostics::Edit;
 use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
@@ -140,6 +142,12 @@ pub trait FortitudeNode<'tree> {
     /// Get the module name from a use statement node.
     /// Returns None if the node is not a use statement or has no module_name child.
     fn module_name(&self, src: &str) -> Option<String>;
+
+    /// Get preceding comment block, if it exists.
+    ///
+    /// This is the set of comments without interleaving blank lines that starts
+    /// immediately before this node
+    fn prev_attached_comment_block(&self, src: &str) -> Option<CommentBlock>;
 }
 
 impl<'tree1> FortitudeNode<'tree1> for Node<'tree1> {
@@ -292,6 +300,26 @@ impl<'tree1> FortitudeNode<'tree1> for Node<'tree1> {
             .to_text(src)
             .map(|s| s.to_string())
     }
+
+    fn prev_attached_comment_block(&self, src: &str) -> Option<CommentBlock> {
+        let mut comments = Vec::new();
+        let mut prev_comment = *self;
+
+        while let Some(comment) = prev_comment.prev_named_sibling() {
+            if comment.kind() != "comment" {
+                break;
+            }
+            if comment.end_position().row != prev_comment.start_position().row.saturating_sub(1) {
+                break;
+            }
+            comments.push(comment);
+            prev_comment = comment;
+        }
+
+        // We've worked backwards, so reverse to get in correct order
+        comments.reverse();
+        CommentBlock::try_from_node_range(comments, src).ok()
+    }
 }
 
 /// Strip line breaks from a string of Fortran code.
@@ -306,4 +334,144 @@ pub fn dtype_is_plain_number(dtype: &str) -> bool {
         dtype.to_lowercase().as_str(),
         "integer" | "real" | "logical" | "complex"
     )
+}
+
+/// A block of consecutive comments (no blank lines)
+#[derive(Debug, Clone)]
+pub struct CommentBlock {
+    text_range: TextRange,
+    start_row: usize,
+    end_row: usize,
+    text: String,
+}
+
+impl CommentBlock {
+    pub fn try_from_node_range(nodes: Vec<Node>, src: &str) -> Result<Self> {
+        if let Some(non_comment) = nodes.iter().find(|node| node.kind() != "comment") {
+            return Err(anyhow!(
+                "Unexpected non-comment '{non_comment:?}' in comment block"
+            ));
+        }
+        if nodes.is_empty() {
+            return Err(anyhow!("CommentBlock requires at least one node"));
+        }
+        // Have at least one, so can get first and last
+        let first = nodes.first().unwrap();
+        let last = nodes.last().unwrap();
+
+        let start_textsize = first.start_textsize();
+        let end_textsize = last.end_textsize();
+        let text_range = TextRange::new(start_textsize, end_textsize);
+
+        let start_row = first.start_position().row;
+        let end_row = last.end_position().row;
+
+        let text = nodes
+            .iter()
+            .filter_map(|node| node.to_text(src))
+            .collect_vec()
+            .join("\n");
+
+        Ok(Self {
+            text_range,
+            start_row,
+            end_row,
+            text,
+        })
+    }
+
+    pub fn start_row(&self) -> usize {
+        self.start_row
+    }
+
+    pub fn end_row(&self) -> usize {
+        self.end_row
+    }
+
+    pub fn text(&self) -> &str {
+        self.text.as_ref()
+    }
+}
+
+impl TextRanged for CommentBlock {
+    fn textrange(&self) -> TextRange {
+        self.text_range
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::{Context, Result};
+    use textwrap::dedent;
+    use tree_sitter::Parser;
+
+    #[test]
+    fn test_comment_block() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = dedent(
+            r#"
+          ! one
+          ! two
+          program foo
+
+          contains
+
+            ! not this
+
+            ! but this
+            subroutine bar()
+            end subroutine bar
+          end program foo
+
+          ! not this either
+
+          module zing
+          end module zing
+
+          "#,
+        );
+
+        let tree = parser.parse(&code, None).context("Failed to parse")?;
+
+        let program_node = tree
+            .root_node()
+            .child_with_name("program")
+            .context("Missing program node")?;
+        let program_comments = program_node
+            .prev_attached_comment_block(&code)
+            .context("Couldn't find program comment block")?;
+
+        let expected_text = "! one\n! two";
+        assert_eq!(
+            program_comments.textrange(),
+            TextRange::new(
+                TextSize::new(1),
+                TextSize::new(expected_text.len().saturating_add(1).try_into()?)
+            )
+        );
+        assert_eq!(program_comments.text(), expected_text);
+
+        let subroutine_node = program_node
+            .descendants()
+            .find(|node| node.kind() == "subroutine")
+            .context("Missing subroutine node")?;
+        let subroutine_comments = subroutine_node
+            .prev_attached_comment_block(&code)
+            .context("Couldn't find subroutine comment block")?;
+        let expected_text = "! but this";
+        assert_eq!(subroutine_comments.text(), expected_text);
+
+        let module_node = tree
+            .root_node()
+            .child_with_name("module")
+            .context("Missing module node")?;
+        assert!(module_node.prev_attached_comment_block(&code).is_none());
+
+        Ok(())
+    }
 }

--- a/crates/fortitude_linter/src/rules/correctness/use_statements.rs
+++ b/crates/fortitude_linter/src/rules/correctness/use_statements.rs
@@ -49,10 +49,7 @@ impl AstRule for UseAll {
         src: &SourceFile,
         _symbol_table: &SymbolTables,
     ) -> Option<Vec<Diagnostic>> {
-        let module_name = node
-            .child_with_name("module_name")?
-            .to_text(src.source_text())?
-            .to_lowercase();
+        let module_name = node.module_name(src.source_text())?.to_lowercase();
 
         if !settings
             .use_statements
@@ -125,10 +122,7 @@ impl AstRule for MissingIntrinsic {
         if settings.target_std < FortranStandard::F2003 {
             return None;
         }
-        let module_name = node
-            .child_with_name("module_name")?
-            .to_text(src.source_text())?
-            .to_lowercase();
+        let module_name = node.module_name(src.source_text())?.to_lowercase();
 
         if INTRINSIC_MODULES.iter().any(|&m| m == module_name)
             && node

--- a/crates/fortitude_linter/src/rules/mod.rs
+++ b/crates/fortitude_linter/src/rules/mod.rs
@@ -158,6 +158,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Style, "261") => (RuleGroup::Preview, None, Default, style::inconsistent_dimension::InconsistentArrayDeclaration),
         (Style, "262") => (RuleGroup::Preview, None, Optional, style::inconsistent_dimension::MixedScalarArrayDeclaration),
         (Style, "263") => (RuleGroup::Preview, None, Optional, style::inconsistent_dimension::BadArrayDeclaration),
+        (Style, "271") => (RuleGroup::Preview, Ast, Default, style::use_statement::UnsortedUses),
         (Style, "901") => (RuleGroup::Preview, Ast, Optional, style::too_complex::TooComplex),
 
         // obsolescent

--- a/crates/fortitude_linter/src/rules/modernisation/mpi.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/mpi.rs
@@ -93,13 +93,10 @@ impl AstRule for OldMPIModule {
     fn check(
         _settings: &CheckSettings,
         node: &Node,
-        _src: &SourceFile,
+        src: &SourceFile,
         _symbol_table: &SymbolTables,
     ) -> Option<Vec<Diagnostic>> {
-        let module_name = node
-            .child_with_name("module_name")?
-            .to_text(_src.source_text())?
-            .to_lowercase();
+        let module_name = node.module_name(src.source_text())?.to_lowercase();
 
         if module_name == "mpi" {
             return some_vec![Diagnostic::from_node(OldMPIModule {}, node)];

--- a/crates/fortitude_linter/src/rules/style/mod.rs
+++ b/crates/fortitude_linter/src/rules/style/mod.rs
@@ -10,6 +10,7 @@ pub mod line_length;
 pub(crate) mod semicolons;
 pub mod strings;
 pub mod too_complex;
+pub(crate) mod use_statement;
 pub mod useless_return;
 pub(crate) mod whitespace;
 
@@ -56,6 +57,7 @@ mod tests {
     #[test_case(Rule::SuperfluousElseCycle, Path::new("S253.f90"))]
     #[test_case(Rule::SuperfluousElseExit, Path::new("S254.f90"))]
     #[test_case(Rule::SuperfluousElseStop, Path::new("S255.f90"))]
+    #[test_case(Rule::UnsortedUses, Path::new("S271.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(
@@ -68,6 +70,7 @@ mod tests {
     }
 
     #[test_case(Rule::SuperfluousImplicitNone, Path::new("S201_ok.f90"))]
+    #[test_case(Rule::UnsortedUses, Path::new("S271_ok.f90"))]
     fn rules_pass(rule_code: Rule, path: &Path) -> Result<()> {
         let diagnostics = test_path(
             Path::new("style").join(path).as_path(),

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S271.f90:2:2: S271 [*] `use` statements are not sorted
   |
@@ -13,22 +14,19 @@ expression: diagnostics
   = help: Sort `use` statements
 
 ℹ Safe fix
-1  1  | module test_module
-2     |-	use module_z_with_tab, only: fun_z_with_tab
-   2  |+  use, intrinsic :: iso_fortran_env, ONLY: int32
-   3  |+    USE module_a, only: fun_a !! module_a inline comments
-3  4  |   use module_c, only: fun_c3, &
-4  5  |                       fun_c2, & !! fun_c2 comments
-5  6  |                       fun_c1
-6     |-  use, intrinsic :: iso_fortran_env, ONLY: int32
-7     |-    USE module_a, only: fun_a !! module_a inline comments
-   7  |+  use module_no_only
-8  8  |   USE module_z, only: fun_z
-9     |-  use module_no_only
-   9  |+	use module_z_with_tab, only: fun_z_with_tab
+1 1 | module test_module
+2   |-	use module_z_with_tab, only: fun_z_with_tab
+  2 |+  use, intrinsic :: iso_fortran_env, ONLY: int32
+  3 |+    USE module_a, only: fun_a !! module_a inline comments
+3 4 |   use module_c, only: fun_c3, &
+4 5 |                       fun_c2, & !! fun_c2 comments
+5 6 |                       fun_c1
+6   |-  use, intrinsic :: iso_fortran_env, ONLY: int32
+7   |-    USE module_a, only: fun_a !! module_a inline comments
+  7 |+	use module_z_with_tab, only: fun_z_with_tab
+8 8 |   USE module_z, only: fun_z
+9 9 |   use module_no_only
 10 10 | 
-11 11 |   use module_single, only: fun_single
-12 12 | 
 
 ./resources/test/fixtures/style/S271.f90:13:3: S271 [*] `use` statements are not sorted
    |
@@ -79,27 +77,31 @@ expression: diagnostics
 27 27 | 
 28 28 |     compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)
 
-./resources/test/fixtures/style/S271.f90:33:5: S271 [*] `use` statements are not sorted
+./resources/test/fixtures/style/S271.f90:32:5: S271 [*] `use` statements are not sorted
    |
-31 |   subroutine test_comments_as_separator()
-32 |     !! fun_c is used for...
-33 |     use module_c, only: fun_c
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ S271
-34 |     use module_a, only: fun_a
-35 |     ! fun_b is used for...
+31 |     subroutine test_comments_as_separator()
+32 | /     !! fun_c is used for...
+33 | |     use module_c, only: fun_c
+   | |_____________________________^ S271
+34 |       use module_a, only: fun_a
+35 |       ! fun_b is used for...
    |
    = help: Sort `use` statements
 
 ℹ Safe fix
+29 29 |   end function compute_something
 30 30 | 
 31 31 |   subroutine test_comments_as_separator()
-32 32 |     !! fun_c is used for...
-   33 |+    use module_a, only: fun_a
-33 34 |     use module_c, only: fun_c
-34    |-    use module_a, only: fun_a
-35 35 |     ! fun_b is used for...
-36 36 |     use module_b, only: fun_b
+32    |-    !! fun_c is used for...
+33    |-    use module_c, only: fun_c
+34 32 |     use module_a, only: fun_a
+35 33 |     ! fun_b is used for...
+36 34 |     use module_b, only: fun_b
+   35 |+    !! fun_c is used for...
+   36 |+    use module_c, only: fun_c
 37 37 |   end subroutine test_comments_as_separator
+38 38 | 
+39 39 |   subroutine test_freeform()
 
 ./resources/test/fixtures/style/S271.f90:40:5: S271 [*] `use` statements are not sorted
    |

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
@@ -1,0 +1,79 @@
+---
+source: crates/fortitude_linter/src/rules/style/mod.rs
+expression: diagnostics
+---
+./resources/test/fixtures/style/S271.f90:2:3: S271 [*] `use` statements are not sorted
+  |
+1 |   module test_module
+2 | /   use module_c, only: fun_c3, &
+3 | |                       fun_c2, &
+4 | |                       fun_c1
+  | |____________________________^ S271
+5 |                                   use, intrinsic :: iso_fortran_env, ONLY: int32
+6 |       USE module_a, only: fun_a
+  |
+  = help: Sort `use` statements
+
+ℹ Safe fix
+1 1 | module test_module
+  2 |+                                use, intrinsic :: iso_fortran_env, ONLY: int32
+  3 |+    USE module_a, only: fun_a
+  4 |+					use module_b_with_tab, only: fun_b
+2 5 |   use module_c, only: fun_c3, &
+3 6 |                       fun_c2, &
+4 7 |                       fun_c1
+5   |-                                use, intrinsic :: iso_fortran_env, ONLY: int32
+6   |-    USE module_a, only: fun_a
+7 8 |     use module_no_only
+8   |-					use module_b_with_tab, only: fun_b
+9 9 |     USE module_z_last, only: fun_z
+10 10 | 
+11 11 |   use module_single, only: fun_single
+
+./resources/test/fixtures/style/S271.f90:13:1: S271 [*] `use` statements are not sorted
+   |
+11 |   use module_single, only: fun_single
+12 |
+13 | use, intrinsic :: iso_fortran_env, only: real64
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S271
+14 |         use aa_non_intrinsic_module_d, only: fun_d
+15 |         use, intrinsic :: iso_c_binding, only: fun_i
+   |
+   = help: Sort `use` statements
+
+ℹ Safe fix
+10 10 | 
+11 11 |   use module_single, only: fun_single
+12 12 | 
+   13 |+        use, intrinsic :: iso_c_binding, only: fun_i
+13 14 | use, intrinsic :: iso_fortran_env, only: real64
+14 15 |         use aa_non_intrinsic_module_d, only: fun_d
+15    |-        use, intrinsic :: iso_c_binding, only: fun_i
+16 16 | 
+17 17 |   implicit none (type, external)
+18 18 | 
+
+./resources/test/fixtures/style/S271.f90:23:5: S271 [*] `use` statements are not sorted
+   |
+22 |   real function compute_something(x, y)
+23 |     use custom_math, only: fun_m
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S271
+24 |     use another_package, only: helper, util
+25 |     use, intrinsic :: iso_fortran_env, only: real64, int32
+   |
+   = help: Sort `use` statements
+
+ℹ Safe fix
+20 20 |   contains
+21 21 |
+22 22 |   real function compute_something(x, y)
+   23 |+    use, intrinsic :: ieee_arithmetic, only: fun_a
+   24 |+    use, intrinsic :: iso_fortran_env, only: real64, int32
+   25 |+    use another_package, only: helper, util
+23 26 |     use custom_math, only: fun_m
+24    |-    use another_package, only: helper, util
+25    |-    use, intrinsic :: iso_fortran_env, only: real64, int32
+26    |-    use, intrinsic :: ieee_arithmetic, only: fun_a
+27 27 |     real(real64), intent(in) :: x, y
+28 28 | 
+29 29 |     compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
@@ -2,42 +2,42 @@
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 ---
-./resources/test/fixtures/style/S271.f90:2:3: S271 [*] `use` statements are not sorted
+./resources/test/fixtures/style/S271.f90:2:2: S271 [*] `use` statements are not sorted
   |
-1 |   module test_module
-2 | /   use module_c, only: fun_c3, &
-3 | |                       fun_c2, &
-4 | |                       fun_c1
-  | |____________________________^ S271
-5 |                                   use, intrinsic :: iso_fortran_env, ONLY: int32
-6 |       USE module_a, only: fun_a
+1 | module test_module
+2 |     use module_z_with_tab, only: fun_z_with_tab
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S271
+3 |   use module_c, only: fun_c3, &
+4 |                       fun_c2, & !! fun_c2 comments
   |
   = help: Sort `use` statements
 
 ℹ Safe fix
-1 1 | module test_module
-  2 |+                                use, intrinsic :: iso_fortran_env, ONLY: int32
-  3 |+    USE module_a, only: fun_a
-  4 |+					use module_b_with_tab, only: fun_b
-2 5 |   use module_c, only: fun_c3, &
-3 6 |                       fun_c2, &
-4 7 |                       fun_c1
-5   |-                                use, intrinsic :: iso_fortran_env, ONLY: int32
-6   |-    USE module_a, only: fun_a
-7 8 |     use module_no_only
-8   |-					use module_b_with_tab, only: fun_b
-9 9 |     USE module_z_last, only: fun_z
+1  1  | module test_module
+2     |-	use module_z_with_tab, only: fun_z_with_tab
+   2  |+  use, intrinsic :: iso_fortran_env, ONLY: int32
+   3  |+    USE module_a, only: fun_a !! module_a inline comments
+3  4  |   use module_c, only: fun_c3, &
+4  5  |                       fun_c2, & !! fun_c2 comments
+5  6  |                       fun_c1
+6     |-  use, intrinsic :: iso_fortran_env, ONLY: int32
+7     |-    USE module_a, only: fun_a !! module_a inline comments
+   7  |+  use module_no_only
+8  8  |   USE module_z, only: fun_z
+9     |-  use module_no_only
+   9  |+	use module_z_with_tab, only: fun_z_with_tab
 10 10 | 
 11 11 |   use module_single, only: fun_single
+12 12 | 
 
-./resources/test/fixtures/style/S271.f90:13:1: S271 [*] `use` statements are not sorted
+./resources/test/fixtures/style/S271.f90:13:3: S271 [*] `use` statements are not sorted
    |
 11 |   use module_single, only: fun_single
 12 |
-13 | use, intrinsic :: iso_fortran_env, only: real64
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S271
-14 |         use aa_non_intrinsic_module_d, only: fun_d
-15 |         use, intrinsic :: iso_c_binding, only: fun_i
+13 |   use, intrinsic :: iso_fortran_env, only: real64
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S271
+14 |   use aa_non_intrinsic_module_d, only: fun_d
+15 |   use, intrinsic :: iso_c_binding, only: fun_i
    |
    = help: Sort `use` statements
 
@@ -45,35 +45,58 @@ expression: diagnostics
 10 10 | 
 11 11 |   use module_single, only: fun_single
 12 12 | 
-   13 |+        use, intrinsic :: iso_c_binding, only: fun_i
-13 14 | use, intrinsic :: iso_fortran_env, only: real64
-14 15 |         use aa_non_intrinsic_module_d, only: fun_d
-15    |-        use, intrinsic :: iso_c_binding, only: fun_i
+   13 |+  use, intrinsic :: iso_c_binding, only: fun_i
+13 14 |   use, intrinsic :: iso_fortran_env, only: real64
+14 15 |   use aa_non_intrinsic_module_d, only: fun_d
+15    |-  use, intrinsic :: iso_c_binding, only: fun_i
 16 16 | 
 17 17 |   implicit none (type, external)
 18 18 | 
 
-./resources/test/fixtures/style/S271.f90:23:5: S271 [*] `use` statements are not sorted
+./resources/test/fixtures/style/S271.f90:22:5: S271 [*] `use` statements are not sorted
    |
-22 |   real function compute_something(x, y)
-23 |     use custom_math, only: fun_m
+20 |   contains
+21 |   real function compute_something(x, y)
+22 |     use custom_math, only: fun_m
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S271
-24 |     use another_package, only: helper, util
-25 |     use, intrinsic :: iso_fortran_env, only: real64, int32
+23 |     use another_package, only: helper, util
+24 |     use, intrinsic :: iso_fortran_env, only: real64, int32
    |
    = help: Sort `use` statements
 
 ℹ Safe fix
+19 19 |   private
 20 20 |   contains
-21 21 |
-22 22 |   real function compute_something(x, y)
-   23 |+    use, intrinsic :: ieee_arithmetic, only: fun_a
-   24 |+    use, intrinsic :: iso_fortran_env, only: real64, int32
-   25 |+    use another_package, only: helper, util
-23 26 |     use custom_math, only: fun_m
-24    |-    use another_package, only: helper, util
-25    |-    use, intrinsic :: iso_fortran_env, only: real64, int32
-26    |-    use, intrinsic :: ieee_arithmetic, only: fun_a
-27 27 |     real(real64), intent(in) :: x, y
-28 28 | 
-29 29 |     compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)
+21 21 |   real function compute_something(x, y)
+   22 |+    use, intrinsic :: ieee_arithmetic, only: fun_a
+   23 |+    use, intrinsic :: iso_fortran_env, only: real64, int32
+   24 |+    use another_package, only: helper, util
+22 25 |     use custom_math, only: fun_m
+23    |-    use another_package, only: helper, util
+24    |-    use, intrinsic :: iso_fortran_env, only: real64, int32
+25    |-    use, intrinsic :: ieee_arithmetic, only: fun_a
+26 26 |     real(real64), intent(in) :: x, y
+27 27 | 
+28 28 |     compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)
+
+./resources/test/fixtures/style/S271.f90:33:5: S271 [*] `use` statements are not sorted
+   |
+31 |   subroutine test_comments_as_separator()
+32 |     !! fun_c is used for...
+33 |     use module_c, only: fun_c
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ S271
+34 |     use module_a, only: fun_a
+35 |     ! fun_b is used for...
+   |
+   = help: Sort `use` statements
+
+ℹ Safe fix
+30 30 | 
+31 31 |   subroutine test_comments_as_separator()
+32 32 |     !! fun_c is used for...
+   33 |+    use module_a, only: fun_a
+33 34 |     use module_c, only: fun_c
+34    |-    use module_a, only: fun_a
+35 35 |     ! fun_b is used for...
+36 36 |     use module_b, only: fun_b
+37 37 |   end subroutine test_comments_as_separator

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
@@ -5,11 +5,16 @@ snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S271.f90:2:2: S271 [*] `use` statements are not sorted
   |
-1 | module test_module
-2 |     use module_z_with_tab, only: fun_z_with_tab
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S271
-3 |   use module_c, only: fun_c3, &
-4 |                       fun_c2, & !! fun_c2 comments
+1 |   module test_module
+2 | /     use module_z_with_tab, only: fun_z_with_tab
+3 | |   use module_c, only: fun_c3, &
+4 | |                       fun_c2, & !! fun_c2 comments
+5 | |                       fun_c1
+6 | |   use, intrinsic :: iso_fortran_env, ONLY: int32
+7 | |     USE module_a, only: fun_a !! module_a inline comments
+  | |_____________________________^ S271
+8 |     USE module_z, only: fun_z
+9 |     use module_no_only
   |
   = help: Sort `use` statements
 
@@ -30,12 +35,14 @@ snapshot_kind: text
 
 ./resources/test/fixtures/style/S271.f90:13:3: S271 [*] `use` statements are not sorted
    |
-11 |   use module_single, only: fun_single
+11 |     use module_single, only: fun_single
 12 |
-13 |   use, intrinsic :: iso_fortran_env, only: real64
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S271
-14 |   use aa_non_intrinsic_module_d, only: fun_d
-15 |   use, intrinsic :: iso_c_binding, only: fun_i
+13 | /   use, intrinsic :: iso_fortran_env, only: real64
+14 | |   use aa_non_intrinsic_module_d, only: fun_d
+15 | |   use, intrinsic :: iso_c_binding, only: fun_i
+   | |______________________________________________^ S271
+16 |
+17 |     implicit none (type, external)
    |
    = help: Sort `use` statements
 
@@ -53,12 +60,14 @@ snapshot_kind: text
 
 ./resources/test/fixtures/style/S271.f90:22:5: S271 [*] `use` statements are not sorted
    |
-20 |   contains
-21 |   real function compute_something(x, y)
-22 |     use custom_math, only: fun_m
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S271
-23 |     use another_package, only: helper, util
-24 |     use, intrinsic :: iso_fortran_env, only: real64, int32
+20 |     contains
+21 |     real function compute_something(x, y)
+22 | /     use custom_math, only: fun_m
+23 | |     use another_package, only: helper, util
+24 | |     use, intrinsic :: iso_fortran_env, only: real64, int32
+25 | |     use, intrinsic :: ieee_arithmetic, only: fun_a
+   | |__________________________________________________^ S271
+26 |       real(real64), intent(in) :: x, y
    |
    = help: Sort `use` statements
 
@@ -82,9 +91,11 @@ snapshot_kind: text
 31 |     subroutine test_comments_as_separator()
 32 | /     !! fun_c is used for...
 33 | |     use module_c, only: fun_c
+34 | |     use module_a, only: fun_a
+35 | |     ! fun_b is used for...
+36 | |     use module_b, only: fun_b
    | |_____________________________^ S271
-34 |       use module_a, only: fun_a
-35 |       ! fun_b is used for...
+37 |     end subroutine test_comments_as_separator
    |
    = help: Sort `use` statements
 
@@ -105,11 +116,14 @@ snapshot_kind: text
 
 ./resources/test/fixtures/style/S271.f90:40:5: S271 [*] `use` statements are not sorted
    |
-39 |   subroutine test_freeform()
-40 |     use module_f, only: fun_f
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ S271
-41 |     use module_a
-42 |     use module_z, only: fun_z; use module_b; use module_c, only: fun_c
+39 |     subroutine test_freeform()
+40 | /     use module_f, only: fun_f
+41 | |     use module_a
+42 | |     use module_z, only: fun_z; use module_b; use module_c, only: fun_c
+43 | |     use module_e
+   | |________________^ S271
+44 |     end subroutine test_freeform
+45 |   end module test_module
    |
    = help: Sort `use` statements
 

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
@@ -100,3 +100,26 @@ expression: diagnostics
 35 35 |     ! fun_b is used for...
 36 36 |     use module_b, only: fun_b
 37 37 |   end subroutine test_comments_as_separator
+
+./resources/test/fixtures/style/S271.f90:40:5: S271 [*] `use` statements are not sorted
+   |
+39 |   subroutine test_freeform()
+40 |     use module_f, only: fun_f
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ S271
+41 |     use module_a
+42 |     use module_z, only: fun_z; use module_b; use module_c, only: fun_c
+   |
+   = help: Sort `use` statements
+
+ℹ Safe fix
+37 37 |   end subroutine test_comments_as_separator
+38 38 | 
+39 39 |   subroutine test_freeform()
+   40 |+    use module_a
+   41 |+    use module_e
+40 42 |     use module_f, only: fun_f
+41    |-    use module_a
+42 43 |     use module_z, only: fun_z; use module_b; use module_c, only: fun_c
+43    |-    use module_e
+44 44 |   end subroutine test_freeform
+45 45 | end module test_module

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -5,7 +5,7 @@ use crate::traits::TextRanged;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_source_file::SourceFile;
+use ruff_source_file::{LineEnding, SourceFile, find_newline};
 use ruff_text_size::{TextRange, TextSize};
 use tree_sitter::Node;
 
@@ -133,9 +133,8 @@ fn extract_use_statement_data(node: &Node, src: &SourceFile) -> UseStatementData
     let node_text = node.to_text(src.source_text()).unwrap_or("");
     let after_node = &src.source_text()[range.end().to_usize()..];
     // Capture any inline comment after the node by reading everything between the end of the node and the next newline.
-    let line_remainder = after_node
-        .find('\n')
-        .map(|pos| &after_node[..pos])
+    let line_remainder = find_newline(after_node)
+        .map(|(pos, _)| &after_node[..pos])
         .unwrap_or("");
     let text = format!("{}{}{}", node.indentation(src), node_text, line_remainder);
 
@@ -189,11 +188,17 @@ fn check_and_fix_block(block: &[Node], src: &SourceFile) -> Option<Diagnostic> {
         first.textrange().start() - TextSize::from(first.indentation(src).len() as u32);
     let block_end = block.last()?.textrange().end();
 
+    // Preserve the line ending style of the source file (LF or CRLF)
+    let nl = find_newline(src.source_text())
+        .map(|(_, ending)| ending)
+        .unwrap_or(LineEnding::Lf)
+        .as_str();
+
     let mut replacement = String::new();
     for (i, stmt) in sorted.iter().enumerate() {
         replacement.push_str(&stmt.text);
         if i < sorted.len() - 1 {
-            replacement.push('\n');
+            replacement.push_str(nl);
         }
     }
 

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -65,7 +65,7 @@ impl AstRule for UnsortedUses {
         }
 
         // Group use statements into blocks separated by empty lines
-        let blocks = group_use_statements_into_blocks(&use_statements, src);
+        let blocks = group_use_statements_into_blocks(&use_statements);
 
         let mut diagnostics = Vec::new();
 
@@ -87,22 +87,18 @@ impl AstRule for UnsortedUses {
     }
 }
 
-fn group_use_statements_into_blocks<'a>(
-    use_statements: &[Node<'a>],
-    src: &SourceFile,
-) -> Vec<Vec<Node<'a>>> {
+fn group_use_statements_into_blocks<'a>(use_statements: &[Node<'a>]) -> Vec<Vec<Node<'a>>> {
     let mut blocks = Vec::new();
     let mut current_block = Vec::new();
 
     for (i, stmt) in use_statements.iter().enumerate() {
         current_block.push(*stmt);
 
-        // Check if this is the last statement or if the next statement is separated by an empty line
-        let is_last = i == use_statements.len() - 1;
-        if !is_last {
-            let next_stmt = &use_statements[i + 1];
-            if !are_statements_adjacent(stmt, next_stmt, src) {
-                // Start a new block
+        if let Some(next_stmt) = use_statements.get(i + 1) {
+            // If the next statement is not on the immediately following line
+            // (blank line, comment, or any other content acts as a block separator),
+            // close the current block and start a new one.
+            if !are_statements_adjacent(stmt, next_stmt) {
                 blocks.push(current_block);
                 current_block = Vec::new();
             }
@@ -116,16 +112,12 @@ fn group_use_statements_into_blocks<'a>(
     blocks
 }
 
-fn are_statements_adjacent(stmt1: &Node, stmt2: &Node, src: &SourceFile) -> bool {
-    let range1 = stmt1.textrange();
-    let range2 = stmt2.textrange();
-
-    // Get the text between the end of stmt1 and start of stmt2
-    let between_range = TextRange::new(range1.end(), range2.start());
-    let between_text = src.slice(between_range);
-
-    // Check if there's only whitespace (no empty lines)
-    !between_text.contains("\n\n") && !between_text.contains("\r\n\r\n")
+/// Two use statements are considered adjacent if the second one starts
+/// on the line immediately following the end of the first one.
+fn are_statements_adjacent(stmt1: &Node, stmt2: &Node) -> bool {
+    let line1 = stmt1.end_position().row;
+    let line2 = stmt2.start_position().row;
+    line2 == line1 + 1
 }
 
 #[derive(Clone)]
@@ -133,6 +125,35 @@ struct UseStatementData {
     text: String,
     module_name: String,
     is_intrinsic: bool,
+}
+
+fn extract_use_statement_data(node: &Node, src: &SourceFile) -> UseStatementData {
+    // Build full line text: indentation + node text + inline comment if any
+    let range = node.textrange();
+    let node_text = node.to_text(src.source_text()).unwrap_or("");
+    let after_node = &src.source_text()[range.end().to_usize()..];
+    // Capture any inline comment after the node by reading everything between the end of the node and the next newline.
+    let line_remainder = after_node
+        .find('\n')
+        .map(|pos| &after_node[..pos])
+        .unwrap_or("");
+    let text = format!("{}{}{}", node.indentation(src), node_text, line_remainder);
+
+    let module_name = node
+        .module_name(src.source_text())
+        // Fortran is case-insensitive, normalize to lowercase for consistent sorting
+        .map(|s| s.to_lowercase())
+        .unwrap_or_default();
+
+    let is_intrinsic = node
+        .children(&mut node.walk())
+        .any(|child| child.to_text(src.source_text()) == Some("intrinsic"));
+
+    UseStatementData {
+        text,
+        module_name,
+        is_intrinsic,
+    }
 }
 
 fn check_and_fix_block(block: &[Node], src: &SourceFile) -> Option<Diagnostic> {
@@ -143,33 +164,12 @@ fn check_and_fix_block(block: &[Node], src: &SourceFile) -> Option<Diagnostic> {
     // Extract module name, intrinsic status and full line text
     let statements_with_data: Vec<UseStatementData> = block
         .iter()
-        .map(|node| {
-            // Reconstruct the full line by prepending the node's indentation to its text.
-            let indentation = node.indentation(src);
-            let node_text = node.to_text(src.source_text()).unwrap_or("");
-            let text = format!("{}{}", indentation, node_text);
-
-            let module_name = node
-                .module_name(src.source_text())
-                // Fortran is case-insensitive, normalize to lowercase for consistent sorting
-                .map(|s| s.to_lowercase())
-                .unwrap_or_default();
-
-            let is_intrinsic = node
-                .children(&mut node.walk())
-                .any(|child| child.to_text(src.source_text()) == Some("intrinsic"));
-
-            UseStatementData {
-                text,
-                module_name,
-                is_intrinsic,
-            }
-        })
+        .map(|node| extract_use_statement_data(node, src))
         .collect();
 
     // Sort statements
     let mut sorted = statements_with_data.clone();
-    sorted.sort_by(|a, b| compare_use_statements(&a, &b));
+    sorted.sort_by(|a, b| compare_use_statements(a, b));
 
     // Check if already sorted
     let is_sorted = statements_with_data
@@ -184,9 +184,9 @@ fn check_and_fix_block(block: &[Node], src: &SourceFile) -> Option<Diagnostic> {
     // The textrange of a node starts after its indentation.
     // We need to include the indentation in the replacement range,
     // so we walk back to the beginning of the line.
-    let block_indentation = block.first()?.indentation(src);
+    let first = block.first()?;
     let block_start =
-        block.first()?.textrange().start() - TextSize::from(block_indentation.len() as u32);
+        first.textrange().start() - TextSize::from(first.indentation(src).len() as u32);
     let block_end = block.last()?.textrange().end();
 
     let mut replacement = String::new();

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -54,10 +54,23 @@ impl AstRule for UnsortedUses {
         src: &SourceFile,
         _symbol_table: &SymbolTables,
     ) -> Option<Vec<Diagnostic>> {
+        // Collect only the first `use_statement` per line
+        let mut last_row: Option<usize> = None;
+
         // Find all use statements
         let use_statements: Vec<Node> = node
             .children(&mut node.walk())
             .filter(|child| child.kind() == "use_statement")
+            .filter(|child| {
+                let row = child.start_position().row;
+                // Skip this node if it is on the same line as the previous one
+                if Some(row) == last_row {
+                    false
+                } else {
+                    last_row = Some(row);
+                    true
+                }
+            })
             .collect();
 
         if use_statements.is_empty() {

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -17,6 +17,8 @@ use tree_sitter::Node;
 /// Sorted imports are easier to scan, reduce cognitive load when reviewing code,
 /// and help avoid merge conflicts when multiple developers add imports to the same block.
 ///
+/// Blocks of `use` statements separated by blank lines are sorted independently.
+///
 /// ## Example
 /// ```f90
 /// ! Not recommended
@@ -31,8 +33,6 @@ use tree_sitter::Node;
 /// use module_b, only: fun_b
 /// use module_c, only: fun_c
 /// ```
-///
-/// Blocks of `use` statements separated by blank lines are sorted independently.
 #[derive(ViolationMetadata)]
 pub(crate) struct UnsortedUses {}
 

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -5,8 +5,8 @@ use crate::traits::TextRanged;
 use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_source_file::{LineEnding, SourceFile, find_newline};
-use ruff_text_size::{TextRange, TextSize};
+use ruff_source_file::{LineRanges, SourceFile};
+use ruff_text_size::TextRange;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -128,15 +128,8 @@ struct UseStatementData {
 }
 
 fn extract_use_statement_data(node: &Node, src: &SourceFile) -> UseStatementData {
-    // Build full line text: indentation + node text + inline comment if any
     let range = node.textrange();
-    let node_text = node.to_text(src.source_text()).unwrap_or("");
-    let after_node = &src.source_text()[range.end().to_usize()..];
-    // Capture any inline comment after the node by reading everything between the end of the node and the next newline.
-    let line_remainder = find_newline(after_node)
-        .map(|(pos, _)| &after_node[..pos])
-        .unwrap_or("");
-    let text = format!("{}{}{}", node.indentation(src), node_text, line_remainder);
+    let text = src.source_text().full_lines_str(range).to_string();
 
     let module_name = node
         .module_name(src.source_text())
@@ -180,27 +173,15 @@ fn check_and_fix_block(block: &[Node], src: &SourceFile) -> Option<Diagnostic> {
         return None;
     }
 
-    // The textrange of a node starts after its indentation.
-    // We need to include the indentation in the replacement range,
-    // so we walk back to the beginning of the line.
-    let first = block.first()?;
-    let block_start =
-        first.textrange().start() - TextSize::from(first.indentation(src).len() as u32);
-    let block_end = block.last()?.textrange().end();
+    let block_start = src
+        .source_text()
+        .line_start(block.first()?.textrange().start());
+    let block_end = src
+        .source_text()
+        .full_line_end(block.last()?.textrange().end());
 
-    // Preserve the line ending style of the source file (LF or CRLF)
-    let nl = find_newline(src.source_text())
-        .map(|(_, ending)| ending)
-        .unwrap_or(LineEnding::Lf)
-        .as_str();
-
-    let mut replacement = String::new();
-    for (i, stmt) in sorted.iter().enumerate() {
-        replacement.push_str(&stmt.text);
-        if i < sorted.len() - 1 {
-            replacement.push_str(nl);
-        }
-    }
+    // Concatenate the sorted use statements into a single replacement string
+    let replacement = sorted.iter().map(|s| s.text.as_str()).collect::<String>();
 
     let edit = Edit::range_replacement(replacement, TextRange::new(block_start, block_end));
     let fix = Fix::safe_edit(edit);

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -172,9 +172,6 @@ struct UseStatementData {
 }
 
 fn extract_use_statement_data(node: &Node, src: &SourceFile) -> UseStatementData {
-    let range = node.textrange();
-    let text = src.source_text().full_lines_str(range).to_string();
-
     let module_name = node
         .module_name(src.source_text())
         // Fortran is case-insensitive, normalize to lowercase for consistent sorting
@@ -185,9 +182,21 @@ fn extract_use_statement_data(node: &Node, src: &SourceFile) -> UseStatementData
         .children(&mut node.walk())
         .any(|child| child.to_text(src.source_text()) == Some("intrinsic"));
 
+    let mut text_range = node.textrange();
+    let mut start_position_row = node.start_position().row;
+
+    // If there's a preceding block of comments, then keep those attached to
+    // this statement
+    if let Some(comments) = node.prev_attached_comment_block(src.source_text()) {
+        text_range = TextRange::new(comments.start_textsize(), node.end_textsize());
+        start_position_row = comments.start_row();
+    }
+
+    let text = src.source_text().full_lines_str(text_range).to_string();
+
     UseStatementData {
-        text_range: node.textrange(),
-        start_position_row: node.start_position().row,
+        text_range,
+        start_position_row,
         end_position_row: node.end_position().row,
         text,
         module_name,
@@ -224,9 +233,7 @@ mod tests {
 
         // Block 1: alpha, beta
         // blank line separator
-        // Block 2: charlie, delta
-        // comment separator
-        // Block 3: echo (alone)
+        // Block 2: charlie, delta, echo
         // Block 4: only foxtrot is kept — golf is on the same line and must be ignored
         let code = {
             r#"
@@ -260,14 +267,13 @@ mod tests {
             block.iter().map(|s| s.module_name.clone()).collect()
         };
 
-        assert_eq!(blocks.len(), 4, "expected 4 blocks");
+        assert_eq!(blocks.len(), 3, "expected 3 blocks");
         assert_eq!(block_names(&blocks[0]), vec!["alpha_module", "beta_module"]);
         assert_eq!(
             block_names(&blocks[1]),
-            vec!["charlie_module", "delta_module"]
+            vec!["charlie_module", "delta_module", "echo_module"]
         );
-        assert_eq!(block_names(&blocks[2]), vec!["echo_module"]);
-        assert_eq!(block_names(&blocks[3]), vec!["foxtrot_module"]); // golf_module ignored: same line
+        assert_eq!(block_names(&blocks[2]), vec!["foxtrot_module"]); // golf_module ignored: same line
 
         Ok(())
     }

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -1,8 +1,8 @@
+use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::settings::CheckSettings;
 use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
-use crate::{AstRule, FromAstNode};
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::{LineRanges, SourceFile};
@@ -54,38 +54,51 @@ impl AstRule for UnsortedUses {
         src: &SourceFile,
         _symbol_table: &SymbolTables,
     ) -> Option<Vec<Diagnostic>> {
-        // Collect only the first `use_statement` per line
-        let mut last_row: Option<usize> = None;
-
-        // Find all use statements
-        let use_statements: Vec<Node> = node
+        let use_statements: Vec<UseStatementData> = node
             .children(&mut node.walk())
             .filter(|child| child.kind() == "use_statement")
-            .filter(|child| {
-                let row = child.start_position().row;
-                // Skip this node if it is on the same line as the previous one
-                if Some(row) == last_row {
-                    false
-                } else {
-                    last_row = Some(row);
-                    true
-                }
-            })
+            .map(|child| extract_use_statement_data(&child, src))
             .collect();
 
-        if use_statements.is_empty() {
+        if use_statements.len() <= 1 {
             return None;
         }
-
         // Group use statements into blocks separated by empty lines
         let blocks = group_use_statements_into_blocks(&use_statements);
 
         let mut diagnostics = Vec::new();
 
-        for block in blocks {
-            if let Some(diagnostic) = check_and_fix_block(&block, src) {
-                diagnostics.push(diagnostic);
+        for block in &blocks {
+            if block.len() <= 1 {
+                continue;
             }
+
+            let mut sorted: Vec<&UseStatementData> = block.to_vec();
+            sorted.sort_by(|a, b| compare_use_statements(a, b));
+
+            let is_sorted = block
+                .iter()
+                .zip(sorted.iter())
+                .all(|(orig, s)| orig.text == s.text);
+
+            if is_sorted {
+                continue;
+            }
+
+            let block_start = src
+                .source_text()
+                .line_start(block.first()?.text_range.start());
+            let block_end = src
+                .source_text()
+                .full_line_end(block.last()?.text_range.end());
+
+            let replacement = sorted.iter().map(|s| s.text.as_str()).collect::<String>();
+            let edit = Edit::range_replacement(replacement, TextRange::new(block_start, block_end));
+            let fix = Fix::safe_edit(edit);
+
+            let first = block.first()?;
+            let diag = Diagnostic::new(UnsortedUses {}, first.text_range).with_fix(fix);
+            diagnostics.push(diag);
         }
 
         if diagnostics.is_empty() {
@@ -100,41 +113,59 @@ impl AstRule for UnsortedUses {
     }
 }
 
-fn group_use_statements_into_blocks<'a>(use_statements: &[Node<'a>]) -> Vec<Vec<Node<'a>>> {
-    let mut blocks = Vec::new();
-    let mut current_block = Vec::new();
+/// Groups indices of `use` statements into contiguous blocks.
+fn group_use_statements_into_blocks<'a>(
+    all_use_statements: &'a [UseStatementData],
+) -> Vec<Vec<&'a UseStatementData>> {
+    let mut last_row: Option<usize> = None;
 
-    for (i, stmt) in use_statements.iter().enumerate() {
-        current_block.push(*stmt);
-
-        if let Some(next_stmt) = use_statements.get(i + 1) {
-            // If the next statement is not on the immediately following line
-            // (blank line, comment, or any other content acts as a block separator),
-            // close the current block and start a new one.
-            if !are_statements_adjacent(stmt, next_stmt) {
-                blocks.push(current_block);
-                current_block = Vec::new();
+    let use_statements: Vec<&UseStatementData> = all_use_statements
+        .iter()
+        .filter(|child| {
+            let row = child.start_position_row;
+            if Some(row) == last_row {
+                false
+            } else {
+                last_row = Some(row);
+                true
             }
+        })
+        .collect();
+
+    if use_statements.is_empty() {
+        return Vec::new();
+    }
+    let mut blocks: Vec<Vec<&'a UseStatementData>> = Vec::new();
+    let mut current_block = vec![use_statements[0]];
+
+    for i in 1..use_statements.len() {
+        let prev = &use_statements[i - 1];
+        let curr = &use_statements[i];
+
+        if are_statements_adjacent(prev, curr) {
+            current_block.push(curr);
+        } else {
+            blocks.push(current_block);
+            current_block = vec![curr];
         }
     }
 
-    if !current_block.is_empty() {
-        blocks.push(current_block);
-    }
-
+    blocks.push(current_block);
     blocks
 }
 
 /// Two use statements are considered adjacent if the second one starts
 /// on the line immediately following the end of the first one.
-fn are_statements_adjacent(stmt1: &Node, stmt2: &Node) -> bool {
-    let line1 = stmt1.end_position().row;
-    let line2 = stmt2.start_position().row;
+fn are_statements_adjacent(stmt1: &UseStatementData, stmt2: &UseStatementData) -> bool {
+    let line1 = stmt1.end_position_row;
+    let line2 = stmt2.start_position_row;
     line2 == line1 + 1
 }
 
-#[derive(Clone)]
 struct UseStatementData {
+    text_range: TextRange,
+    start_position_row: usize,
+    end_position_row: usize,
     text: String,
     module_name: String,
     is_intrinsic: bool,
@@ -155,51 +186,13 @@ fn extract_use_statement_data(node: &Node, src: &SourceFile) -> UseStatementData
         .any(|child| child.to_text(src.source_text()) == Some("intrinsic"));
 
     UseStatementData {
+        text_range: node.textrange(),
+        start_position_row: node.start_position().row,
+        end_position_row: node.end_position().row,
         text,
         module_name,
         is_intrinsic,
     }
-}
-
-fn check_and_fix_block(block: &[Node], src: &SourceFile) -> Option<Diagnostic> {
-    if block.len() <= 1 {
-        return None; // Single statements or empty blocks don't need sorting
-    }
-
-    // Extract module name, intrinsic status and full line text
-    let statements_with_data: Vec<UseStatementData> = block
-        .iter()
-        .map(|node| extract_use_statement_data(node, src))
-        .collect();
-
-    // Sort statements
-    let mut sorted = statements_with_data.clone();
-    sorted.sort_by(|a, b| compare_use_statements(a, b));
-
-    // Check if already sorted
-    let is_sorted = statements_with_data
-        .iter()
-        .zip(sorted.iter())
-        .all(|(orig, s)| orig.text == s.text);
-
-    if is_sorted {
-        return None;
-    }
-
-    let block_start = src
-        .source_text()
-        .line_start(block.first()?.textrange().start());
-    let block_end = src
-        .source_text()
-        .full_line_end(block.last()?.textrange().end());
-
-    // Concatenate the sorted use statements into a single replacement string
-    let replacement = sorted.iter().map(|s| s.text.as_str()).collect::<String>();
-
-    let edit = Edit::range_replacement(replacement, TextRange::new(block_start, block_end));
-    let fix = Fix::safe_edit(edit);
-
-    Some(Diagnostic::from_node(UnsortedUses {}, block.first().unwrap()).with_fix(fix))
 }
 
 // Intrinsic modules (e.g. `use, intrinsic :: iso_fortran_env`) always come first,
@@ -209,5 +202,165 @@ fn compare_use_statements(a: &UseStatementData, b: &UseStatementData) -> std::cm
         (true, false) => std::cmp::Ordering::Less,
         (false, true) => std::cmp::Ordering::Greater,
         _ => a.module_name.cmp(&b.module_name),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{Context, Result};
+    use ruff_source_file::SourceFileBuilder;
+    use tree_sitter::Parser;
+
+    use crate::rules::style::use_statement::{
+        UseStatementData, extract_use_statement_data, group_use_statements_into_blocks,
+    };
+
+    #[test]
+    fn test_group_use_statements_into_blocks() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        // Block 1: alpha, beta
+        // blank line separator
+        // Block 2: charlie, delta
+        // comment separator
+        // Block 3: echo (alone)
+        // Block 4: only foxtrot is kept — golf is on the same line and must be ignored
+        let code = {
+            r#"
+        program foo
+          use alpha_module
+          use beta_module
+
+          use charlie_module
+          use delta_module
+          ! a comment acts as a separator
+          use echo_module
+
+          use foxtrot_module; use golf_module
+        end program foo
+    "#
+        };
+
+        let tree = parser.parse(code, None).context("Failed to parse")?;
+        let src = SourceFileBuilder::new("test.f90", code).finish();
+
+        let program_node = tree.root_node().child(0).context("Missing program node")?;
+        assert_eq!(program_node.kind(), "program");
+
+        let use_statements: Vec<UseStatementData> = program_node
+            .children(&mut program_node.walk())
+            .filter(|child| child.kind() == "use_statement")
+            .map(|child| extract_use_statement_data(&child, &src))
+            .collect();
+        let blocks = group_use_statements_into_blocks(&use_statements);
+        let block_names = |block: &Vec<&UseStatementData>| -> Vec<String> {
+            block.iter().map(|s| s.module_name.clone()).collect()
+        };
+
+        assert_eq!(blocks.len(), 4, "expected 4 blocks");
+        assert_eq!(block_names(&blocks[0]), vec!["alpha_module", "beta_module"]);
+        assert_eq!(
+            block_names(&blocks[1]),
+            vec!["charlie_module", "delta_module"]
+        );
+        assert_eq!(block_names(&blocks[2]), vec!["echo_module"]);
+        assert_eq!(block_names(&blocks[3]), vec!["foxtrot_module"]); // golf_module ignored: same line
+
+        Ok(())
+    }
+    #[test]
+    fn test_extract_use_statement_data() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = {
+            r#"
+        program foo
+          use iso_fortran_env, only: real64
+          use, intrinsic :: iso_c_binding, only: c_int
+          use My_Module
+          use foxtrot_module; use golf_module
+          use multiline_module, only: fun_1, &
+                                      fun_2, & !! 123_comments
+                                      fun_3
+        end program foo
+    "#
+        };
+
+        let tree = parser.parse(code, None).context("Failed to parse")?;
+        let root = tree.root_node().child(0).context("Missing child")?;
+        let src = SourceFileBuilder::new("test.f90", code).finish();
+
+        let all_use_statements: Vec<UseStatementData> = root
+            .children(&mut root.walk())
+            .filter(|child| child.kind() == "use_statement")
+            .map(|child| extract_use_statement_data(&child, &src))
+            .collect();
+
+        assert_eq!(all_use_statements.len(), 6);
+
+        // Test regular use statement
+        let regular = &all_use_statements[0];
+        assert!(!regular.is_intrinsic);
+        assert_eq!(regular.module_name, "iso_fortran_env");
+        assert_eq!(regular.start_position_row, 2);
+        assert_eq!(regular.end_position_row, 2);
+        assert!(regular.text.contains("iso_fortran_env"));
+        assert!(!regular.text_range.is_empty());
+
+        // Test intrinsic use statement
+        let intrinsic = &all_use_statements[1];
+        assert!(intrinsic.is_intrinsic);
+        assert_eq!(intrinsic.module_name, "iso_c_binding");
+        assert_eq!(intrinsic.start_position_row, 3);
+        assert_eq!(intrinsic.end_position_row, 3);
+        assert!(intrinsic.text.contains("iso_c_binding"));
+        assert!(!intrinsic.text_range.is_empty());
+
+        // Test mixed case use statement
+        let mixed_case = &all_use_statements[2];
+        assert!(!mixed_case.is_intrinsic);
+        assert_eq!(mixed_case.module_name, "my_module");
+        assert_eq!(mixed_case.start_position_row, 4);
+        assert_eq!(mixed_case.end_position_row, 4);
+        assert!(mixed_case.text.contains("My_Module"));
+        assert!(!mixed_case.text_range.is_empty());
+
+        // Test foxtrot_module (first on same line)
+        let foxtrot = &all_use_statements[3];
+        assert!(!foxtrot.is_intrinsic);
+        assert_eq!(foxtrot.module_name, "foxtrot_module");
+        assert_eq!(foxtrot.start_position_row, 5);
+        assert_eq!(foxtrot.end_position_row, 5);
+        assert!(foxtrot.text.contains("foxtrot_module"));
+        assert!(!foxtrot.text_range.is_empty());
+
+        // Test golf_module (second on same line)
+        let golf = &all_use_statements[4];
+        assert!(!golf.is_intrinsic);
+        assert_eq!(golf.module_name, "golf_module");
+        assert_eq!(golf.start_position_row, 5);
+        assert_eq!(golf.end_position_row, 5);
+        assert!(golf.text.contains("golf_module"));
+        assert!(!golf.text_range.is_empty());
+
+        // Test multiline_module
+        let multiline = &all_use_statements[5];
+        assert!(!multiline.is_intrinsic);
+        assert_eq!(multiline.module_name, "multiline_module");
+        assert_eq!(multiline.start_position_row, 6);
+        assert_eq!(multiline.end_position_row, 8);
+        assert!(multiline.text.contains("fun_1"));
+        assert!(multiline.text.contains("fun_2"));
+        assert!(multiline.text.contains("fun_3"));
+        assert!(multiline.text.contains("123_comments"));
+
+        assert!(!golf.text_range.is_empty());
+        Ok(())
     }
 }

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -1,0 +1,214 @@
+use crate::ast::FortitudeNode;
+use crate::settings::CheckSettings;
+use crate::symbol_table::SymbolTables;
+use crate::traits::TextRanged;
+use crate::{AstRule, FromAstNode};
+use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_source_file::SourceFile;
+use ruff_text_size::{TextRange, TextSize};
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks that `use` statements are sorted alphabetically within contiguous blocks.
+/// Intrinsic modules (`use, intrinsic ::`) are always placed first.
+///
+/// ## Why is this bad?
+/// Sorted imports are easier to scan, reduce cognitive load when reviewing code,
+/// and help avoid merge conflicts when multiple developers add imports to the same block.
+///
+/// ## Example
+/// ```f90
+/// ! Not recommended
+/// use module_c, only: fun_c
+/// use, intrinsic :: iso_fortran_env, only: int32
+/// use module_a, only: fun_a
+/// use module_b, only: fun_b
+///
+/// ! Better
+/// use, intrinsic :: iso_fortran_env, only: int32
+/// use module_a, only: fun_a
+/// use module_b, only: fun_b
+/// use module_c, only: fun_c
+/// ```
+///
+/// Blocks of `use` statements separated by blank lines are sorted independently.
+#[derive(ViolationMetadata)]
+pub(crate) struct UnsortedUses {}
+
+impl AlwaysFixableViolation for UnsortedUses {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "`use` statements are not sorted".to_string()
+    }
+
+    fn fix_title(&self) -> String {
+        "Sort `use` statements".to_string()
+    }
+}
+
+impl AstRule for UnsortedUses {
+    fn check(
+        _settings: &CheckSettings,
+        node: &Node,
+        src: &SourceFile,
+        _symbol_table: &SymbolTables,
+    ) -> Option<Vec<Diagnostic>> {
+        // Find all use statements
+        let use_statements: Vec<Node> = node
+            .children(&mut node.walk())
+            .filter(|child| child.kind() == "use_statement")
+            .collect();
+
+        if use_statements.is_empty() {
+            return None;
+        }
+
+        // Group use statements into blocks separated by empty lines
+        let blocks = group_use_statements_into_blocks(&use_statements, src);
+
+        let mut diagnostics = Vec::new();
+
+        for block in blocks {
+            if let Some(diagnostic) = check_and_fix_block(&block, src) {
+                diagnostics.push(diagnostic);
+            }
+        }
+
+        if diagnostics.is_empty() {
+            None
+        } else {
+            Some(diagnostics)
+        }
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["module", "submodule", "program", "subroutine", "function"]
+    }
+}
+
+fn group_use_statements_into_blocks<'a>(
+    use_statements: &[Node<'a>],
+    src: &SourceFile,
+) -> Vec<Vec<Node<'a>>> {
+    let mut blocks = Vec::new();
+    let mut current_block = Vec::new();
+
+    for (i, stmt) in use_statements.iter().enumerate() {
+        current_block.push(*stmt);
+
+        // Check if this is the last statement or if the next statement is separated by an empty line
+        let is_last = i == use_statements.len() - 1;
+        if !is_last {
+            let next_stmt = &use_statements[i + 1];
+            if !are_statements_adjacent(stmt, next_stmt, src) {
+                // Start a new block
+                blocks.push(current_block);
+                current_block = Vec::new();
+            }
+        }
+    }
+
+    if !current_block.is_empty() {
+        blocks.push(current_block);
+    }
+
+    blocks
+}
+
+fn are_statements_adjacent(stmt1: &Node, stmt2: &Node, src: &SourceFile) -> bool {
+    let range1 = stmt1.textrange();
+    let range2 = stmt2.textrange();
+
+    // Get the text between the end of stmt1 and start of stmt2
+    let between_range = TextRange::new(range1.end(), range2.start());
+    let between_text = src.slice(between_range);
+
+    // Check if there's only whitespace (no empty lines)
+    !between_text.contains("\n\n") && !between_text.contains("\r\n\r\n")
+}
+
+#[derive(Clone)]
+struct UseStatementData {
+    text: String,
+    module_name: String,
+    is_intrinsic: bool,
+}
+
+fn check_and_fix_block(block: &[Node], src: &SourceFile) -> Option<Diagnostic> {
+    if block.len() <= 1 {
+        return None; // Single statements or empty blocks don't need sorting
+    }
+
+    // Extract module name, intrinsic status and full line text
+    let statements_with_data: Vec<UseStatementData> = block
+        .iter()
+        .map(|node| {
+            // Reconstruct the full line by prepending the node's indentation to its text.
+            let indentation = node.indentation(src);
+            let node_text = node.to_text(src.source_text()).unwrap_or("");
+            let text = format!("{}{}", indentation, node_text);
+
+            let module_name = node
+                .module_name(src.source_text())
+                // Fortran is case-insensitive, normalize to lowercase for consistent sorting
+                .map(|s| s.to_lowercase())
+                .unwrap_or_default();
+
+            let is_intrinsic = node
+                .children(&mut node.walk())
+                .any(|child| child.to_text(src.source_text()) == Some("intrinsic"));
+
+            UseStatementData {
+                text,
+                module_name,
+                is_intrinsic,
+            }
+        })
+        .collect();
+
+    // Sort statements
+    let mut sorted = statements_with_data.clone();
+    sorted.sort_by(|a, b| compare_use_statements(&a, &b));
+
+    // Check if already sorted
+    let is_sorted = statements_with_data
+        .iter()
+        .zip(sorted.iter())
+        .all(|(orig, s)| orig.text == s.text);
+
+    if is_sorted {
+        return None;
+    }
+
+    // The textrange of a node starts after its indentation.
+    // We need to include the indentation in the replacement range,
+    // so we walk back to the beginning of the line.
+    let block_indentation = block.first()?.indentation(src);
+    let block_start =
+        block.first()?.textrange().start() - TextSize::from(block_indentation.len() as u32);
+    let block_end = block.last()?.textrange().end();
+
+    let mut replacement = String::new();
+    for (i, stmt) in sorted.iter().enumerate() {
+        replacement.push_str(&stmt.text);
+        if i < sorted.len() - 1 {
+            replacement.push('\n');
+        }
+    }
+
+    let edit = Edit::range_replacement(replacement, TextRange::new(block_start, block_end));
+    let fix = Fix::safe_edit(edit);
+
+    Some(Diagnostic::from_node(UnsortedUses {}, block.first().unwrap()).with_fix(fix))
+}
+
+// Intrinsic modules (e.g. `use, intrinsic :: iso_fortran_env`) always come first,
+// followed by regular modules sorted alphabetically by name.
+fn compare_use_statements(a: &UseStatementData, b: &UseStatementData) -> std::cmp::Ordering {
+    match (a.is_intrinsic, b.is_intrinsic) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.module_name.cmp(&b.module_name),
+    }
+}

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -97,7 +97,9 @@ impl AstRule for UnsortedUses {
             let fix = Fix::safe_edit(edit);
 
             let first = block.first()?;
-            let diag = Diagnostic::new(UnsortedUses {}, first.text_range).with_fix(fix);
+            let last = block.last()?;
+            let range = TextRange::new(first.start_textsize(), last.end_textsize());
+            let diag = Diagnostic::new(UnsortedUses {}, range).with_fix(fix);
             diagnostics.push(diag);
         }
 
@@ -169,6 +171,12 @@ struct UseStatementData {
     text: String,
     module_name: String,
     is_intrinsic: bool,
+}
+
+impl TextRanged for UseStatementData {
+    fn textrange(&self) -> TextRange {
+        self.text_range
+    }
 }
 
 fn extract_use_statement_data(node: &Node, src: &SourceFile) -> UseStatementData {

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -108,6 +108,7 @@
 | S261 | [inconsistent-array-declaration](rules/inconsistent-array-declaration.md) | Inconsistent specification of dimension | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | S262 | [mixed-scalar-array-declaration](rules/mixed-scalar-array-declaration.md) | Mixed declaration of scalar(s) and array | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 | S263 | [bad-array-declaration](rules/bad-array-declaration.md) | Bad declaration of array | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
+| S271 | [unsorted-uses](rules/unsorted-uses.md) | `use` statements are not sorted | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | S901 | [too-complex](rules/too-complex.md) | cyclomatic complexity of {actual_complexity}, exceeds maximum {max_complexity\} | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 
 ### Portability (PORT)

--- a/docs/rules/unsorted-uses.md
+++ b/docs/rules/unsorted-uses.md
@@ -13,6 +13,8 @@ Intrinsic modules (`use, intrinsic ::`) are always placed first.
 Sorted imports are easier to scan, reduce cognitive load when reviewing code,
 and help avoid merge conflicts when multiple developers add imports to the same block.
 
+Blocks of `use` statements separated by blank lines are sorted independently.
+
 ## Example
 ```f90
 ! Not recommended
@@ -27,5 +29,3 @@ use module_a, only: fun_a
 use module_b, only: fun_b
 use module_c, only: fun_c
 ```
-
-Blocks of `use` statements separated by blank lines are sorted independently.

--- a/docs/rules/unsorted-uses.md
+++ b/docs/rules/unsorted-uses.md
@@ -1,0 +1,31 @@
+# unsorted-uses (S271)
+Fix is always available.
+
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+This rule is turned on by default.
+
+## What it does
+Checks that `use` statements are sorted alphabetically within contiguous blocks.
+Intrinsic modules (`use, intrinsic ::`) are always placed first.
+
+## Why is this bad?
+Sorted imports are easier to scan, reduce cognitive load when reviewing code,
+and help avoid merge conflicts when multiple developers add imports to the same block.
+
+## Example
+```f90
+! Not recommended
+use module_c, only: fun_c
+use, intrinsic :: iso_fortran_env, only: int32
+use module_a, only: fun_a
+use module_b, only: fun_b
+
+! Better
+use, intrinsic :: iso_fortran_env, only: int32
+use module_a, only: fun_a
+use module_b, only: fun_b
+use module_c, only: fun_c
+```
+
+Blocks of `use` statements separated by blank lines are sorted independently.


### PR DESCRIPTION
Fixing https://github.com/PlasmaFAIR/fortitude/issues/560

## Summary

This PR implements the S271 rule for sorting `use` statements, following the issue's reference to isort-style ordering.

### What is implemented

- `use` statements are sorted alphabetically by module name (case-insensitive, normalized to lowercase)
- Intrinsic modules (`use, intrinsic ::`) are always sorted to the top
- Statements are grouped by contiguous blocks — blank lines between groups are preserved and each group is sorted independently
- An autofix is provided

### What is out of scope

Multiline `use` statements (with `&` continuations) are not reordered by this rule. A follow-up rule will handle sorting the `only:` import lists, and that rule will be the right place to also tackle line breaking for long statements. (S272: `unsorted-only-statement`)

### Question on CamelCase / ALLCAPS prioritization

The issue mentions *"prioritising CamelCase and ALLCAPS"* in the sort order — I'm not sure I fully understand the intent here. Should `CamelCase` module names sort before lowercase ones? Is this about Fortran derived type conventions, or something else? I've gone with a simple case-insensitive alphabetical sort for now, which felt like the most predictable behavior. Happy to adjust once the expected ordering is clarified.
