### PR TITLE
Added a pre-commit hook definition for fortitude

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+-   id: fortitude
+    name: Fortitude Fortran code linter
+    description: Runs the Fortitude code linter to check for code quality issues in Fortran files.
+    entry: fortitude
+    language: python
+    files: \.[fF]\d*$
+    args: [check]
+


### PR DESCRIPTION
This allows fortitude to be easily invoked in pre-commit runs of other projects.

I added it using the python installation because the rust cargo install shows problems when the pre-commit infrastructure tries to call it.