### PR TITLE
Fix explaination of C101 rule

### DIFF
--- a/crates/fortitude_linter/src/rules/correctness/derived_default_init.rs
+++ b/crates/fortitude_linter/src/rules/correctness/derived_default_init.rs
@@ -42,7 +42,7 @@ use tree_sitter::Node;
 ///     real :: val1
 ///     integer :: val2
 ///
-///     real, pointer :: pReal1
+///     real, pointer :: pReal1 => null()
 ///
 ///     integer, pointer :: pInt1 => null()
 ///     integer, pointer :: pI1 => null()

--- a/docs/rules/missing-default-pointer-initalisation.md
+++ b/docs/rules/missing-default-pointer-initalisation.md
@@ -35,7 +35,7 @@ type mytype
     real :: val1
     integer :: val2
 
-    real, pointer :: pReal1
+    real, pointer :: pReal1 => null()
 
     integer, pointer :: pInt1 => null()
     integer, pointer :: pI1 => null()


### PR DESCRIPTION
The current explaination of C101 rule is 

```
fortitude explain C101
C101: missing-default-pointer-initalisation

What it does
Checks for uninitialised pointer variables inside derived types

Why is this bad?
Pointers inside derived types are undefined by default, and their
status cannot be tested by intrinsics such as associated. Pointer
variables should be initialised by either associating them with another
variable, or associating to null().


Examples
For example, this derived type:

type mytype                               
    real :: val1                          
    integer :: val2                       
                                          
    real, pointer :: pReal1               
                                          
    integer, pointer :: pInt1 => null()   
    integer, pointer :: pI1               
    integer, pointer :: pI2 => null(), pI3
end mytype                                

will have the pointers pReal1, pI1, and pI3 uninitialised
whenever it is created. Instead, they should be initialised like:

type mytype                                          
    real :: val1                                     
    integer :: val2                                  
                                                     
    real, pointer :: pReal1                          
                                                     
    integer, pointer :: pInt1 => null()              
    integer, pointer :: pI1 => null()                
    integer, pointer :: pI2 => null(), pI3  => null()
end mytype                                           

This feature is only available in Fortran 2003 and later.

References
- Metcalf, M., Reid, J. and Cohen, M., 2018, _Modern Fortran Explained:
  Incorporating Fortran 2018_, Oxford University Press, Section 8.5.3/8.5.4.
- Clerman, N. Spector, W., 2012, _Modern Fortran: Style and Usage_, Cambridge
  University Press, Rule 136, p. 189.
```

Unless I am missing something pReal1 should be set to null, in the example showing how mytype should be defined.