### PR TITLE
Disable per-file-ignores rules rather than dropping messages

### DIFF
--- a/crates/fortitude/src/check.rs
+++ b/crates/fortitude/src/check.rs
@@ -426,7 +426,7 @@ fn check_stdin(
     let path = filename.unwrap_or_else(|| Path::new("-"));
     let source_file = SourceFileBuilder::new(path.to_str().unwrap_or("-"), stdin.as_str()).finish();
 
-    let (mut messages, fixed) = if matches!(fix_mode, FixMode::Apply | FixMode::Diff) {
+    let (messages, fixed) = if matches!(fix_mode, FixMode::Apply | FixMode::Diff) {
         match check_and_fix_file(path, &source_file, &settings.check, ignore_allow_comments) {
             Ok(FixerResult {
                 result,
@@ -477,24 +477,6 @@ fn check_stdin(
         let fixed = FxHashMap::default();
         (result, fixed)
     };
-
-    let per_file_ignores = &settings.check.per_file_ignores;
-    // Ignore based on per-file-ignores.
-    // If the DiagnosticMessage is discarded, its fix will also be ignored.
-    let per_file_ignores = if !messages.is_empty() && !per_file_ignores.is_empty() {
-        fs::ignores_from_path(path, per_file_ignores)
-    } else {
-        vec![]
-    };
-    if !per_file_ignores.is_empty() {
-        messages.retain(|message| {
-            if let Some(rule) = message.rule() {
-                !per_file_ignores.contains(&rule)
-            } else {
-                true
-            }
-        });
-    }
 
     let diagnostics = Diagnostics {
         messages,

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -29,8 +29,6 @@ use diagnostics::{DiagnosticMessage, Diagnostics, FixMap};
 use fix::{FixResult, fix_file};
 use locator::Locator;
 use registry::AsRule;
-use rule_table::RuleTable;
-use rules::AstRuleEnum;
 use rules::correctness::split_escaped_quote::SplitEscapedQuote;
 use rules::error::invalid_character::check_invalid_character;
 use rules::error::syntax_error::SyntaxError;
@@ -52,11 +50,11 @@ use itertools::Itertools;
 use ruff_source_file::SourceFile;
 use rustc_hash::FxHashMap;
 use source_kind::SourceKindDiff;
+use std::borrow::Cow;
 use std::fs::File;
 use std::io::{self, Write};
 use std::iter::once;
 use std::path::Path;
-use std::{borrow::Cow, collections::BTreeMap};
 use tree_sitter::{Node, Parser, Tree};
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -86,7 +84,7 @@ pub fn check_file(
     fix_mode: FixMode,
     ignore_allow_comments: settings::IgnoreAllowComments,
 ) -> anyhow::Result<Diagnostics> {
-    let (mut messages, fixed) = if matches!(fix_mode, FixMode::Apply | FixMode::Diff) {
+    let (messages, fixed) = if matches!(fix_mode, FixMode::Apply | FixMode::Diff) {
         if let Ok(FixerResult {
             result,
             transformed,
@@ -122,24 +120,6 @@ pub fn check_file(
         let fixed = FxHashMap::default();
         (result, fixed)
     };
-
-    // Ignore based on per-file-ignores.
-    // If the DiagnosticMessage is discarded, its fix will also be ignored.
-    let per_file_ignores = &settings.per_file_ignores;
-    let per_file_ignores = if !messages.is_empty() && !per_file_ignores.is_empty() {
-        fs::ignores_from_path(path, per_file_ignores)
-    } else {
-        vec![]
-    };
-    if !per_file_ignores.is_empty() {
-        messages.retain(|message| {
-            if let Some(rule) = message.rule() {
-                !per_file_ignores.contains(&rule)
-            } else {
-                true
-            }
-        });
-    }
 
     Ok(Diagnostics {
         messages,
@@ -183,7 +163,11 @@ pub(crate) fn check_path(
     let mut violations = Vec::new();
     let mut allow_comments = Vec::new();
 
-    let rules = &settings.rules;
+    // Ignore diagnostics based on per-file-ignores.
+    let mut rules = settings.rules.clone();
+    for ignore in crate::fs::ignores_from_path(path, &settings.per_file_ignores) {
+        rules.disable(ignore);
+    }
 
     // Check file paths directly
     if rules.enabled(Rule::NonStandardFileExtension) {
@@ -245,7 +229,7 @@ pub(crate) fn check_path(
             }
         }
 
-        if let Some(rules) = settings.ast_entrypoints.get(node.kind()) {
+        if let Some(rules) = rules.ast_entrypoints().get(node.kind()) {
             for rule in rules {
                 if let Some(violation) = rule.check(settings, &node, file, &symbol_table) {
                     violations.extend(violation);
@@ -315,7 +299,7 @@ pub(crate) fn check_path(
             Rule::DisabledAllowComment,
         ])
     {
-        let ignored = check_allow_comments(&mut violations, &allow_comments, rules, file);
+        let ignored = check_allow_comments(&mut violations, &allow_comments, &rules, file);
         if ignore_allow_comments.is_disabled() {
             for index in ignored.iter().rev() {
                 violations.swap_remove(*index);
@@ -553,29 +537,6 @@ This indicates a bug in Fortitude. If you could open an issue at:
             codes,
         );
     }
-}
-
-/// Create a mapping of AST entrypoints to lists of the rules and codes that operate on them.
-pub fn ast_entrypoint_map(rules: &RuleTable) -> BTreeMap<&'static str, Vec<AstRuleEnum>> {
-    let ast_rules: Vec<AstRuleEnum> = rules
-        .iter_enabled()
-        .filter_map(|rule| TryFrom::try_from(rule).ok())
-        .collect();
-
-    let mut map: BTreeMap<&'static str, Vec<_>> = BTreeMap::new();
-    for rule in ast_rules {
-        for entrypoint in rule.entrypoints() {
-            match map.get_mut(entrypoint) {
-                Some(rule_vec) => {
-                    rule_vec.push(rule);
-                }
-                None => {
-                    map.insert(entrypoint, vec![rule]);
-                }
-            }
-        }
-    }
-    map
 }
 
 /// Simplify making a `SourceFile` in tests

--- a/crates/fortitude_linter/src/rule_table.rs
+++ b/crates/fortitude_linter/src/rule_table.rs
@@ -2,9 +2,13 @@
 // Copyright 2022 Charles Marsh
 // SPDX-License-Identifier: MIT
 
-use std::fmt::{Debug, Display, Formatter};
+use std::{
+    collections::BTreeMap,
+    fmt::{Debug, Display, Formatter},
+    sync::OnceLock,
+};
 
-use crate::display_settings;
+use crate::{display_settings, rules::AstRuleEnum};
 use ruff_macros::CacheKey;
 
 use crate::registry::{Rule, RuleSet, RuleSetIterator};
@@ -15,6 +19,8 @@ pub struct RuleTable {
     /// Maps rule codes to a boolean indicating if the rule should be fixed.
     enabled: RuleSet,
     should_fix: RuleSet,
+    #[cache_key(ignore)]
+    ast_entrypoints: OnceLock<BTreeMap<&'static str, Vec<AstRuleEnum>>>,
 }
 
 impl RuleTable {
@@ -23,6 +29,7 @@ impl RuleTable {
         Self {
             enabled: RuleSet::empty(),
             should_fix: RuleSet::empty(),
+            ast_entrypoints: OnceLock::new(),
         }
     }
 
@@ -57,6 +64,8 @@ impl RuleTable {
         if should_fix {
             self.should_fix.insert(rule);
         }
+        // Invalidate the AST entrypoints
+        self.ast_entrypoints.take();
     }
 
     /// Disables the given rule.
@@ -64,6 +73,26 @@ impl RuleTable {
     pub fn disable(&mut self, rule: Rule) {
         self.enabled.remove(rule);
         self.should_fix.remove(rule);
+        // Invalidate the AST entrypoints
+        self.ast_entrypoints.take();
+    }
+
+    /// Return a mapping of AST entrypoints to lists of the rules and codes that
+    /// operate on them.
+    pub fn ast_entrypoints(&self) -> &BTreeMap<&'static str, Vec<AstRuleEnum>> {
+        self.ast_entrypoints.get_or_init(|| {
+            let mut map: BTreeMap<&'static str, Vec<_>> = BTreeMap::new();
+
+            self.iter_enabled()
+                .filter_map(|rule| TryFrom::try_from(rule).ok())
+                .for_each(|rule: AstRuleEnum| {
+                    for entrypoint in rule.entrypoints() {
+                        map.entry(entrypoint).or_default().push(rule);
+                    }
+                });
+
+            map
+        })
     }
 }
 
@@ -87,6 +116,7 @@ impl FromIterator<Rule> for RuleTable {
         Self {
             enabled: rules.clone(),
             should_fix: rules,
+            ast_entrypoints: OnceLock::new(),
         }
     }
 }

--- a/crates/fortitude_linter/src/settings.rs
+++ b/crates/fortitude_linter/src/settings.rs
@@ -2,7 +2,6 @@
 // Copyright 2022 Charles Marsh
 // SPDX-License-Identifier: MIT
 
-use std::collections::BTreeMap;
 /// A collection of user-modifiable settings. Should be expanded as new features are added.
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -15,15 +14,14 @@ use ruff_macros::CacheKey;
 use serde::{Deserialize, Deserializer, Serialize, de};
 use strum::IntoEnumIterator;
 
+use crate::display_settings;
 use crate::fs::{EXCLUDE_BUILTINS, FilePatternSet, INCLUDE};
 use crate::registry::Rule;
 use crate::rule_selector::{CompiledPerFileIgnoreList, PreviewOptions, RuleSelector};
 use crate::rule_table::RuleTable;
-use crate::rules::AstRuleEnum;
 use crate::rules::correctness::{exit_labels, use_statements};
 use crate::rules::portability::{self, invalid_tab};
 use crate::rules::style::{complexity, inconsistent_dimension, keywords, line_length, strings};
-use crate::{ast_entrypoint_map, display_settings};
 
 #[derive(Debug)]
 pub struct Settings {
@@ -61,7 +59,6 @@ pub struct CheckSettings {
 
     pub rules: RuleTable,
     pub per_file_ignores: CompiledPerFileIgnoreList,
-    pub ast_entrypoints: BTreeMap<&'static str, Vec<AstRuleEnum>>,
 
     pub line_length: usize,
 
@@ -101,7 +98,6 @@ impl CheckSettings {
                 .iter()
                 .flat_map(|selector| selector.rules(&PreviewOptions::default()))
                 .collect(),
-            ast_entrypoints: BTreeMap::new(),
             per_file_ignores: CompiledPerFileIgnoreList::default(),
             line_length: 100,
             fix: false,
@@ -131,11 +127,9 @@ impl CheckSettings {
 
     pub fn for_rules(rules: impl IntoIterator<Item = Rule>) -> Self {
         let rules = RuleTable::from_iter(rules);
-        let ast_entrypoints = ast_entrypoint_map(&rules);
 
         Self {
             rules,
-            ast_entrypoints,
             ..Self::default()
         }
     }

--- a/crates/fortitude_workspace/src/configuration.rs
+++ b/crates/fortitude_workspace/src/configuration.rs
@@ -17,7 +17,7 @@ use fortitude_linter::settings::{
     CheckSettings, DEFAULT_SELECTORS, ExcludeMode, FileResolverSettings, FortranStandard,
     GitignoreMode, OutputFormat, PreviewMode, ProgressBar, Settings, UnsafeFixes,
 };
-use fortitude_linter::{ast_entrypoint_map, fs, warn_user_once_by_id, warn_user_once_by_message};
+use fortitude_linter::{fs, warn_user_once_by_id, warn_user_once_by_message};
 
 use anyhow::{Context, Result, anyhow};
 use itertools::Itertools;
@@ -352,7 +352,6 @@ impl Configuration {
             extend_fixable: self.extend_fixable,
         };
         let rules = to_rule_table(rule_selection, &preview)?;
-        let ast_entrypoints = ast_entrypoint_map(&rules);
 
         let mut progress_bar = self.progress_bar.unwrap_or_default();
         // Override progress bar settings if not using colour terminal
@@ -366,7 +365,6 @@ impl Configuration {
             check: CheckSettings {
                 project_root: project_root.to_path_buf(),
                 rules,
-                ast_entrypoints,
                 fix: self.fix.unwrap_or_default(),
                 fix_only: self.fix_only.unwrap_or_default(),
                 line_length: self


### PR DESCRIPTION
Closes #628

Several advantages of this approach:

- We completely skip any ignored rules on each file, rather than just discarding
  results afterwards
- Removes some duplicated code
- Ensures that the AST entrypoints map is always correct
- Removes some use of `DiagnosticMessage`, which will be refactored when
  upgrading the diagnostic system to match recent Ruff changes

One main disadvantage:

- This requires reconstructing the AST entrypoints map for each file

There's some performance tradeoff between skipping rules completely and copying
the rules table + building the AST entrypoints map, but it seems to be minimal