### PR TITLE
keyword-has-whitespace.md: fix typo

### DIFF
--- a/crates/fortitude_linter/src/rules/style/keywords.rs
+++ b/crates/fortitude_linter/src/rules/style/keywords.rs
@@ -183,7 +183,7 @@ impl AstRule for KeywordsMissingSpace {
 /// [`goto-with-space`](../settings.md#goto-with-space).
 ///
 /// ## Why is this bad?
-/// By convention, `inout` in normally preferred to `in out`. Both `go to` and
+/// By convention, `inout` is normally preferred to `in out`. Both `go to` and
 /// `goto` are valid, but Fortitude prefers the latter as `goto` is most common
 /// in other languages, and neither `go` nor `to` have secondary purposes in
 /// other keywords. Enforcing this rule can help maintain a consistent style.

--- a/docs/rules/keyword-has-whitespace.md
+++ b/docs/rules/keyword-has-whitespace.md
@@ -10,7 +10,7 @@ Either may be exempted from this rule by setting the options
 [`goto-with-space`](../settings.md#goto-with-space).
 
 ## Why is this bad?
-By convention, `inout` in normally preferred to `in out`. Both `go to` and
+By convention, `inout` is normally preferred to `in out`. Both `go to` and
 `goto` are valid, but Fortitude prefers the latter as `goto` is most common
 in other languages, and neither `go` nor `to` have secondary purposes in
 other keywords. Enforcing this rule can help maintain a consistent style.


### PR DESCRIPTION
Fix typo: `in` should be `is`.