### PR TITLE
Add superfluous save lint

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/modernisation/MOD051.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/modernisation/MOD051.f90
@@ -1,0 +1,14 @@
+module test
+  save
+
+  integer :: a
+
+  contains
+    subroutine should_have_save()
+      integer, save :: b = 0
+    end subroutine should_have_save
+end module test
+
+module test
+  integer, save :: a
+end module test

--- a/crates/fortitude_linter/src/rules/mod.rs
+++ b/crates/fortitude_linter/src/rules/mod.rs
@@ -120,6 +120,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Modernisation, "021") => (RuleGroup::Stable, Ast, Default, modernisation::relational_operators::DeprecatedRelationalOperator),
         (Modernisation, "031") => (RuleGroup::Stable, Ast, Optional, modernisation::include_statement::IncludeStatement),
         (Modernisation, "041") => (RuleGroup::Preview, Ast, Default, modernisation::out_of_line_attribute::OutOfLineAttribute),
+        (Modernisation, "051") => (RuleGroup::Preview, Ast, Default, modernisation::save::SuperfluousSave),
         (Modernisation, "201") => (RuleGroup::Preview, Ast, Optional, modernisation::mpi::OldMPIModule),
 
         // portability

--- a/crates/fortitude_linter/src/rules/modernisation/mod.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod mpi;
 pub(crate) mod old_style_array_literal;
 pub mod out_of_line_attribute;
 pub(crate) mod relational_operators;
+pub(crate) mod save;
 
 #[cfg(test)]
 mod tests {
@@ -26,6 +27,7 @@ mod tests {
     #[test_case(Rule::IncludeStatement, Path::new("MOD031.f90"))]
     #[test_case(Rule::OldMPIModule, Path::new("MOD201.f90"))]
     #[test_case(Rule::OutOfLineAttribute, Path::new("MOD041.f90"))]
+    #[test_case(Rule::SuperfluousSave, Path::new("MOD051.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/fortitude_linter/src/rules/modernisation/save.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/save.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 
 use crate::{
@@ -38,16 +38,14 @@ pub(crate) struct SuperfluousSave {
     entity: &'static str,
 }
 
-impl Violation for SuperfluousSave {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
-
+impl AlwaysFixableViolation for SuperfluousSave {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("save {} is superfluous at the module level", self.entity)
     }
 
-    fn fix_title(&self) -> Option<String> {
-        Some("Remove `save`".to_string())
+    fn fix_title(&self) -> String {
+        "Remove `save`".to_string()
     }
 }
 

--- a/crates/fortitude_linter/src/rules/modernisation/save.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/save.rs
@@ -1,0 +1,123 @@
+use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use ruff_macros::{ViolationMetadata, derive_message_formats};
+
+use crate::{
+    AstRule, FromAstNode, ast::FortitudeNode, settings::FortranStandard, traits::TextRanged,
+};
+
+/// ## What it does
+/// Checks for unnecessary `save` statements and qualifiers
+///
+/// ## Why is this bad?
+/// Since Fortran 2008, module variables are implicitly saved. Save statements
+/// and attributes can safely be removed.
+///
+/// ## Example
+/// ```f90
+/// module example
+///     integer, save :: a
+/// end module example
+/// ```
+/// or
+/// ```f90
+/// module example
+///     save
+///
+///     integer :: a
+/// end module example
+/// ```
+///
+/// Use instead:
+/// ```f90
+/// module example
+///     integer :: a
+/// end module example
+/// ```
+#[derive(ViolationMetadata)]
+pub(crate) struct SuperfluousSave {
+    entity: &'static str,
+}
+
+impl Violation for SuperfluousSave {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("save {} is superfluous at the module level", self.entity)
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Remove `save`".to_string())
+    }
+}
+
+impl AstRule for SuperfluousSave {
+    fn check(
+        settings: &crate::settings::CheckSettings,
+        node: &tree_sitter::Node,
+        source: &ruff_source_file::SourceFile,
+        _symbol_table: &crate::ast::symbol_table::SymbolTables,
+    ) -> Option<Vec<ruff_diagnostics::Diagnostic>> {
+        // Only F2008 and later made `save` at the module level implicit
+        if settings.target_std < FortranStandard::F2008 {
+            return None;
+        }
+
+        if node.kind() == "variable_declaration" {
+            if node
+                .parent()
+                .is_none_or(|x| !matches!(x.kind(), "module" | "submodule"))
+            {
+                return None;
+            }
+
+            let save_qualifier = node
+                .named_children(&mut node.walk())
+                .filter(|c| c.grammar_name() == "type_qualifier")
+                .find(|c| c.to_text(source.source_text()) == Some("save"))?;
+
+            let start_node = match save_qualifier.prev_sibling() {
+                None => save_qualifier,
+                Some(prev) => {
+                    if prev.grammar_name() == "," {
+                        prev
+                    } else {
+                        save_qualifier
+                    }
+                }
+            };
+
+            some_vec![
+                Diagnostic::from_node(
+                    Self {
+                        entity: "attribute"
+                    },
+                    &save_qualifier
+                )
+                .with_fix(Fix::safe_edit(Edit::deletion(
+                    start_node.start_textsize(),
+                    save_qualifier.end_textsize()
+                )))
+            ]
+        } else {
+            let save_statement = node.child_with_name("save_statement")?;
+
+            some_vec![
+                Diagnostic::from_node(
+                    Self {
+                        entity: "statement"
+                    },
+                    &save_statement
+                )
+                .with_fix(Fix::safe_edit(Edit::deletion(
+                    save_statement.start_textsize(),
+                    save_statement.end_textsize()
+                )))
+            ]
+        }
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["module", "submodule", "variable_declaration"]
+    }
+}

--- a/crates/fortitude_linter/src/rules/modernisation/save.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/save.rs
@@ -107,10 +107,7 @@ impl AstRule for SuperfluousSave {
                     },
                     &save_statement
                 )
-                .with_fix(Fix::safe_edit(Edit::deletion(
-                    save_statement.start_textsize(),
-                    save_statement.end_textsize()
-                )))
+                .with_fix(Fix::safe_edit(save_statement.edit_delete(source)))
             ]
         }
     }

--- a/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__superfluous-save_MOD051.f90.snap
+++ b/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__superfluous-save_MOD051.f90.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/modernisation/mod.rs
-assertion_line: 38
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/modernisation/MOD051.f90:2:3: MOD051 [*] save statement is superfluous at the module level
   |
@@ -16,10 +16,9 @@ expression: diagnostics
 ℹ Safe fix
 1 1 | module test
 2   |-  save
-  2 |+  
-3 3 | 
-4 4 |   integer :: a
-5 5 | 
+3 2 | 
+4 3 |   integer :: a
+5 4 | 
 
 ./resources/test/fixtures/modernisation/MOD051.f90:13:12: MOD051 [*] save attribute is superfluous at the module level
    |

--- a/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__superfluous-save_MOD051.f90.snap
+++ b/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__superfluous-save_MOD051.f90.snap
@@ -1,0 +1,39 @@
+---
+source: crates/fortitude_linter/src/rules/modernisation/mod.rs
+assertion_line: 38
+expression: diagnostics
+---
+./resources/test/fixtures/modernisation/MOD051.f90:2:3: MOD051 [*] save statement is superfluous at the module level
+  |
+1 | module test
+2 |   save
+  |   ^^^^ MOD051
+3 |
+4 |   integer :: a
+  |
+  = help: Remove `save`
+
+ℹ Safe fix
+1 1 | module test
+2   |-  save
+  2 |+  
+3 3 | 
+4 4 |   integer :: a
+5 5 | 
+
+./resources/test/fixtures/modernisation/MOD051.f90:13:12: MOD051 [*] save attribute is superfluous at the module level
+   |
+12 | module test
+13 |   integer, save :: a
+   |            ^^^^ MOD051
+14 | end module test
+   |
+   = help: Remove `save`
+
+ℹ Safe fix
+10 10 | end module test
+11 11 | 
+12 12 | module test
+13    |-  integer, save :: a
+   13 |+  integer :: a
+14 14 | end module test

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -76,6 +76,7 @@
 | MOD021 | [deprecated-relational-operator](rules/deprecated-relational-operator.md) | deprecated relational operator '{symbol}', prefer '{new_symbol}' instead | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | MOD031 | [include-statement](rules/include-statement.md) | Include statement is deprecated, use modules instead | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 | MOD041 | [out-of-line-attribute](rules/out-of-line-attribute.md) | Out of line '{attribute}' attribute for variable '{variable}' | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| MOD051 | [superfluous-save](rules/superfluous-save.md) | save {} is superfluous at the module level | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | MOD201 | [old-mpi-module](rules/old-mpi-module.md) | Use of mpi module discouraged, use mpi_f08 instead | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 
 ### Style (S)

--- a/docs/rules/superfluous-save.md
+++ b/docs/rules/superfluous-save.md
@@ -1,0 +1,35 @@
+# superfluous-save (MOD051)
+Fix is always available.
+
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+This rule is turned on by default.
+
+## What it does
+Checks for unnecessary `save` statements and qualifiers
+
+## Why is this bad?
+Since Fortran 2008, module variables are implicitly saved. Save statements
+and attributes can safely be removed.
+
+## Example
+```f90
+module example
+    integer, save :: a
+end module example
+```
+or
+```f90
+module example
+    save
+
+    integer :: a
+end module example
+```
+
+Use instead:
+```f90
+module example
+    integer :: a
+end module example
+```


### PR DESCRIPTION
Since Fortran 2008, `save` statements and attributes are no longer needed for module level variables.