### PR TITLE
Add pFUnit file extensions to defaults

### DIFF
--- a/crates/fortitude_linter/src/fs.rs
+++ b/crates/fortitude_linter/src/fs.rs
@@ -306,7 +306,7 @@ pub fn relativize_path_to<P: AsRef<Path>, R: AsRef<Path>>(path: P, project_root:
 
 /// Default extensions to check
 pub const FORTRAN_EXTS: &[&str] = &[
-    "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "f18", "F18", "f23", "F23",
+    "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "f18", "F18", "f23", "F23", "pf",
 ];
 
 /// Default paths to exclude when searching paths
@@ -342,4 +342,5 @@ pub const INCLUDE: &[FilePattern] = &[
     FilePattern::Builtin("*.F18"),
     FilePattern::Builtin("*.f23"),
     FilePattern::Builtin("*.F23"),
+    FilePattern::Builtin("*.pf"),
 ];

--- a/crates/fortitude_linter/src/rules/style/file_extensions.rs
+++ b/crates/fortitude_linter/src/rules/style/file_extensions.rs
@@ -12,6 +12,8 @@ use std::path::Path;
 /// The standard file extensions for modern (free-form) Fortran are '.f90' or  '.F90'.
 /// Forms that reference later Fortran standards such as '.f08' or '.F95' may be rejected
 /// by some compilers and build tools.
+///
+/// The file extension '.pf' is permitted for users of the pFUnit testing framework.
 #[derive(ViolationMetadata)]
 pub(crate) struct NonStandardFileExtension {}
 
@@ -27,7 +29,7 @@ impl NonStandardFileExtension {
         match path.extension() {
             Some(ext) => {
                 // Must check like this as ext is an OsStr
-                if ["f90", "F90"].iter().any(|&x| x == ext) {
+                if ["f90", "F90", "pf"].iter().any(|&x| x == ext) {
                     None
                 } else {
                     Some(Diagnostic::new(Self {}, TextRange::default()))
@@ -70,7 +72,9 @@ mod tests {
     fn test_correct_file_extensions() {
         let path1 = Path::new("my/dir/to/file.f90");
         let path2 = Path::new("my/dir/to/file.F90");
+        let path3 = Path::new("my/dir/to/file.pf");
         assert_eq!(NonStandardFileExtension::check(path1), None);
         assert_eq!(NonStandardFileExtension::check(path2), None);
+        assert_eq!(NonStandardFileExtension::check(path3), None);
     }
 }

--- a/crates/fortitude_workspace/src/options.rs
+++ b/crates/fortitude_workspace/src/options.rs
@@ -37,7 +37,7 @@ pub struct Options {
     ///
     /// !!! info "_Introduced in 0.8.0_"
     #[option(
-        default = r#"["*.f90", "*.F90", "*.f95", "*.F95", "*.f03", "*.F03", "*.f08", "*.F08", "*.f18", "*.F18", "*.f23", "*.F23"]"#,
+        default = r#"["*.f90", "*.F90", "*.f95", "*.F95", "*.f03", "*.F03", "*.f08", "*.F08", "*.f18", "*.F18", "*.f23", "*.F23", "*.pf"]"#,
         value_type = "list[str]",
         example = r#"
             include = ["*.f90", "*.F90"]
@@ -243,7 +243,7 @@ pub struct CheckOptions {
     // File resolver options
     /// A list of file extensions to check
     #[option(
-        default = r#"["f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "f18", "F18", "f23", "F23"]"#,
+        default = r#"["f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "f18", "F18", "f23", "F23", "pf"]"#,
         value_type = "list[str]",
         example = r#"
           file-extensions = ["f90", "fpp"]

--- a/docs/rules/non-standard-file-extension.md
+++ b/docs/rules/non-standard-file-extension.md
@@ -8,3 +8,5 @@ Checks for use of standard file extensions.
 The standard file extensions for modern (free-form) Fortran are '.f90' or  '.F90'.
 Forms that reference later Fortran standards such as '.f08' or '.F95' may be rejected
 by some compilers and build tools.
+
+The file extension '.pf' is permitted for users of the pFUnit testing framework.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -12,7 +12,7 @@ For more information on the glob syntax, refer to the [`globset` documentation](
 
 !!! info "_Introduced in 0.8.0_"
 
-**Default value**: `["*.f90", "*.F90", "*.f95", "*.F95", "*.f03", "*.F03", "*.f08", "*.F08", "*.f18", "*.F18", "*.f23", "*.F23"]`
+**Default value**: `["*.f90", "*.F90", "*.f95", "*.F95", "*.f03", "*.F03", "*.f08", "*.F08", "*.f18", "*.F18", "*.f23", "*.F23", "*.pf"]`
 
 **Type**: `list[str]`
 
@@ -220,7 +220,7 @@ specified by [`select`](#check_select).
 
 A list of file extensions to check
 
-**Default value**: `["f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "f18", "F18", "f23", "F23"]`
+**Default value**: `["f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "f18", "F18", "f23", "F23", "pf"]`
 
 **Type**: `list[str]`
 


### PR DESCRIPTION
Closes https://github.com/PlasmaFAIR/fortitude/issues/634

(the parser upgrade to handle pFUnit directives was added as a side effect in a previous PR, this just makes pFUnit support official)

Adds `*.pf` to the default file extensions so that pFUnit tests are picked up automatically.

Allows an exception to `non-standard-file-extension`, but doesn't modify the message printed.