### PR TITLE
Upgrade implicit typing rules

### DIFF
--- a/crates/fortitude/tests/check.rs
+++ b/crates/fortitude/tests/check.rs
@@ -248,7 +248,7 @@ end program
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] C001 program missing 'implicit none'
+    [TEMP_FILE] C001 program uses implicit typing
       |
     2 | program test
       | ^^^^^^^^^^^^ C001
@@ -319,7 +319,7 @@ end program
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] C001 program missing 'implicit none'
+    [TEMP_FILE] C001 program uses implicit typing
       |
     2 | program test
       | ^^^^^^^^^^^^ C001
@@ -381,7 +381,7 @@ select = ["C001", "style"]
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] C001 program missing 'implicit none'
+    [TEMP_FILE] C001 program uses implicit typing
       |
     2 | program test
       | ^^^^^^^^^^^^ C001
@@ -444,7 +444,7 @@ select = ["C001"]
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] C001 program missing 'implicit none'
+    [TEMP_FILE] C001 program uses implicit typing
       |
     2 | program test
       | ^^^^^^^^^^^^ C001
@@ -506,7 +506,7 @@ select = ["C001", "style"]
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] C001 program missing 'implicit none'
+    [TEMP_FILE] C001 program uses implicit typing
       |
     2 | program test
       | ^^^^^^^^^^^^ C001
@@ -1137,7 +1137,7 @@ end module {file}{idx}
     success: false
     exit_code: 1
     ----- stdout -----
-    bar0.f90:2:1: C001 module missing 'implicit none'
+    bar0.f90:2:1: C001 module uses implicit typing
       |
     2 | module bar0
       | ^^^^^^^^^^^ C001
@@ -1147,7 +1147,7 @@ end module {file}{idx}
       |
       = help: Insert `implicit none`
 
-    baz0.f90:2:1: C001 module missing 'implicit none'
+    baz0.f90:2:1: C001 module uses implicit typing
       |
     2 | module baz0
       | ^^^^^^^^^^^ C001
@@ -1157,7 +1157,7 @@ end module {file}{idx}
       |
       = help: Insert `implicit none`
 
-    foo0.f90:2:1: C001 module missing 'implicit none'
+    foo0.f90:2:1: C001 module uses implicit typing
       |
     2 | module foo0
       | ^^^^^^^^^^^ C001
@@ -1167,7 +1167,7 @@ end module {file}{idx}
       |
       = help: Insert `implicit none`
 
-    nested/bar1.f90:2:1: C001 module missing 'implicit none'
+    nested/bar1.f90:2:1: C001 module uses implicit typing
       |
     2 | module bar1
       | ^^^^^^^^^^^ C001
@@ -1177,7 +1177,7 @@ end module {file}{idx}
       |
       = help: Insert `implicit none`
 
-    nested/baz1.f90:2:1: C001 module missing 'implicit none'
+    nested/baz1.f90:2:1: C001 module uses implicit typing
       |
     2 | module baz1
       | ^^^^^^^^^^^ C001
@@ -1187,7 +1187,7 @@ end module {file}{idx}
       |
       = help: Insert `implicit none`
 
-    nested/foo1.f90:2:1: C001 module missing 'implicit none'
+    nested/foo1.f90:2:1: C001 module uses implicit typing
       |
     2 | module foo1
       | ^^^^^^^^^^^ C001
@@ -1257,7 +1257,7 @@ end module {file}{idx}
     success: false
     exit_code: 1
     ----- stdout -----
-    baz0.f90:2:1: C001 module missing 'implicit none'
+    baz0.f90:2:1: C001 module uses implicit typing
       |
     2 | module baz0
       | ^^^^^^^^^^^ C001
@@ -1267,7 +1267,7 @@ end module {file}{idx}
       |
       = help: Insert `implicit none`
 
-    foo0.f90:2:1: C001 module missing 'implicit none'
+    foo0.f90:2:1: C001 module uses implicit typing
       |
     2 | module foo0
       | ^^^^^^^^^^^ C001
@@ -1277,7 +1277,7 @@ end module {file}{idx}
       |
       = help: Insert `implicit none`
 
-    nested/baz1.f90:2:1: C001 module missing 'implicit none'
+    nested/baz1.f90:2:1: C001 module uses implicit typing
       |
     2 | module baz1
       | ^^^^^^^^^^^ C001
@@ -1287,7 +1287,7 @@ end module {file}{idx}
       |
       = help: Insert `implicit none`
 
-    nested/foo1.f90:2:1: C001 module missing 'implicit none'
+    nested/foo1.f90:2:1: C001 module uses implicit typing
       |
     2 | module foo1
       | ^^^^^^^^^^^ C001
@@ -1363,7 +1363,7 @@ fn check_exclude() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    .venv/lib/site-packages/numpy/numpy.f90:2:1: C001 module missing 'implicit none'
+    .venv/lib/site-packages/numpy/numpy.f90:2:1: C001 module uses implicit typing
       |
     2 | module numpy
       | ^^^^^^^^^^^^ C001
@@ -1373,7 +1373,7 @@ fn check_exclude() -> anyhow::Result<()> {
       |
       = help: Insert `implicit none`
 
-    base.f90:2:1: C001 module missing 'implicit none'
+    base.f90:2:1: C001 module uses implicit typing
       |
     2 | module base
       | ^^^^^^^^^^^ C001
@@ -1383,7 +1383,7 @@ fn check_exclude() -> anyhow::Result<()> {
       |
       = help: Insert `implicit none`
 
-    foo/foo.f90:2:1: C001 module missing 'implicit none'
+    foo/foo.f90:2:1: C001 module uses implicit typing
       |
     2 | module foo
       | ^^^^^^^^^^ C001
@@ -1423,7 +1423,7 @@ fn check_extend_exclude() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    base.f90:2:1: C001 module missing 'implicit none'
+    base.f90:2:1: C001 module uses implicit typing
       |
     2 | module base
       | ^^^^^^^^^^^ C001
@@ -1463,7 +1463,7 @@ fn check_no_force_exclude() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    foo/foo.f90:2:1: C001 module missing 'implicit none'
+    foo/foo.f90:2:1: C001 module uses implicit typing
       |
     2 | module foo
       | ^^^^^^^^^^ C001
@@ -1527,7 +1527,7 @@ fn check_exclude_builtin() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    .venv/lib/site-packages/numpy/numpy.f90:2:1: C001 module missing 'implicit none'
+    .venv/lib/site-packages/numpy/numpy.f90:2:1: C001 module uses implicit typing
       |
     2 | module numpy
       | ^^^^^^^^^^^^ C001
@@ -1650,7 +1650,7 @@ end program
     success: false
     exit_code: 1
     ----- stdout -----
-    [TEMP_FILE] C001 program missing 'implicit none'
+    [TEMP_FILE] C001 program uses implicit typing
       |
     2 | ! allow(C001, unnamed-end-statement, literal-kind)
     3 | program test
@@ -1822,7 +1822,7 @@ end program myprogram
     exit_code: 1
     ----- stdout -----
     [TEMP_FILE] S091 file extension should be '.f90' or '.F90'
-    [TEMP_FILE] C001 program missing 'implicit none'
+    [TEMP_FILE] C001 program uses implicit typing
       |
     2 | program myprogram
       | ^^^^^^^^^^^^^^^^^ C001
@@ -1910,7 +1910,7 @@ fn check_gitignore() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    include.f90:2:1: C001 module missing 'implicit none'
+    include.f90:2:1: C001 module uses implicit typing
       |
     2 | module base
       | ^^^^^^^^^^^ C001
@@ -1920,7 +1920,7 @@ fn check_gitignore() -> anyhow::Result<()> {
       |
       = help: Insert `implicit none`
 
-    include/include.f90:2:1: C001 module missing 'implicit none'
+    include/include.f90:2:1: C001 module uses implicit typing
       |
     2 | module include
       | ^^^^^^^^^^^^^^ C001
@@ -1959,7 +1959,7 @@ fn check_no_respect_gitignore() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    exclude.f90:2:1: C001 module missing 'implicit none'
+    exclude.f90:2:1: C001 module uses implicit typing
       |
     2 | module base
       | ^^^^^^^^^^^ C001
@@ -1969,7 +1969,7 @@ fn check_no_respect_gitignore() -> anyhow::Result<()> {
       |
       = help: Insert `implicit none`
 
-    exclude/exclude.f90:2:1: C001 module missing 'implicit none'
+    exclude/exclude.f90:2:1: C001 module uses implicit typing
       |
     2 | module exclude
       | ^^^^^^^^^^^^^^ C001
@@ -1979,7 +1979,7 @@ fn check_no_respect_gitignore() -> anyhow::Result<()> {
       |
       = help: Insert `implicit none`
 
-    exclude/include.f90:2:1: C001 module missing 'implicit none'
+    exclude/include.f90:2:1: C001 module uses implicit typing
       |
     2 | module exclude
       | ^^^^^^^^^^^^^^ C001
@@ -1989,7 +1989,7 @@ fn check_no_respect_gitignore() -> anyhow::Result<()> {
       |
       = help: Insert `implicit none`
 
-    include.f90:2:1: C001 module missing 'implicit none'
+    include.f90:2:1: C001 module uses implicit typing
       |
     2 | module base
       | ^^^^^^^^^^^ C001
@@ -1999,7 +1999,7 @@ fn check_no_respect_gitignore() -> anyhow::Result<()> {
       |
       = help: Insert `implicit none`
 
-    include/exclude.f90:2:1: C001 module missing 'implicit none'
+    include/exclude.f90:2:1: C001 module uses implicit typing
       |
     2 | module include
       | ^^^^^^^^^^^^^^ C001
@@ -2009,7 +2009,7 @@ fn check_no_respect_gitignore() -> anyhow::Result<()> {
       |
       = help: Insert `implicit none`
 
-    include/exclude/exclude.f90:2:1: C001 module missing 'implicit none'
+    include/exclude/exclude.f90:2:1: C001 module uses implicit typing
       |
     2 | module exclude
       | ^^^^^^^^^^^^^^ C001
@@ -2019,7 +2019,7 @@ fn check_no_respect_gitignore() -> anyhow::Result<()> {
       |
       = help: Insert `implicit none`
 
-    include/exclude/include.f90:2:1: C001 module missing 'implicit none'
+    include/exclude/include.f90:2:1: C001 module uses implicit typing
       |
     2 | module exclude
       | ^^^^^^^^^^^^^^ C001
@@ -2029,7 +2029,7 @@ fn check_no_respect_gitignore() -> anyhow::Result<()> {
       |
       = help: Insert `implicit none`
 
-    include/include.f90:2:1: C001 module missing 'implicit none'
+    include/include.f90:2:1: C001 module uses implicit typing
       |
     2 | module include
       | ^^^^^^^^^^^^^^ C001

--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C001.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C001.f90
@@ -23,3 +23,13 @@ end program my_program
 subroutine external_sub(x)
   print*, x
 end subroutine external_sub
+
+module my_module_external
+  implicit none (external)
+  parameter(N = 1)
+end module my_module_external
+
+real function external_func() result(x)
+  implicit real (a-z)
+  x = 3.14
+end function external_func

--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C001_ok.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C001_ok.f90
@@ -18,3 +18,18 @@ subroutine external_sub(x)
   integer, intent(in) :: x
   print*, x
 end subroutine external_sub
+
+module my_module_type
+  implicit none (type)
+contains
+  integer function double(x)
+    integer, intent(in) :: x
+    double = 2 * x
+  end function double
+end module my_module_type
+
+subroutine external_sub_type(x)
+  implicit none (type)
+  integer, intent(in) :: x
+  print*, x
+end subroutine external_sub_type

--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C002.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C002.f90
@@ -4,15 +4,24 @@ module my_module
     integer function myfunc(x)
       integer, intent(in) :: x
     end function myfunc
+
+    subroutine mysub(x)
+      implicit none (external)
+      integer, intent(in) :: x
+    end subroutine mysub
   end interface
 end module my_module
 
 program my_program
   implicit none
   interface
-    subroutine myfunc2(x)
+    real function myfunc2(x)
+      implicit real (a,z)
+    end function myfunc2
+
+    subroutine mysub2(x)
       integer, intent(inout) :: x
-    end subroutine myfunc2
+    end subroutine mysub2
   end interface
   write(*,*) 42
 end program my_program

--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C002_ok.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C002_ok.f90
@@ -1,5 +1,5 @@
 module my_module
-  implicit none
+  implicit none (type)
   interface
     integer function myfunc(x)
       implicit none
@@ -12,7 +12,7 @@ program my_program
   implicit none
   interface
     subroutine mysub(x)
-      implicit none
+      implicit none (type)
       integer, intent(inout) :: x
     end subroutine mysub
   end interface

--- a/crates/fortitude_linter/resources/test/fixtures/style/S201.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S201.f90
@@ -7,14 +7,14 @@ contains
     myfunc = x * 2
   end function myfunc
   subroutine mysub(x)
-    implicit none
+    implicit none (type)
     integer, intent(inout) :: x
     x = x * 2
   end subroutine mysub
 end module my_module
 
 program my_program
-  implicit none
+  implicit none (type)
 
   write(*,*) 42
 

--- a/crates/fortitude_linter/resources/test/fixtures/style/S201_ok.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S201_ok.f90
@@ -20,7 +20,7 @@ contains
 end module my_module
 
 program my_program
-  implicit none
+  implicit none (type)
 
   write(*,*) 42
 
@@ -33,4 +33,7 @@ contains
     integer, intent(inout) :: x
     x = x * 2
   end subroutine mysub2
+  subroutine mysub3(x)
+    implicit real (a-z)
+  end subroutine mysub3
 end program my_program

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -3,6 +3,7 @@
 use std::str::FromStr;
 
 use anyhow::{Context, Result, anyhow};
+use bitflags::bitflags;
 use itertools::Itertools;
 use ruff_source_file::SourceFile;
 use strum_macros::{Display, EnumIs, EnumString, IntoStaticStr};
@@ -486,64 +487,75 @@ pub(crate) enum BlockExit {
     Error,
 }
 
-#[derive(Eq, PartialEq)]
-pub(crate) enum ImplicitType {
-    Missing,
-    Implicit,
-    None,
-    NoneType,
-    NoneExternal,
-    NoneTypeExternal,
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct ImplicitNoneType: u8 {
+        const TYPE = 0b0001;
+        const EXTERNAL = 0b0010;
+    }
 }
 
-impl ImplicitType {
-    pub fn equivalent_to(&self, other: &Self) -> bool {
-        match self {
-            Self::Implicit => false, // Assume implicit type(...) is never equivalent to anything else
-            Self::None | Self::NoneType => matches!(other, Self::None | Self::NoneType),
-            this => other == this, // All other variants are only equivalent to themselves
-        }
-    }
+#[derive(Clone, Debug)]
+pub(crate) struct ImplicitStatement<'a> {
+    node: Node<'a>,
+    none_type: ImplicitNoneType,
+}
 
-    /// Classify an implicit statement as either `implicit none`, `implicit none
-    /// (type)`, `implicit none (external)`, `implicit none (type, external)`,
-    /// or `implicit type(...)`.
-    pub fn from_implicit_statement(node: &Node, src: &SourceFile) -> Option<Self> {
+impl<'a> ImplicitStatement<'a> {
+    pub fn try_from_node(node: Node<'a>, src: &SourceFile) -> Option<Self> {
         if node.kind() != "implicit_statement" {
             return None;
         }
-        // Expect something after 'implicit'. If not, just return None and let
-        // the rule exit early -- this is probably a syntax error.
-        let child = node.child(1)?;
-        if child.kind() == "none" {
-            let text = node.to_text(src.source_text())?.to_lowercase();
-            let none_type = text.contains("type");
-            let none_external = text.contains("external");
-            if none_type && none_external {
-                return Some(ImplicitType::NoneTypeExternal);
-            } else if none_type {
-                return Some(ImplicitType::NoneType);
-            } else if none_external {
-                return Some(ImplicitType::NoneExternal);
-            } else {
-                return Some(ImplicitType::None);
-            }
+        let text = node.to_text(src.source_text()).map(|t| t.to_lowercase())?;
+        let mut none_type = ImplicitNoneType::empty();
+        if !text.contains("none") {
+            return Some(Self { node, none_type });
         }
-        Some(ImplicitType::Implicit)
+        if text.contains("type") {
+            none_type |= ImplicitNoneType::TYPE;
+        }
+        if text.contains("external") {
+            none_type |= ImplicitNoneType::EXTERNAL;
+        }
+        // If the (type, external) part is missing, then 'type' is implied
+        if !text.contains("type") && !text.contains("external") {
+            none_type = ImplicitNoneType::TYPE;
+        }
+        Some(Self { node, none_type })
     }
 
     /// Determine the implicit typing scheme of a
     /// program/module/submodule/function/subroutine node.
-    pub fn from_scope(node: &Node, src: &SourceFile) -> Option<Self> {
+    pub fn try_from_scope(node: &'a Node, src: &SourceFile) -> Option<Self> {
         if matches!(
             node.kind(),
             "module" | "submodule" | "program" | "function" | "subroutine"
         ) {
             if let Some(child) = node.child_with_name("implicit_statement") {
-                return ImplicitType::from_implicit_statement(&child, src);
+                return ImplicitStatement::try_from_node(child, src);
             }
-            return Some(ImplicitType::Missing);
+            return None;
         }
         None
+    }
+
+    pub fn node(&self) -> &Node<'a> {
+        &self.node
+    }
+
+    pub fn is_equivalent_to(&self, other: &Self) -> bool {
+        self.none_type == other.none_type
+    }
+
+    pub fn is_not_implicit_none(&self) -> bool {
+        self.none_type.is_empty()
+    }
+
+    pub fn is_implicit_none_type(&self) -> bool {
+        self.none_type.contains(ImplicitNoneType::TYPE)
+    }
+
+    pub fn is_implicit_none_external(&self) -> bool {
+        self.none_type.contains(ImplicitNoneType::EXTERNAL)
     }
 }

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result, anyhow};
 use itertools::Itertools;
+use ruff_source_file::SourceFile;
 use strum_macros::{Display, EnumIs, EnumString, IntoStaticStr};
 use tree_sitter::Node;
 
@@ -483,4 +484,66 @@ pub(crate) enum BlockExit {
     Exit,
     Stop,
     Error,
+}
+
+#[derive(Eq, PartialEq)]
+pub(crate) enum ImplicitType {
+    Missing,
+    Implicit,
+    None,
+    NoneType,
+    NoneExternal,
+    NoneTypeExternal,
+}
+
+impl ImplicitType {
+    pub fn equivalent_to(&self, other: &Self) -> bool {
+        match self {
+            Self::Implicit => false, // Assume implicit type(...) is never equivalent to anything else
+            Self::None | Self::NoneType => matches!(other, Self::None | Self::NoneType),
+            this => other == this, // All other variants are only equivalent to themselves
+        }
+    }
+
+    /// Classify an implicit statement as either `implicit none`, `implicit none
+    /// (type)`, `implicit none (external)`, `implicit none (type, external)`,
+    /// or `implicit type(...)`.
+    pub fn from_implicit_statement(node: &Node, src: &SourceFile) -> Option<Self> {
+        if node.kind() != "implicit_statement" {
+            return None;
+        }
+        // Expect something after 'implicit'. If not, just return None and let
+        // the rule exit early -- this is probably a syntax error.
+        let child = node.child(1)?;
+        if child.kind() == "none" {
+            let text = node.to_text(src.source_text())?.to_lowercase();
+            let none_type = text.contains("type");
+            let none_external = text.contains("external");
+            if none_type && none_external {
+                return Some(ImplicitType::NoneTypeExternal);
+            } else if none_type {
+                return Some(ImplicitType::NoneType);
+            } else if none_external {
+                return Some(ImplicitType::NoneExternal);
+            } else {
+                return Some(ImplicitType::None);
+            }
+        }
+        Some(ImplicitType::Implicit)
+    }
+
+    /// Determine the implicit typing scheme of a
+    /// program/module/submodule/function/subroutine node.
+    pub fn from_scope(node: &Node, src: &SourceFile) -> Option<Self> {
+        if matches!(
+            node.kind(),
+            "module" | "submodule" | "program" | "function" | "subroutine"
+        ) {
+            if let Some(child) = node.child_with_name("implicit_statement") {
+                return ImplicitType::from_implicit_statement(&child, src);
+            }
+            return Some(ImplicitType::Missing);
+        }
+        None
+    }
 }

--- a/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
+++ b/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
@@ -1,5 +1,5 @@
 /// Defines rules that raise errors if implicit typing is in use.
-use crate::ast::{FortitudeNode, types::ImplicitType};
+use crate::ast::{FortitudeNode, types::ImplicitStatement};
 use crate::settings::{CheckSettings, FortranStandard};
 use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
@@ -9,7 +9,9 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
-fn insert_implicit_none(node: &Node, src: &SourceFile) -> Option<Fix> {
+/// Inserts `implicit none` in the current scope. Should be called on a program,
+/// module, submodule, function, or subroutine.
+fn insert_implicit_none(node: &Node, src: &SourceFile) -> Option<Edit> {
     // Find suitable place to insert `implicit none`, the line
     // after the last `use` statement, if any
     let last_use_statement_range = node
@@ -33,10 +35,78 @@ fn insert_implicit_none(node: &Node, src: &SourceFile) -> Option<Fix> {
     // TODO(peter): determine indentation of file using `Stylist` struct
     let indent = (last_use_statement_range.start() - line_start).to_usize();
     let insert = format!("{:indent$}implicit none\n", "");
+    Some(Edit::insertion(insert, line_end))
+}
 
-    let edit = Edit::insertion(insert, line_end);
+/// Replaces an existing implicit statement with `implicit none`. Used when
+/// there is an implicit statement such as `implicit real(a-z)`.
+fn replace_with_implicit_none(node: &Node, src: &SourceFile) -> Edit {
+    node.edit_replacement(src, "implicit none".to_owned())
+}
 
-    Some(Fix::unsafe_edit(edit))
+/// Assuming we have `implicit none (external)` for some cursed reason, adds
+/// `type` to it to make it `implicit none (type, external)`.
+fn add_type_to_implicit_none(node: &Node, src: &SourceFile) -> Option<Edit> {
+    node.children(&mut node.walk())
+        .find(|child| child.to_text(src.source_text()).unwrap().to_lowercase() == "external")
+        .map(|external_node| Edit::insertion("type, ".to_string(), external_node.start_textsize()))
+}
+
+enum ImplicitTypingErrorType {
+    NoImplicitStatement,
+    NotImplicitNone,
+    ExternalWithoutType,
+}
+
+impl ImplicitTypingErrorType {
+    fn fix_title(&self) -> String {
+        match self {
+            Self::NoImplicitStatement => "Insert `implicit none`".to_string(),
+            Self::NotImplicitNone => "Change to `implicit none`".to_string(),
+            Self::ExternalWithoutType => "Change to `implicit none (type, external)`".to_string(),
+        }
+    }
+}
+
+struct ImplicitTypingEdit {
+    edit: Edit,
+    error_type: ImplicitTypingErrorType,
+}
+
+impl ImplicitTypingEdit {
+    /// Called on the scope that should contain an `implicit none` statement.
+    /// Returns an edit if a violation is found, otherwise returns `None`.
+    fn try_from_scope(node: &Node, src: &SourceFile) -> Option<Self> {
+        match ImplicitStatement::try_from_scope(node, src) {
+            Some(stmt) => {
+                if stmt.is_implicit_none_type() {
+                    // This is sufficient for these rules.
+                    // implicit-external-procedures will handle missing `external` in `implicit none (type)`.
+                    return None;
+                }
+                if stmt.is_implicit_none_external() {
+                    // User has specified `implicit none (external)`, which is
+                    // technically correct but probably a mistake, so we want to
+                    // fix it to `implicit none (type, external)`.
+                    let error_type = ImplicitTypingErrorType::ExternalWithoutType;
+                    let edit = add_type_to_implicit_none(stmt.node(), src)?;
+                    return Some(Self { edit, error_type });
+                }
+                // If we get here, then there is an implicit statement but it's
+                // not `implicit none`. Should replace the whole statement with
+                // `implicit none`.
+                let error_type = ImplicitTypingErrorType::NotImplicitNone;
+                let edit = replace_with_implicit_none(stmt.node(), src);
+                Some(Self { edit, error_type })
+            }
+            None => {
+                // Missing implicit statement -- should insert one.
+                let error_type = ImplicitTypingErrorType::NoImplicitStatement;
+                let edit = insert_implicit_none(node, src)?;
+                Some(Self { edit, error_type })
+            }
+        }
+    }
 }
 
 /// ## What does it do?
@@ -67,6 +137,7 @@ fn insert_implicit_none(node: &Node, src: &SourceFile) -> Option<Fix> {
 #[derive(ViolationMetadata)]
 pub(crate) struct ImplicitTyping {
     entity: String,
+    error_type: ImplicitTypingErrorType,
 }
 
 impl Violation for ImplicitTyping {
@@ -74,14 +145,15 @@ impl Violation for ImplicitTyping {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let Self { entity } = self;
-        format!("{entity} missing 'implicit none'")
+        let Self { entity, .. } = self;
+        format!("{entity} uses implicit typing")
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("Insert `implicit none`".to_string())
+        Some(self.error_type.fix_title())
     }
 }
+
 impl AstRule for ImplicitTyping {
     fn check(
         _settings: &CheckSettings,
@@ -89,25 +161,23 @@ impl AstRule for ImplicitTyping {
         src: &SourceFile,
         _symbol_table: &SymbolTables,
     ) -> Option<Vec<Diagnostic>> {
-        // If a procedure _isn't_ in a parent entity, then it should
-        // have `implicit none`
+        // Run on functions and subroutines only if they aren't in a module,
+        // program, or submodule. This rule will catch implicit typing in the
+        // parent enttity, so we don't need to check it in the children.
         if matches!(node.kind(), "function" | "subroutine")
             && node.parent()?.kind() != "translation_unit"
         {
             return None;
         }
 
-        let implicit_type = ImplicitType::from_scope(node, src)?;
-
-        if implicit_type != ImplicitType::Missing {
-            return None;
-        }
+        let ImplicitTypingEdit { edit, error_type } =
+            ImplicitTypingEdit::try_from_scope(node, src)?;
         let entity = node.kind().to_string();
         let block_stmt = node.child(0)?;
 
         some_vec![
-            Diagnostic::from_node(Self { entity }, &block_stmt)
-                .with_fix(insert_implicit_none(node, src)?)
+            Diagnostic::from_node(Self { entity, error_type }, &block_stmt)
+                .with_fix(Fix::unsafe_edit(edit))
         ]
     }
 
@@ -125,6 +195,7 @@ impl AstRule for ImplicitTyping {
 #[derive(ViolationMetadata)]
 pub(crate) struct InterfaceImplicitTyping {
     name: String,
+    error_type: ImplicitTypingErrorType,
 }
 
 impl Violation for InterfaceImplicitTyping {
@@ -132,12 +203,12 @@ impl Violation for InterfaceImplicitTyping {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let Self { name } = self;
-        format!("interface '{name}' missing 'implicit none'")
+        let Self { name, .. } = self;
+        format!("interface '{name}' uses implicit typing")
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("Insert `implicit none`".to_string())
+        Some(self.error_type.fix_title())
     }
 }
 
@@ -148,20 +219,21 @@ impl AstRule for InterfaceImplicitTyping {
         src: &SourceFile,
         _symbol_table: &SymbolTables,
     ) -> Option<Vec<Diagnostic>> {
+        // Exit early if we're not in an interface.
         let parent = node.parent()?;
         if parent.kind() != "interface" {
             return None;
         }
-        let implicit_type = ImplicitType::from_scope(node, src)?;
-        if implicit_type == ImplicitType::Missing {
-            let name = node.kind().to_string();
-            let interface_stmt = node.child(0)?;
-            return some_vec![
-                Diagnostic::from_node(Self { name }, &interface_stmt)
-                    .with_fix(insert_implicit_none(node, src)?)
-            ];
-        }
-        None
+
+        let ImplicitTypingEdit { edit, error_type } =
+            ImplicitTypingEdit::try_from_scope(node, src)?;
+        let name = node.kind().to_string();
+        let interface_stmt = node.child(0)?;
+
+        some_vec![
+            Diagnostic::from_node(Self { name, error_type }, &interface_stmt)
+                .with_fix(Fix::unsafe_edit(edit))
+        ]
     }
 
     fn entrypoints() -> Vec<&'static str> {
@@ -209,34 +281,27 @@ impl AstRule for ImplicitExternalProcedures {
             return None;
         }
 
-        let edit = match ImplicitType::from_implicit_statement(node, src)? {
-            ImplicitType::Missing
-            | ImplicitType::Implicit
-            | ImplicitType::NoneTypeExternal
-            | ImplicitType::NoneExternal => {
-                // If it's not `implicit none`, then we don't care about it.
-                // If it's `implicit none (type, external)`, then it's already correct.
-                // If it's `implicit none (external)`, then it's technically
-                // correct, but probably a bad idea. C001/implicit-typing will
-                // catch this.
-                return None;
-            }
-            ImplicitType::None => {
-                // If it's `implicit none` without `(external)`, then we want to fix it
-                Edit::insertion(" (type, external)".to_string(), node.end_textsize())
-            }
-            ImplicitType::NoneType => {
-                // If it's `implicit none (type)`, then we want to fix it.
-                node.children(&mut node.walk())
-                    .find(|child| {
-                        child.to_text(src.source_text()).unwrap().to_lowercase() == "type"
-                    })
-                    .map(|type_node| {
-                        Edit::insertion(", external".to_string(), type_node.end_textsize())
-                    })?
-            }
-        };
+        let stmt = ImplicitStatement::try_from_node(*node, src)?;
 
+        if stmt.is_implicit_none_external() {
+            // If `external` is already present, then it's correct.
+            return None;
+        }
+
+        if stmt.is_not_implicit_none() {
+            // This isn't `implicit none` at all, so we don't care about it.
+            return None;
+        }
+
+        // If we get here, it's either `implicit none` or `implicit none
+        // (type)`, so we want to add `external` to it.
+        let edit = node
+            .children(&mut node.walk())
+            .find(|child| child.to_text(src.source_text()).unwrap().to_lowercase() == "type")
+            .map_or_else(
+                || Edit::insertion(" (type, external)".to_string(), node.end_textsize()),
+                |type_node| Edit::insertion(", external".to_string(), type_node.end_textsize()),
+            );
         some_vec!(Diagnostic::from_node(Self {}, node).with_fix(Fix::unsafe_edit(edit)))
     }
 

--- a/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
+++ b/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
@@ -1,5 +1,5 @@
 /// Defines rules that raise errors if implicit typing is in use.
-use crate::ast::FortitudeNode;
+use crate::ast::{FortitudeNode, types::ImplicitType};
 use crate::settings::{CheckSettings, FortranStandard};
 use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
@@ -8,20 +8,6 @@ use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
-
-pub fn implicit_statement_is_none(node: &Node) -> bool {
-    if let Some(child) = node.child(1) {
-        return child.kind() == "none";
-    }
-    false
-}
-
-pub fn has_implicit_none(node: &Node) -> bool {
-    if let Some(child) = node.child_with_name("implicit_statement") {
-        return implicit_statement_is_none(&child);
-    }
-    false
-}
 
 fn insert_implicit_none(node: &Node, src: &SourceFile) -> Option<Fix> {
     // Find suitable place to insert `implicit none`, the line
@@ -111,7 +97,9 @@ impl AstRule for ImplicitTyping {
             return None;
         }
 
-        if has_implicit_none(node) {
+        let implicit_type = ImplicitType::from_scope(node, src)?;
+
+        if implicit_type != ImplicitType::Missing {
             return None;
         }
         let entity = node.kind().to_string();
@@ -161,7 +149,11 @@ impl AstRule for InterfaceImplicitTyping {
         _symbol_table: &SymbolTables,
     ) -> Option<Vec<Diagnostic>> {
         let parent = node.parent()?;
-        if parent.kind() == "interface" && !has_implicit_none(node) {
+        if parent.kind() != "interface" {
+            return None;
+        }
+        let implicit_type = ImplicitType::from_scope(node, src)?;
+        if implicit_type == ImplicitType::Missing {
             let name = node.kind().to_string();
             let interface_stmt = node.child(0)?;
             return some_vec![
@@ -211,34 +203,41 @@ impl AstRule for ImplicitExternalProcedures {
         src: &SourceFile,
         _symbol_table: &SymbolTables,
     ) -> Option<Vec<Diagnostic>> {
+        // implicit none (type, external) was added in Fortran 2018, so don't
+        // run this rule if we're targeting an older standard.
         if settings.target_std < FortranStandard::F2018 {
             return None;
         }
 
-        if !implicit_statement_is_none(node) {
-            return None;
-        }
-
-        let text = node.to_text(src.source_text())?.to_lowercase();
-
-        if !text.contains("external") {
-            let edit = if let Some(type_node) = node
-                .children(&mut node.walk())
-                .find(|child| child.to_text(src.source_text()).unwrap().to_lowercase() == "type")
-            {
-                // Seems unlikely someone would have `implicit none (type)`
-                // without `external` -- is that a sign they _explicitly_ don't
-                // want it? That's probably still unwise though
-                Edit::insertion(", external".to_string(), type_node.end_textsize())
-            } else {
+        let edit = match ImplicitType::from_implicit_statement(node, src)? {
+            ImplicitType::Missing
+            | ImplicitType::Implicit
+            | ImplicitType::NoneTypeExternal
+            | ImplicitType::NoneExternal => {
+                // If it's not `implicit none`, then we don't care about it.
+                // If it's `implicit none (type, external)`, then it's already correct.
+                // If it's `implicit none (external)`, then it's technically
+                // correct, but probably a bad idea. C001/implicit-typing will
+                // catch this.
+                return None;
+            }
+            ImplicitType::None => {
+                // If it's `implicit none` without `(external)`, then we want to fix it
                 Edit::insertion(" (type, external)".to_string(), node.end_textsize())
-            };
-            let fix = Fix::unsafe_edit(edit);
+            }
+            ImplicitType::NoneType => {
+                // If it's `implicit none (type)`, then we want to fix it.
+                node.children(&mut node.walk())
+                    .find(|child| {
+                        child.to_text(src.source_text()).unwrap().to_lowercase() == "type"
+                    })
+                    .map(|type_node| {
+                        Edit::insertion(", external".to_string(), type_node.end_textsize())
+                    })?
+            }
+        };
 
-            some_vec!(Diagnostic::from_node(Self {}, node).with_fix(fix))
-        } else {
-            None
-        }
+        some_vec!(Diagnostic::from_node(Self {}, node).with_fix(Fix::unsafe_edit(edit)))
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
+++ b/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
@@ -52,6 +52,16 @@ fn add_type_to_implicit_none(node: &Node, src: &SourceFile) -> Option<Edit> {
         .map(|external_node| Edit::insertion("type, ".to_string(), external_node.start_textsize()))
 }
 
+// Add `(external)` to `implicit none (type)` or `(type, external)` to `implicit none`.
+fn add_external_to_implicit_none(node: &Node, src: &SourceFile) -> Edit {
+    node.children(&mut node.walk())
+        .find(|child| child.to_text(src.source_text()).unwrap().to_lowercase() == "type")
+        .map_or_else(
+            || Edit::insertion(" (type, external)".to_string(), node.end_textsize()),
+            |type_node| Edit::insertion(", external".to_string(), type_node.end_textsize()),
+        )
+}
+
 enum ImplicitTypingErrorType {
     NoImplicitStatement,
     NotImplicitNone,
@@ -295,13 +305,7 @@ impl AstRule for ImplicitExternalProcedures {
 
         // If we get here, it's either `implicit none` or `implicit none
         // (type)`, so we want to add `external` to it.
-        let edit = node
-            .children(&mut node.walk())
-            .find(|child| child.to_text(src.source_text()).unwrap().to_lowercase() == "type")
-            .map_or_else(
-                || Edit::insertion(" (type, external)".to_string(), node.end_textsize()),
-                |type_node| Edit::insertion(", external".to_string(), type_node.end_textsize()),
-            );
+        let edit = add_external_to_implicit_none(stmt.node(), src);
         some_vec!(Diagnostic::from_node(Self {}, node).with_fix(Fix::unsafe_edit(edit)))
     }
 

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__implicit-typing_C001.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__implicit-typing_C001.f90.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
-snapshot_kind: text
 ---
-./resources/test/fixtures/correctness/C001.f90:1:1: C001 [*] module missing 'implicit none'
+./resources/test/fixtures/correctness/C001.f90:1:1: C001 [*] module uses implicit typing
   |
 1 | module my_module
   | ^^^^^^^^^^^^^^^^ C001
@@ -19,7 +18,7 @@ snapshot_kind: text
 3 4 | end module my_module
 4 5 | 
 
-./resources/test/fixtures/correctness/C001.f90:5:1: C001 [*] module missing 'implicit none'
+./resources/test/fixtures/correctness/C001.f90:5:1: C001 [*] module uses implicit typing
   |
 3 | end module my_module
 4 |
@@ -40,7 +39,7 @@ snapshot_kind: text
 8 9 | contains
 9 10 |   integer function double(x)
 
-./resources/test/fixtures/correctness/C001.f90:15:1: C001 [*] program missing 'implicit none'
+./resources/test/fixtures/correctness/C001.f90:15:1: C001 [*] program uses implicit typing
    |
 13 | end module safe_fix
 14 |
@@ -61,7 +60,7 @@ snapshot_kind: text
 20 21 |   write(*,*) 42
 21 22 | end program my_program
 
-./resources/test/fixtures/correctness/C001.f90:23:1: C001 [*] subroutine missing 'implicit none'
+./resources/test/fixtures/correctness/C001.f90:23:1: C001 [*] subroutine uses implicit typing
    |
 21 | end program my_program
 22 |
@@ -79,3 +78,47 @@ snapshot_kind: text
    24 |+implicit none
 24 25 |   print*, x
 25 26 | end subroutine external_sub
+26 27 | 
+
+./resources/test/fixtures/correctness/C001.f90:27:1: C001 [*] module uses implicit typing
+   |
+25 | end subroutine external_sub
+26 |
+27 | module my_module_external
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ C001
+28 |   implicit none (external)
+29 |   parameter(N = 1)
+30 | end module my_module_external
+   |
+   = help: Change to `implicit none (type, external)`
+
+ℹ Unsafe fix
+25 25 | end subroutine external_sub
+26 26 | 
+27 27 | module my_module_external
+28    |-  implicit none (external)
+   28 |+  implicit none (type, external)
+29 29 |   parameter(N = 1)
+30 30 | end module my_module_external
+31 31 | 
+
+./resources/test/fixtures/correctness/C001.f90:32:1: C001 [*] function uses implicit typing
+   |
+30 | end module my_module_external
+31 |
+32 | real function external_func() result(x)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C001
+33 |   implicit real (a-z)
+34 |   x = 3.14
+35 | end function external_func
+   |
+   = help: Change to `implicit none`
+
+ℹ Unsafe fix
+30 30 | end module my_module_external
+31 31 | 
+32 32 | real function external_func() result(x)
+33    |-  implicit real (a-z)
+   33 |+  implicit none
+34 34 |   x = 3.14
+35 35 | end function external_func

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__interface-implicit-typing_C002.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__interface-implicit-typing_C002.f90.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
-snapshot_kind: text
 ---
-./resources/test/fixtures/correctness/C002.f90:4:5: C002 [*] interface 'function' missing 'implicit none'
+./resources/test/fixtures/correctness/C002.f90:4:5: C002 [*] interface 'function' uses implicit typing
   |
 2 |   implicit none
 3 |   interface
@@ -11,7 +10,6 @@ snapshot_kind: text
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ C002
 5 |       integer, intent(in) :: x
 6 |     end function myfunc
-7 |   end interface
   |
   = help: Insert `implicit none`
 
@@ -22,25 +20,68 @@ snapshot_kind: text
   5 |+    implicit none
 5 6 |       integer, intent(in) :: x
 6 7 |     end function myfunc
-7 8 |   end interface
+7 8 | 
 
-./resources/test/fixtures/correctness/C002.f90:13:5: C002 [*] interface 'subroutine' missing 'implicit none'
+./resources/test/fixtures/correctness/C002.f90:8:5: C002 [*] interface 'subroutine' uses implicit typing
    |
-11 |   implicit none
-12 |   interface
-13 |     subroutine myfunc2(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^ C002
-14 |       integer, intent(inout) :: x
-15 |     end subroutine myfunc2
-16 |   end interface
+ 6 |     end function myfunc
+ 7 |
+ 8 |     subroutine mysub(x)
+   |     ^^^^^^^^^^^^^^^^^^^ C002
+ 9 |       implicit none (external)
+10 |       integer, intent(in) :: x
+11 |     end subroutine mysub
+   |
+   = help: Change to `implicit none (type, external)`
+
+ℹ Unsafe fix
+6  6  |     end function myfunc
+7  7  | 
+8  8  |     subroutine mysub(x)
+9     |-      implicit none (external)
+   9  |+      implicit none (type, external)
+10 10 |       integer, intent(in) :: x
+11 11 |     end subroutine mysub
+12 12 |   end interface
+
+./resources/test/fixtures/correctness/C002.f90:18:5: C002 [*] interface 'function' uses implicit typing
+   |
+16 |   implicit none
+17 |   interface
+18 |     real function myfunc2(x)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ C002
+19 |       implicit real (a,z)
+20 |     end function myfunc2
+   |
+   = help: Change to `implicit none`
+
+ℹ Unsafe fix
+16 16 |   implicit none
+17 17 |   interface
+18 18 |     real function myfunc2(x)
+19    |-      implicit real (a,z)
+   19 |+      implicit none
+20 20 |     end function myfunc2
+21 21 | 
+22 22 |     subroutine mysub2(x)
+
+./resources/test/fixtures/correctness/C002.f90:22:5: C002 [*] interface 'subroutine' uses implicit typing
+   |
+20 |     end function myfunc2
+21 |
+22 |     subroutine mysub2(x)
+   |     ^^^^^^^^^^^^^^^^^^^^ C002
+23 |       integer, intent(inout) :: x
+24 |     end subroutine mysub2
+25 |   end interface
    |
    = help: Insert `implicit none`
 
 ℹ Unsafe fix
-11 11 |   implicit none
-12 12 |   interface
-13 13 |     subroutine myfunc2(x)
-   14 |+    implicit none
-14 15 |       integer, intent(inout) :: x
-15 16 |     end subroutine myfunc2
-16 17 |   end interface
+20 20 |     end function myfunc2
+21 21 | 
+22 22 |     subroutine mysub2(x)
+   23 |+    implicit none
+23 24 |       integer, intent(inout) :: x
+24 25 |     end subroutine mysub2
+25 26 |   end interface

--- a/crates/fortitude_linter/src/rules/style/implicit_none.rs
+++ b/crates/fortitude_linter/src/rules/style/implicit_none.rs
@@ -1,5 +1,5 @@
 /// Defines rules that raise errors if implicit typing is in use.
-use crate::ast::{FortitudeNode, types::ImplicitType};
+use crate::ast::{FortitudeNode, types::ImplicitStatement};
 use crate::settings::CheckSettings;
 use crate::symbol_table::SymbolTables;
 use crate::{AstRule, FromAstNode};
@@ -38,9 +38,9 @@ impl AstRule for SuperfluousImplicitNone {
         src: &SourceFile,
         _symbol_table: &SymbolTables,
     ) -> Option<Vec<Diagnostic>> {
+        let stmt = ImplicitStatement::try_from_node(*node, src)?;
         // If this isn't an `implicit none` statement, then we don't care about it.
-        let implicit_type = ImplicitType::from_implicit_statement(node, src)?;
-        if implicit_type == ImplicitType::Implicit {
+        if stmt.is_not_implicit_none() {
             return None;
         }
         let parent = node.parent()?;
@@ -48,40 +48,33 @@ impl AstRule for SuperfluousImplicitNone {
             for ancestor in parent.ancestors() {
                 let kind = ancestor.kind();
                 match kind {
+                    "interface" => {
+                        // Implicit none doesn't propagate through interfaces.
+                        break;
+                    }
                     "module" | "submodule" | "program" | "function" | "subroutine" => {
-                        match ImplicitType::from_scope(&ancestor, src)? {
-                            ImplicitType::Missing => {
-                                // Keep searching up the tree for a higher-level
-                                // entity with `implicit none`, if any. If we
-                                // reach the top without finding one, then it's
-                                // not a problem.
+                        match ImplicitStatement::try_from_scope(&ancestor, src) {
+                            None => {
+                                // If the ancestor doesn't have any `implicit` statement, then
+                                // keep searching up the tree for a higher-level entity with
+                                // `implicit none`, if any. If we reach the top without finding
+                                // one, then it's not a problem.
                                 continue;
                             }
-                            ImplicitType::Implicit => {
-                                // If we find an ancestor entity with `implicit
-                                // type(a-z)`, then this one is not superfluous.
-                                break;
-                            }
-                            ancestor_implicit_type => {
-                                // If we find an ancestor entity with `implicit
-                                // none`, then this one is superfluous provided
-                                // it is equivalent to the ancestor's `implicit
-                                // none` (e.g. `implicit none (type)` is not
-                                // equivalent to `implicit none (external)`, but
-                                // is to `implicit none`).
-                                if !implicit_type.equivalent_to(&ancestor_implicit_type) {
+                            Some(ancestor_stmt) => {
+                                // If the ancestor statement is equivalent to this one,
+                                // then this one is superfluous and should be removed.
+                                if stmt.is_equivalent_to(&ancestor_stmt) {
+                                    let entity = kind.to_string();
+                                    let fix = Fix::safe_edit(node.edit_delete(src));
+                                    return some_vec![
+                                        Diagnostic::from_node(Self { entity }, node).with_fix(fix)
+                                    ];
+                                } else {
                                     break;
                                 }
-                                let entity = kind.to_string();
-                                let fix = Fix::safe_edit(node.edit_delete(src));
-                                return some_vec![
-                                    Diagnostic::from_node(Self { entity }, node).with_fix(fix)
-                                ];
                             }
                         }
-                    }
-                    "interface" => {
-                        break;
                     }
                     _ => {
                         continue;

--- a/crates/fortitude_linter/src/rules/style/implicit_none.rs
+++ b/crates/fortitude_linter/src/rules/style/implicit_none.rs
@@ -1,6 +1,5 @@
 /// Defines rules that raise errors if implicit typing is in use.
-use crate::ast::FortitudeNode;
-use crate::rules::correctness::implicit_typing::{has_implicit_none, implicit_statement_is_none};
+use crate::ast::{FortitudeNode, types::ImplicitType};
 use crate::settings::CheckSettings;
 use crate::symbol_table::SymbolTables;
 use crate::{AstRule, FromAstNode};
@@ -39,7 +38,9 @@ impl AstRule for SuperfluousImplicitNone {
         src: &SourceFile,
         _symbol_table: &SymbolTables,
     ) -> Option<Vec<Diagnostic>> {
-        if !implicit_statement_is_none(node) {
+        // If this isn't an `implicit none` statement, then we don't care about it.
+        let implicit_type = ImplicitType::from_implicit_statement(node, src)?;
+        if implicit_type == ImplicitType::Implicit {
             return None;
         }
         let parent = node.parent()?;
@@ -48,14 +49,36 @@ impl AstRule for SuperfluousImplicitNone {
                 let kind = ancestor.kind();
                 match kind {
                     "module" | "submodule" | "program" | "function" | "subroutine" => {
-                        if !has_implicit_none(&ancestor) {
-                            continue;
+                        match ImplicitType::from_scope(&ancestor, src)? {
+                            ImplicitType::Missing => {
+                                // Keep searching up the tree for a higher-level
+                                // entity with `implicit none`, if any. If we
+                                // reach the top without finding one, then it's
+                                // not a problem.
+                                continue;
+                            }
+                            ImplicitType::Implicit => {
+                                // If we find an ancestor entity with `implicit
+                                // type(a-z)`, then this one is not superfluous.
+                                break;
+                            }
+                            ancestor_implicit_type => {
+                                // If we find an ancestor entity with `implicit
+                                // none`, then this one is superfluous provided
+                                // it is equivalent to the ancestor's `implicit
+                                // none` (e.g. `implicit none (type)` is not
+                                // equivalent to `implicit none (external)`, but
+                                // is to `implicit none`).
+                                if !implicit_type.equivalent_to(&ancestor_implicit_type) {
+                                    break;
+                                }
+                                let entity = kind.to_string();
+                                let fix = Fix::safe_edit(node.edit_delete(src));
+                                return some_vec![
+                                    Diagnostic::from_node(Self { entity }, node).with_fix(fix)
+                                ];
+                            }
                         }
-                        let entity = kind.to_string();
-                        let fix = Fix::safe_edit(node.edit_delete(src));
-                        return some_vec![
-                            Diagnostic::from_node(Self { entity }, node).with_fix(fix)
-                        ];
                     }
                     "interface" => {
                         break;

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-implicit-none_S201.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-implicit-none_S201.f90.snap
@@ -1,7 +1,6 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
-snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S201.f90:5:5: S201 [*] 'implicit none' set on the enclosing module
   |
@@ -27,8 +26,8 @@ snapshot_kind: text
    |
  8 |   end function myfunc
  9 |   subroutine mysub(x)
-10 |     implicit none
-   |     ^^^^^^^^^^^^^ S201
+10 |     implicit none (type)
+   |     ^^^^^^^^^^^^^^^^^^^^ S201
 11 |     integer, intent(inout) :: x
 12 |     x = x * 2
    |
@@ -38,7 +37,7 @@ snapshot_kind: text
 7  7  |     myfunc = x * 2
 8  8  |   end function myfunc
 9  9  |   subroutine mysub(x)
-10    |-    implicit none
+10    |-    implicit none (type)
 11 10 |     integer, intent(inout) :: x
 12 11 |     x = x * 2
 13 12 |   end subroutine mysub

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -14,8 +14,8 @@
 
 | Code | Name | Message | |
 | ---- | ---- | ------- | ------: |
-| C001 | [implicit-typing](rules/implicit-typing.md) | {entity} missing 'implicit none' | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
-| C002 | [interface-implicit-typing](rules/interface-implicit-typing.md) | interface '{name}' missing 'implicit none' | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| C001 | [implicit-typing](rules/implicit-typing.md) | {entity} uses implicit typing | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| C002 | [interface-implicit-typing](rules/interface-implicit-typing.md) | interface '{name}' uses implicit typing | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | C003 | [implicit-external-procedures](rules/implicit-external-procedures.md) | 'implicit none' missing 'external' | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | C011 | [missing-default-case](rules/missing-default-case.md) | Missing default case may not handle all values | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | C021 | [no-real-suffix](rules/no-real-suffix.md) | real literal {literal} missing kind suffix | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |


### PR DESCRIPTION
Resolves https://github.com/PlasmaFAIR/fortitude/issues/609

Our rules for implicit typing are missing a few edge cases. For example:

- As stated in #609, `implicit-typing` misses `implicit none (external)`.
- `superfluous-implicit-none` doesn't check if the `implicit none` in the higher scope is actually equivalent, e.g. `implicit none (type) == implicit none`, but `implicit none (external) != implicit none`.

I've started a refactor of the machinery around these rules so we can better handle each case. I still need to make some changes to a few rules and add all of the edge cases to the tests.

This one affects rules that have been long out of preview, so we'll have to make sure we get this right!