### PR TITLE
Pass context struct into rule check functions

### DIFF
--- a/crates/fortitude_linter/src/allow_comments.rs
+++ b/crates/fortitude_linter/src/allow_comments.rs
@@ -1,6 +1,6 @@
+use crate::CheckContext;
 use crate::ast::FortitudeNode;
 use crate::rule_redirects::get_redirect_target;
-use crate::rule_table::RuleTable;
 use crate::rules::Rule;
 use crate::rules::fortitude::allow_comments::{
     DisabledAllowComment, DuplicatedAllowComment, InvalidRuleCodeOrName, RedirectedAllowComment,
@@ -25,6 +25,12 @@ pub struct Code<'a> {
     pub rule: Option<Rule>,
     // The location of the code
     pub loc: TextRange,
+}
+
+impl<'a> TextRanged for &Code<'a> {
+    fn textrange(&self) -> TextRange {
+        self.loc
+    }
 }
 
 /// A single allowed rule and the range it applies to
@@ -95,11 +101,12 @@ pub fn gather_allow_comments<'a, 'b>(
 }
 
 /// Check allow comments, raise applicable violations, and ignore allowed diagnostics
-pub fn check_allow_comments(
+///
+/// Returns list of indices of allowed violations
+pub(crate) fn check_allow_comments(
     diagnostics: &mut Vec<Diagnostic>,
     allow_comments: &[AllowComment],
-    rules: &RuleTable,
-    file: &SourceFile,
+    context: &CheckContext,
 ) -> Vec<usize> {
     // Indices of diagnostics that were ignored by a `noqa` directive.
     let mut ignored_diagnostics = vec![];
@@ -128,7 +135,7 @@ pub fn check_allow_comments(
 
         for code in &comment.codes {
             let redirect = get_redirect_target(code.code);
-            if rules.enabled(Rule::RedirectedAllowComment) {
+            if context.is_rule_enabled(Rule::RedirectedAllowComment) {
                 if let Some(redirect) = redirect {
                     let rule = Rule::from_code(redirect).unwrap();
                     let new_code = rule.noqa_code().to_string();
@@ -150,38 +157,28 @@ pub fn check_allow_comments(
                 }
             }
 
-            let rule_str = code.code.to_string();
-            let edit = remove_code_from_allow_comment(comment, code, file);
+            let rule = code.code.to_string();
+            let edit = remove_code_from_allow_comment(comment, code, context.source_file());
 
-            match code.rule {
-                None => {
-                    if rules.enabled(Rule::InvalidRuleCodeOrName) {
-                        diagnostics.push(
-                            Diagnostic::new(InvalidRuleCodeOrName { rule: rule_str }, code.loc)
-                                .with_fix(Fix::safe_edit(edit)),
-                        );
+            let diagnostic = match code.rule {
+                None => context.create_diagnostic_if_enabled(InvalidRuleCodeOrName { rule }, code),
+                Some(rule_code) => {
+                    let used = used_codes.contains(&rule_code);
+                    let enabled = context.is_rule_enabled(rule_code);
+                    if !seen_codes.insert(rule_code) {
+                        context.create_diagnostic_if_enabled(DuplicatedAllowComment { rule }, code)
+                    } else if !enabled {
+                        context.create_diagnostic_if_enabled(DisabledAllowComment { rule }, code)
+                    } else if !used && enabled {
+                        context.create_diagnostic_if_enabled(UnusedAllowComment { rule }, code)
+                    } else {
+                        None
                     }
                 }
-                Some(rule) => {
-                    let used = used_codes.contains(&rule);
-                    let enabled = rules.enabled(rule);
-                    if !seen_codes.insert(rule) && rules.enabled(Rule::DuplicatedAllowComment) {
-                        diagnostics.push(
-                            Diagnostic::new(DuplicatedAllowComment { rule: rule_str }, code.loc)
-                                .with_fix(Fix::safe_edit(edit)),
-                        );
-                    } else if !enabled && rules.enabled(Rule::DisabledAllowComment) {
-                        diagnostics.push(
-                            Diagnostic::new(DisabledAllowComment { rule: rule_str }, code.loc)
-                                .with_fix(Fix::safe_edit(edit)),
-                        );
-                    } else if !used && enabled && rules.enabled(Rule::UnusedAllowComment) {
-                        diagnostics.push(
-                            Diagnostic::new(UnusedAllowComment { rule: rule_str }, code.loc)
-                                .with_fix(Fix::safe_edit(edit)),
-                        );
-                    }
-                }
+            };
+
+            if let Some(diagnostic) = diagnostic {
+                diagnostics.push(diagnostic.with_fix(Fix::safe_edit(edit)));
             }
         }
     }

--- a/crates/fortitude_linter/src/allow_comments.rs
+++ b/crates/fortitude_linter/src/allow_comments.rs
@@ -143,16 +143,17 @@ pub(crate) fn check_allow_comments(
                     let edit =
                         Edit::replacement(new_name.clone(), code.loc.start(), code.loc.end());
                     diagnostics.push(
-                        Diagnostic::new(
-                            RedirectedAllowComment {
-                                original: code.code.to_string(),
-                                redirect: redirect.to_string(),
-                                new_code,
-                                new_name,
-                            },
-                            code.loc,
-                        )
-                        .with_fix(Fix::safe_edit(edit)),
+                        context
+                            .create_diagnostic(
+                                RedirectedAllowComment {
+                                    original: code.code.to_string(),
+                                    redirect: redirect.to_string(),
+                                    new_code,
+                                    new_name,
+                                },
+                                code,
+                            )
+                            .with_fix(Fix::safe_edit(edit)),
                     );
                 }
             }

--- a/crates/fortitude_linter/src/diagnostics/mod.rs
+++ b/crates/fortitude_linter/src/diagnostics/mod.rs
@@ -16,9 +16,8 @@ use rustc_hash::FxHashMap;
 use anyhow::Result;
 use log::debug;
 use ruff_text_size::{Ranged, TextRange};
-use tree_sitter::Node;
 
-use crate::{fix::FixTable, rules::Rule, traits::TextRanged};
+use crate::{fix::FixTable, rules::Rule};
 
 pub use violation::{AlwaysFixableViolation, FixAvailability, Violation, ViolationMetadata};
 
@@ -139,10 +138,6 @@ impl Diagnostic {
             rule: T::rule(),
             file: None,
         }
-    }
-
-    pub fn from_node<T: Violation>(violation: T, node: &Node) -> Self {
-        Self::new(violation, node.textrange())
     }
 
     #[inline]

--- a/crates/fortitude_linter/src/diagnostics/mod.rs
+++ b/crates/fortitude_linter/src/diagnostics/mod.rs
@@ -18,7 +18,7 @@ use log::debug;
 use ruff_text_size::{Ranged, TextRange};
 use tree_sitter::Node;
 
-use crate::{fix::FixTable, rules::Rule, settings::CheckSettings, traits::TextRanged};
+use crate::{fix::FixTable, rules::Rule, traits::TextRanged};
 
 pub use violation::{AlwaysFixableViolation, FixAvailability, Violation, ViolationMetadata};
 
@@ -143,19 +143,6 @@ impl Diagnostic {
 
     pub fn from_node<T: Violation>(violation: T, node: &Node) -> Self {
         Self::new(violation, node.textrange())
-    }
-
-    pub fn from_node_if_rule_enabled<T: Violation>(
-        settings: &CheckSettings,
-        rule: Rule,
-        violation: T,
-        node: &Node,
-    ) -> Option<Self> {
-        if settings.rules.enabled(rule) {
-            Some(Diagnostic::from_node(violation, node))
-        } else {
-            None
-        }
     }
 
     #[inline]

--- a/crates/fortitude_linter/src/fix/edits.rs
+++ b/crates/fortitude_linter/src/fix/edits.rs
@@ -184,7 +184,7 @@ pub fn redent(s: &str, indentation: &str, line_ending: LineEnding) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::symbol_table::SymbolTable;
+    use crate::ast::symbol_table::SymbolTable;
 
     use super::*;
     use anyhow::{Context, Result};

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -1,6 +1,7 @@
 use line_filter::FilterSet;
 use ruff_text_size::Ranged;
 pub use rule_selector::RuleSelector;
+use rule_table::RuleTable;
 pub use settings::Settings;
 
 pub mod allow_comments;
@@ -28,7 +29,7 @@ pub mod traits;
 
 use allow_comments::{check_allow_comments, gather_allow_comments};
 use ast::FortitudeNode;
-use diagnostics::{Diagnostic, Diagnostics, FixMap};
+use diagnostics::{Diagnostic, Diagnostics, FixMap, Violation};
 use fix::{FixResult, fix_file};
 use locator::Locator;
 use rules::correctness::split_escaped_quote::SplitEscapedQuote;
@@ -43,12 +44,14 @@ use rules::style::whitespace::{MissingNewlineAtEndOfFile, TrailingWhitespace};
 use rules::testing::test_rules::{self, TEST_RULES, TestRule};
 use rules::{Rule, portability::invalid_tab::check_invalid_tab};
 use settings::{CheckSettings, FixMode};
+use stylist::Stylist;
+use traits::TextRanged;
 
 use anyhow::{Context, anyhow};
 use ast::symbol_table::{self, BEGIN_SCOPE_NODES, END_SCOPE_NODES, SymbolTable, SymbolTables};
 use colored::Colorize;
 use itertools::Itertools;
-use ruff_source_file::SourceFile;
+use ruff_source_file::{SourceFile, SourceFileBuilder};
 use rustc_hash::FxHashMap;
 use source_kind::SourceKindDiff;
 use std::borrow::Cow;
@@ -74,6 +77,92 @@ pub trait AstRule {
 
     /// Return list of tree-sitter node types on which a rule should trigger.
     fn entrypoints() -> Vec<&'static str>;
+}
+
+pub(crate) struct CheckContext<'a> {
+    file: SourceFile,
+    rules: RuleTable,
+    settings: &'a CheckSettings,
+    stylist: &'a Stylist<'a>,
+}
+
+impl<'a> CheckContext<'a> {
+    pub(crate) fn new(
+        path: &Path,
+        contents: &str,
+        settings: &'a CheckSettings,
+        stylist: &'a Stylist,
+    ) -> Self {
+        let file = SourceFileBuilder::new(path.to_string_lossy(), contents).finish();
+
+        // Ignore diagnostics based on per-file-ignores.
+        let mut rules = settings.rules.clone();
+        for ignore in crate::fs::ignores_from_path(path, &settings.per_file_ignores) {
+            rules.disable(ignore);
+        }
+
+        Self {
+            file,
+            rules,
+            settings,
+            stylist,
+        }
+    }
+
+    #[inline]
+    pub(crate) const fn is_rule_enabled(&self, rule: Rule) -> bool {
+        self.rules.enabled(rule)
+    }
+
+    #[inline]
+    pub(crate) const fn any_rule_enabled(&self, rules: &[Rule]) -> bool {
+        self.rules.any_enabled(rules)
+    }
+
+    /// Returns the source file.
+    pub(crate) const fn source_file(&self) -> &SourceFile {
+        &self.file
+    }
+
+    /// Returns the source code.
+    #[inline]
+    pub(crate) fn source_text(&self) -> &str {
+        self.file.source_text()
+    }
+
+    /// The [`CheckSettings`] for the current analysis, including the enabled rules.
+    pub(crate) const fn settings(&self) -> &'a CheckSettings {
+        self.settings
+    }
+
+    /// The [`Stylist`] for the current file, which detects the current line ending, quote, and
+    /// indentation style.
+    pub(crate) const fn stylist(&self) -> &'a Stylist<'a> {
+        self.stylist
+    }
+
+    #[must_use]
+    pub(crate) fn create_diagnostic<T: Violation, R: TextRanged>(
+        &self,
+        kind: T,
+        range: R,
+    ) -> Diagnostic {
+        Diagnostic::new(kind, range.textrange())
+    }
+
+    #[must_use]
+    pub(crate) fn create_diagnostic_if_enabled<T: Violation, R: TextRanged>(
+        &self,
+        kind: T,
+        range: R,
+    ) -> Option<Diagnostic> {
+        let rule = T::rule();
+        if self.is_rule_enabled(rule) {
+            Some(self.create_diagnostic(kind, range))
+        } else {
+            None
+        }
+    }
 }
 
 /// Parse a file, check it for issues, and return the report.
@@ -169,27 +258,26 @@ pub(crate) fn check_path(
     let mut violations = Vec::new();
     let mut allow_comments = Vec::new();
 
-    // Ignore diagnostics based on per-file-ignores.
-    let mut rules = settings.rules.clone();
-    for ignore in crate::fs::ignores_from_path(path, &settings.per_file_ignores) {
-        rules.disable(ignore);
-    }
+    // Detect the current code style (lazily)
+    let stylist = Stylist::from_ast(&tree.root_node(), file);
+
+    let context = CheckContext::new(path, file.source_text(), settings, &stylist);
 
     // Check file paths directly
-    if rules.enabled(Rule::NonStandardFileExtension) {
+    if context.is_rule_enabled(Rule::NonStandardFileExtension) {
         if let Some(violation) = NonStandardFileExtension::check(path) {
             violations.push(violation);
         }
     }
 
     // Perform plain text analysis
-    if rules.enabled(Rule::SplitEscapedQuote) {
+    if context.is_rule_enabled(Rule::SplitEscapedQuote) {
         violations.extend(SplitEscapedQuote::check(file));
     }
-    if rules.enabled(Rule::TrailingWhitespace) {
+    if context.is_rule_enabled(Rule::TrailingWhitespace) {
         violations.extend(TrailingWhitespace::check(file));
     }
-    if rules.enabled(Rule::MissingNewlineAtEndOfFile)
+    if context.is_rule_enabled(Rule::MissingNewlineAtEndOfFile)
         && let Some(violation) = MissingNewlineAtEndOfFile::check(file)
     {
         violations.push(violation);
@@ -199,7 +287,7 @@ pub(crate) fn check_path(
     let root = tree.root_node();
     let mut symbol_table = SymbolTables::default();
     for node in once(root).chain(root.descendants()) {
-        if rules.enabled(Rule::SyntaxError) && node.is_missing() {
+        if context.is_rule_enabled(Rule::SyntaxError) && node.is_missing() {
             violations.push(Diagnostic::from_node(SyntaxError {}, &node));
         }
 
@@ -208,34 +296,32 @@ pub(crate) fn check_path(
 
             // Run rules over variable declarations without needing to reparse
             // them into types
-            if rules.any_enabled(&[
+            if context.any_rule_enabled(&[
                 Rule::InconsistentArrayDeclaration,
                 Rule::MixedScalarArrayDeclaration,
                 Rule::BadArrayDeclaration,
             ]) {
                 for decl_line in new_table.iter_decl_lines() {
-                    violations.extend(check_inconsistent_dimension_rules(
-                        settings, decl_line, file,
-                    ))
+                    violations.extend(check_inconsistent_dimension_rules(&context, decl_line))
                 }
             }
 
             symbol_table.push_table(new_table);
         }
 
-        if rules.any_enabled(&[
+        if context.any_rule_enabled(&[
             Rule::SuperfluousElseReturn,
             Rule::SuperfluousElseCycle,
             Rule::SuperfluousElseExit,
             Rule::SuperfluousElseStop,
         ]) && matches!(node.kind(), "keyword_statement" | "stop_statement")
         {
-            if let Some(violation) = check_superfluous_returns(settings, &node, file) {
+            if let Some(violation) = check_superfluous_returns(&context, &node) {
                 violations.push(violation);
             }
         }
 
-        if let Some(rules) = rules.ast_entrypoints().get(node.kind()) {
+        if let Some(rules) = context.rules.ast_entrypoints().get(node.kind()) {
             for rule in rules {
                 if let Some(violation) = rule.check(settings, &node, file, &symbol_table) {
                     violations.extend(violation);
@@ -253,23 +339,23 @@ pub(crate) fn check_path(
     }
 
     // ignore line length in comments requires AST
-    if rules.enabled(Rule::LineTooLong) {
-        violations.extend(LineTooLong::check(&root, settings, file));
+    if context.is_rule_enabled(Rule::LineTooLong) {
+        violations.extend(LineTooLong::check(&context, &root));
     }
 
-    if rules.enabled(Rule::InvalidTab) {
-        violations.append(&mut check_invalid_tab(&root, file, settings));
+    if context.is_rule_enabled(Rule::InvalidTab) {
+        violations.append(&mut check_invalid_tab(&context, &root));
     }
 
-    if rules.enabled(Rule::InvalidCharacter) {
-        violations.append(&mut check_invalid_character(&root, file));
+    if context.is_rule_enabled(Rule::InvalidCharacter) {
+        violations.append(&mut check_invalid_character(&context, &root));
     }
 
     // Raise violations for internal test rules
     #[cfg(any(feature = "test-rules", test))]
     {
         for test_rule in TEST_RULES {
-            if !rules.enabled(*test_rule) {
+            if !context.is_rule_enabled(*test_rule) {
                 continue;
             }
             let diagnostic = match test_rule {
@@ -298,7 +384,7 @@ pub(crate) fn check_path(
     }
 
     if (ignore_allow_comments.is_disabled() && !violations.is_empty())
-        || rules.any_enabled(&[
+        || context.any_rule_enabled(&[
             Rule::InvalidRuleCodeOrName,
             Rule::UnusedAllowComment,
             Rule::RedirectedAllowComment,
@@ -306,7 +392,7 @@ pub(crate) fn check_path(
             Rule::DisabledAllowComment,
         ])
     {
-        let ignored = check_allow_comments(&mut violations, &allow_comments, &rules, file);
+        let ignored = check_allow_comments(&mut violations, &allow_comments, &context);
         if ignore_allow_comments.is_disabled() {
             for index in ignored.iter().rev() {
                 violations.swap_remove(*index);
@@ -320,7 +406,7 @@ pub(crate) fn check_path(
         // violations up to the first syntax error. If we aren't tracking syntax
         // errors, we report everything but warn that the results are unreliable.
         // In either case, fixes should be considered too risky to apply.
-        if rules.enabled(Rule::SyntaxError) {
+        if context.is_rule_enabled(Rule::SyntaxError) {
             // Check violations for any remaining syntax errors. If any are found, discard violations
             // after it, as they may be false positives.
             warn_user_once_by_message!(
@@ -364,7 +450,7 @@ pub(crate) fn check_path(
     // Disable any fixes for unfixable rules
     for diagnostic in &mut violations {
         let rule = diagnostic.rule();
-        if diagnostic.fixable() && !rules.should_fix(rule) {
+        if diagnostic.fixable() && !context.rules.should_fix(rule) {
             diagnostic.drop_fix();
         }
     }

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -48,7 +48,7 @@ use stylist::Stylist;
 use traits::TextRanged;
 
 use anyhow::{Context, anyhow};
-use ast::symbol_table::{self, BEGIN_SCOPE_NODES, END_SCOPE_NODES, SymbolTable, SymbolTables};
+use ast::symbol_table::{BEGIN_SCOPE_NODES, END_SCOPE_NODES, SymbolTable, SymbolTables};
 use colored::Colorize;
 use itertools::Itertools;
 use ruff_source_file::{SourceFile, SourceFileBuilder};
@@ -68,26 +68,22 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Implemented by rules that analyse the abstract syntax tree.
 pub trait AstRule {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        source: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>>;
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>>;
 
     /// Return list of tree-sitter node types on which a rule should trigger.
     fn entrypoints() -> Vec<&'static str>;
 }
 
-pub(crate) struct CheckContext<'a> {
+pub struct CheckContext<'a> {
     file: SourceFile,
     rules: RuleTable,
     settings: &'a CheckSettings,
     stylist: &'a Stylist<'a>,
+    symbols: SymbolTables<'a>,
 }
 
 impl<'a> CheckContext<'a> {
-    pub(crate) fn new(
+    pub fn new(
         path: &Path,
         contents: &str,
         settings: &'a CheckSettings,
@@ -100,58 +96,68 @@ impl<'a> CheckContext<'a> {
         for ignore in crate::fs::ignores_from_path(path, &settings.per_file_ignores) {
             rules.disable(ignore);
         }
+        let symbols = SymbolTables::default();
 
         Self {
             file,
             rules,
             settings,
             stylist,
+            symbols,
         }
     }
 
     #[inline]
-    pub(crate) const fn is_rule_enabled(&self, rule: Rule) -> bool {
+    pub const fn is_rule_enabled(&self, rule: Rule) -> bool {
         self.rules.enabled(rule)
     }
 
     #[inline]
-    pub(crate) const fn any_rule_enabled(&self, rules: &[Rule]) -> bool {
+    pub const fn any_rule_enabled(&self, rules: &[Rule]) -> bool {
         self.rules.any_enabled(rules)
     }
 
     /// Returns the source file.
-    pub(crate) const fn source_file(&self) -> &SourceFile {
+    pub const fn source_file(&self) -> &SourceFile {
         &self.file
     }
 
     /// Returns the source code.
     #[inline]
-    pub(crate) fn source_text(&self) -> &str {
+    pub fn source_text(&self) -> &str {
         self.file.source_text()
     }
 
     /// The [`CheckSettings`] for the current analysis, including the enabled rules.
-    pub(crate) const fn settings(&self) -> &'a CheckSettings {
+    pub const fn settings(&self) -> &'a CheckSettings {
         self.settings
     }
 
     /// The [`Stylist`] for the current file, which detects the current line ending, quote, and
     /// indentation style.
-    pub(crate) const fn stylist(&self) -> &'a Stylist<'a> {
+    pub const fn stylist(&self) -> &'a Stylist<'a> {
         self.stylist
     }
 
+    pub const fn symbol_table(&'a self) -> &'a SymbolTables<'a> {
+        &self.symbols
+    }
+
+    pub fn push_table(&mut self, table: SymbolTable<'a>) {
+        self.symbols.push_table(table);
+    }
+
+    pub fn pop_table(&mut self) {
+        self.symbols.pop_table();
+    }
+
     #[must_use]
-    pub(crate) fn create_diagnostic<T: Violation, R: TextRanged>(
-        &self,
-        kind: T,
-        range: R,
-    ) -> Diagnostic {
+    pub fn create_diagnostic<T: Violation, R: TextRanged>(&self, kind: T, range: R) -> Diagnostic {
         Diagnostic::new(kind, range.textrange())
     }
 
     #[must_use]
-    pub(crate) fn create_diagnostic_if_enabled<T: Violation, R: TextRanged>(
+    pub fn create_diagnostic_if_enabled<T: Violation, R: TextRanged>(
         &self,
         kind: T,
         range: R,
@@ -261,7 +267,7 @@ pub(crate) fn check_path(
     // Detect the current code style (lazily)
     let stylist = Stylist::from_ast(&tree.root_node(), file);
 
-    let context = CheckContext::new(path, file.source_text(), settings, &stylist);
+    let mut context = CheckContext::new(path, file.source_text(), settings, &stylist);
 
     // Check file paths directly
     if context.is_rule_enabled(Rule::NonStandardFileExtension) {
@@ -272,23 +278,22 @@ pub(crate) fn check_path(
 
     // Perform plain text analysis
     if context.is_rule_enabled(Rule::SplitEscapedQuote) {
-        violations.extend(SplitEscapedQuote::check(file));
+        violations.extend(SplitEscapedQuote::check(&context));
     }
     if context.is_rule_enabled(Rule::TrailingWhitespace) {
-        violations.extend(TrailingWhitespace::check(file));
+        violations.extend(TrailingWhitespace::check(&context));
     }
     if context.is_rule_enabled(Rule::MissingNewlineAtEndOfFile)
-        && let Some(violation) = MissingNewlineAtEndOfFile::check(file)
+        && let Some(violation) = MissingNewlineAtEndOfFile::check(&context)
     {
         violations.push(violation);
     }
 
     // Perform AST analysis
     let root = tree.root_node();
-    let mut symbol_table = SymbolTables::default();
     for node in once(root).chain(root.descendants()) {
         if context.is_rule_enabled(Rule::SyntaxError) && node.is_missing() {
-            violations.push(Diagnostic::from_node(SyntaxError {}, &node));
+            violations.push(context.create_diagnostic(SyntaxError {}, node));
         }
 
         if BEGIN_SCOPE_NODES.contains(&node.kind()) {
@@ -306,7 +311,7 @@ pub(crate) fn check_path(
                 }
             }
 
-            symbol_table.push_table(new_table);
+            context.push_table(new_table);
         }
 
         if context.any_rule_enabled(&[
@@ -323,7 +328,7 @@ pub(crate) fn check_path(
 
         if let Some(rules) = context.rules.ast_entrypoints().get(node.kind()) {
             for rule in rules {
-                if let Some(violation) = rule.check(settings, &node, file, &symbol_table) {
+                if let Some(violation) = rule.check(&context, &node) {
                     violations.extend(violation);
                 }
             }
@@ -334,7 +339,7 @@ pub(crate) fn check_path(
         };
 
         if END_SCOPE_NODES.contains(&node.kind()) {
-            symbol_table.pop_table();
+            context.pop_table();
         }
     }
 

--- a/crates/fortitude_linter/src/rules/correctness/accessibility_statements.rs
+++ b/crates/fortitude_linter/src/rules/correctness/accessibility_statements.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -39,12 +36,7 @@ impl Violation for MissingAccessibilityStatement {
 }
 
 impl AstRule for MissingAccessibilityStatement {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let module = node.parent()?;
 
         let bare_private_statement = match module.child_with_name("private_statement") {
@@ -59,11 +51,13 @@ impl AstRule for MissingAccessibilityStatement {
 
         // No statement whatsoever
         if !bare_private_statement && !bare_public_statement {
-            let name = node.named_child(0)?.to_text(src.source_text())?.to_string();
-            return some_vec![Diagnostic::from_node(
-                MissingAccessibilityStatement { name },
-                node
-            )];
+            let name = node
+                .named_child(0)?
+                .to_text(context.source_text())?
+                .to_string();
+            return some_vec![
+                context.create_diagnostic(MissingAccessibilityStatement { name }, node)
+            ];
         }
 
         None
@@ -96,24 +90,16 @@ impl Violation for DefaultPublicAccessibility {
 }
 
 impl AstRule for DefaultPublicAccessibility {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // Bare `public` statement`
         if node.named_child(0).is_none() {
             let module = node.parent()?;
             let statement = module.child_with_name("module_statement")?;
             let name = statement
                 .child_with_name("name")?
-                .to_text(src.source_text())?
+                .to_text(context.source_text())?
                 .to_string();
-            return some_vec![Diagnostic::from_node(
-                DefaultPublicAccessibility { name },
-                node
-            )];
+            return some_vec![context.create_diagnostic(DefaultPublicAccessibility { name }, node)];
         }
 
         None

--- a/crates/fortitude_linter/src/rules/correctness/assumed_size.rs
+++ b/crates/fortitude_linter/src/rules/correctness/assumed_size.rs
@@ -1,12 +1,10 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::{CheckSettings, FortranStandard};
-use crate::symbol_table::SymbolTables;
+use crate::settings::FortranStandard;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What does it do?
@@ -56,13 +54,8 @@ impl Violation for AssumedSize {
     }
 }
 impl AstRule for AssumedSize {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = src.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
         let declaration = node
             .ancestors()
             .find(|parent| parent.kind() == "variable_declaration")?;
@@ -92,7 +85,7 @@ impl AstRule for AssumedSize {
         {
             let identifier = sized_decl.child_with_name("identifier")?;
             let name = identifier.to_text(src)?.to_string();
-            return some_vec![Diagnostic::from_node(Self { name }, node)];
+            return some_vec![context.create_diagnostic(Self { name }, node)];
         }
 
         // Collect things that look like `dimension(*)` -- this
@@ -108,7 +101,7 @@ impl AstRule for AssumedSize {
                 identifier.to_text(src)
             })
             .map(|name| name.to_string())
-            .map(|name| Diagnostic::from_node(Self { name }, node))
+            .map(|name| context.create_diagnostic(Self { name }, node))
             .collect_vec();
 
         Some(all_decls)
@@ -192,18 +185,13 @@ impl Violation for AssumedSizeCharacterIntent {
     }
 }
 impl AstRule for AssumedSizeCharacterIntent {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // The recommended fix to this is only possible in Fortran 2003 and later.
         // Those still writing Fortran 95 code are on their own!
-        if settings.target_std < FortranStandard::F2003 {
+        if context.settings().target_std < FortranStandard::F2003 {
             return None;
         }
-        let src = src.source_text();
+        let src = context.source_text();
         // TODO: This warning will also catch:
         // - non-dummy arguments -- these are always invalid, should be a separate warning?
 
@@ -255,7 +243,7 @@ impl AstRule for AssumedSizeCharacterIntent {
                 identifier.to_text(src)
             })
             .map(|name| name.to_string())
-            .map(|name| Diagnostic::from_node(Self { name }, node))
+            .map(|name| context.create_diagnostic(Self { name }, node))
             .collect_vec();
 
         Some(all_decls)

--- a/crates/fortitude_linter/src/rules/correctness/conditionals.rs
+++ b/crates/fortitude_linter/src/rules/correctness/conditionals.rs
@@ -1,9 +1,7 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_source_file::{LineEnding, SourceFile, find_newline};
@@ -53,12 +51,7 @@ impl AlwaysFixableViolation for MisleadingInlineIfSemicolon {
     }
 }
 impl AstRule for MisleadingInlineIfSemicolon {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // If this is an `if (...) then` construct, exit early
         if !node.inline_if_statement() {
             return None;
@@ -87,15 +80,16 @@ impl AstRule for MisleadingInlineIfSemicolon {
             // take care to handle indentation and other whitespace.
             let start = semicolon_node.start_textsize();
             let mut end = semicolon_node.end_byte();
-            let text = src.source_text().as_bytes();
+            let text = context.source_text().as_bytes();
             while text[end] == b' ' || text[end] == b'\t' {
                 end += 1;
             }
             let end = TextSize::try_from(end).unwrap();
-            let indentation = node.indentation(src);
+            let indentation = node.indentation(context.source_file());
             let edit = Edit::replacement(format!("\n{indentation}"), start, end);
             return some_vec!(
-                Diagnostic::from_node(MisleadingInlineIfSemicolon {}, &semicolon_node)
+                context
+                    .create_diagnostic(MisleadingInlineIfSemicolon {}, semicolon_node)
                     .with_fix(Fix::safe_edit(edit))
             );
         }
@@ -151,12 +145,7 @@ impl AlwaysFixableViolation for MisleadingInlineIfContinuation {
     }
 }
 impl AstRule for MisleadingInlineIfContinuation {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // If this is an `if (...) then` construct, exit early
         if !node.inline_if_statement() {
             return None;
@@ -167,12 +156,13 @@ impl AstRule for MisleadingInlineIfContinuation {
             .child_with_name("parenthesized_expression")?
             .next_sibling()?;
         if body_start.kind() == "&" {
-            let content = ifthenify(node, src)?;
+            let content = ifthenify(node, context.source_file())?;
             let start_byte = node.start_textsize();
             let end_byte = node.end_textsize();
             let edit = Edit::replacement(content, start_byte, end_byte);
             return some_vec!(
-                Diagnostic::from_node(MisleadingInlineIfContinuation {}, node)
+                context
+                    .create_diagnostic(MisleadingInlineIfContinuation {}, node)
                     .with_fix(Fix::safe_edit(edit))
             );
         }

--- a/crates/fortitude_linter/src/rules/correctness/derived_default_init.rs
+++ b/crates/fortitude_linter/src/rules/correctness/derived_default_init.rs
@@ -1,12 +1,10 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Edit, Fix, Violation};
-use crate::settings::{CheckSettings, FortranStandard};
-use crate::symbol_table::SymbolTables;
+use crate::settings::FortranStandard;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -76,14 +74,9 @@ impl Violation for MissingDefaultPointerInitalisation {
 }
 
 impl AstRule for MissingDefaultPointerInitalisation {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // Feature only available in Fortran 2003 and later
-        if settings.target_std < FortranStandard::F2003 {
+        if context.settings().target_std < FortranStandard::F2003 {
             return None;
         }
         // Only operate on derived types
@@ -97,7 +90,7 @@ impl AstRule for MissingDefaultPointerInitalisation {
         if !node.named_children(&mut node_cursor).any(|node| {
             node.kind() == "type_qualifier"
                 && node
-                    .to_text(src.source_text())
+                    .to_text(context.source_text())
                     .unwrap_or("")
                     .to_lowercase()
                     .starts_with("pointer")
@@ -113,13 +106,18 @@ impl AstRule for MissingDefaultPointerInitalisation {
                 Some(parent) => parent.kind() == "variable_declaration",
             })
             .map(|node| {
-                let var_name = node.to_text(src.source_text()).unwrap_or("").to_string();
+                let var_name = node
+                    .to_text(context.source_text())
+                    .unwrap_or("")
+                    .to_string();
 
                 let init_var = format!(" => null()");
                 let start_pos = node.end_textsize();
                 let fix = Fix::unsafe_edit(Edit::insertion(init_var, start_pos));
 
-                Diagnostic::from_node(Self { var: var_name }, &node).with_fix(fix)
+                context
+                    .create_diagnostic(Self { var: var_name }, node)
+                    .with_fix(fix)
             })
             .collect();
 

--- a/crates/fortitude_linter/src/rules/correctness/error_handling.rs
+++ b/crates/fortitude_linter/src/rules/correctness/error_handling.rs
@@ -1,14 +1,11 @@
 use std::iter::once;
 
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use anyhow::{Context, Result, anyhow};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 #[derive(
@@ -118,13 +115,8 @@ impl Violation for UncheckedStat {
 }
 
 impl AstRule for UncheckedStat {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        source: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = source.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
 
         // Check this is an error checking statement, and get the stat type
         let stat_type = StatType::from_node(node, src).ok()?;
@@ -183,13 +175,13 @@ impl AstRule for UncheckedStat {
                 }
                 Ok(CheckStatus::Overwritten) => {
                     // Found the variable, but it has been overwritten.
-                    return some_vec!(Diagnostic::from_node(
+                    return some_vec!(context.create_diagnostic(
                         Self {
                             name,
                             stat: stat_type,
                             result: CheckStatus::Overwritten
                         },
-                        &stat_node
+                        stat_node
                     ));
                 }
                 Ok(CheckStatus::Unchecked) => {
@@ -202,13 +194,13 @@ impl AstRule for UncheckedStat {
                 }
             }
         }
-        some_vec!(Diagnostic::from_node(
+        some_vec!(context.create_diagnostic(
             Self {
                 name,
                 stat: stat_type,
                 result: CheckStatus::Unchecked
             },
-            &stat_node
+            stat_node
         ))
     }
 
@@ -356,13 +348,8 @@ impl Violation for MultipleAllocationsWithStat {
 }
 
 impl AstRule for MultipleAllocationsWithStat {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        source: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = source.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
 
         // Check this has a stat parameter
         let stat_node = node.kwarg("stat", src)?;
@@ -379,7 +366,7 @@ impl AstRule for MultipleAllocationsWithStat {
 
         let alloc_type = AllocationType::from_node(node).ok()?;
 
-        some_vec!(Diagnostic::from_node(Self { alloc_type }, &stat_node))
+        some_vec!(context.create_diagnostic(Self { alloc_type }, stat_node))
     }
 
     fn entrypoints() -> Vec<&'static str> {
@@ -434,13 +421,8 @@ impl Violation for StatWithoutMessage {
 }
 
 impl AstRule for StatWithoutMessage {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        source: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = source.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
 
         let stat_type = StatType::from_node(node, src).ok()?;
         let stat_name: &'static str = stat_type.into();
@@ -451,7 +433,7 @@ impl AstRule for StatWithoutMessage {
         };
         if let Some(kwarg) = arg_list.kwarg(stat_name, src) {
             if !arg_list.kwarg_exists(stat_type.errmsg(), src) {
-                return some_vec!(Diagnostic::from_node(Self { stat_type }, &kwarg));
+                return some_vec!(context.create_diagnostic(Self { stat_type }, kwarg));
             }
         }
         None

--- a/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
+++ b/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
@@ -1,14 +1,11 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{
     AlwaysFixableViolation, Diagnostic, Edit, Fix, FixAvailability, Violation,
 };
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What does it do?
@@ -46,13 +43,8 @@ impl Violation for MissingExitOrCycleLabel {
     }
 }
 impl AstRule for MissingExitOrCycleLabel {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = src.source_text();
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
         // Skip unlabelled loops
         let label = node
             .child_with_name("block_label_start_expression")?
@@ -69,14 +61,15 @@ impl AstRule for MissingExitOrCycleLabel {
                 let edit = Edit::insertion(label_with_space, stmt.end_textsize());
                 let fix = Fix::unsafe_edit(edit);
 
-                Diagnostic::from_node(
-                    Self {
-                        name: name.to_string(),
-                        label: label.to_string(),
-                    },
-                    &stmt,
-                )
-                .with_fix(fix)
+                context
+                    .create_diagnostic(
+                        Self {
+                            name: name.to_string(),
+                            label: label.to_string(),
+                        },
+                        stmt,
+                    )
+                    .with_fix(fix)
             })
             .collect();
 
@@ -130,13 +123,8 @@ impl Violation for ExitOrCycleInUnlabelledLoop {
 }
 
 impl AstRule for ExitOrCycleInUnlabelledLoop {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        source: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = source.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
         let name = node.to_text(src)?.to_lowercase();
         // This filters to the keywords we want that _also_ don't have a label
         if !matches!(name.as_str(), "exit" | "cycle") {
@@ -159,14 +147,18 @@ impl AstRule for ExitOrCycleInUnlabelledLoop {
 
         // If we're only supposed to check on nested loops, check that there is at least
         // one more level of nesting
-        if settings.exit_unlabelled_loops.allow_unnested_loops {
+        if context
+            .settings()
+            .exit_unlabelled_loops
+            .allow_unnested_loops
+        {
             parent_loop
                 .ancestors()
                 .filter(|ancestor| ancestor.kind() == "do_loop")
                 .nth(0)?;
         }
 
-        some_vec!(Diagnostic::from_node(Self { name }, node))
+        some_vec!(context.create_diagnostic(Self { name }, node))
     }
 
     fn entrypoints() -> Vec<&'static str> {
@@ -222,13 +214,8 @@ fn start_end_names(node_kind: &str) -> (&'static str, &'static str) {
 }
 
 impl AstRule for MissingEndLabel {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = src.source_text();
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
         // Skip unlabelled loops
         let label = node
             .child_with_name("block_label_start_expression")?
@@ -253,15 +240,16 @@ impl AstRule for MissingEndLabel {
 
                 let (start_name, end_name) = start_end_names(node.kind());
 
-                Diagnostic::from_node(
-                    Self {
-                        end_name,
-                        start_name,
-                        label: label.to_string(),
-                    },
-                    &stmt,
-                )
-                .with_fix(fix)
+                context
+                    .create_diagnostic(
+                        Self {
+                            end_name,
+                            start_name,
+                            label: label.to_string(),
+                        },
+                        stmt,
+                    )
+                    .with_fix(fix)
             })?;
 
         Some(vec![violation])

--- a/crates/fortitude_linter/src/rules/correctness/external.rs
+++ b/crates/fortitude_linter/src/rules/correctness/external.rs
@@ -1,10 +1,9 @@
 use crate::diagnostics::{Diagnostic, Violation};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
-use crate::{AstRule, ast::FortitudeNode, settings::CheckSettings, symbol_table::SymbolTables};
+use crate::{AstRule, CheckContext, ast::FortitudeNode};
 
 /// ## What does it do?
 /// Checks for procedures declared with just `external`
@@ -33,15 +32,10 @@ impl Violation for ExternalProcedure {
 }
 
 impl AstRule for ExternalProcedure {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        source: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         if node
             .child_with_name("type_qualifier")?
-            .to_text(source.source_text())?
+            .to_text(context.source_text())?
             .to_lowercase()
             != "external"
         {
@@ -50,9 +44,9 @@ impl AstRule for ExternalProcedure {
 
         let name = node
             .child_by_field_name("declarator")?
-            .to_text(source.source_text())?
+            .to_text(context.source_text())?
             .to_string();
-        some_vec!(Diagnostic::from_node(Self { name }, node))
+        some_vec!(context.create_diagnostic(Self { name }, node))
     }
 
     fn entrypoints() -> Vec<&'static str> {
@@ -82,19 +76,13 @@ impl Violation for ProcedureNotInModule {
 }
 
 impl AstRule for ProcedureNotInModule {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         if node.parent()?.kind() == "translation_unit" {
             let procedure_stmt = node.child(0)?;
             let procedure = node.kind().to_string();
-            return some_vec![Diagnostic::from_node(
-                ProcedureNotInModule { procedure },
-                &procedure_stmt
-            )];
+            return some_vec![
+                context.create_diagnostic(ProcedureNotInModule { procedure }, procedure_stmt)
+            ];
         }
         None
     }

--- a/crates/fortitude_linter/src/rules/correctness/implicit_kinds.rs
+++ b/crates/fortitude_linter/src/rules/correctness/implicit_kinds.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -55,13 +52,11 @@ impl Violation for ImplicitRealKind {
 }
 
 impl AstRule for ImplicitRealKind {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let dtype = node.child(0)?.to_text(src.source_text())?.to_lowercase();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let dtype = node
+            .child(0)?
+            .to_text(context.source_text())?
+            .to_lowercase();
 
         if !matches!(dtype.as_str(), "real" | "complex") {
             return None;
@@ -75,7 +70,7 @@ impl AstRule for ImplicitRealKind {
             return None;
         }
 
-        some_vec![Diagnostic::from_node(ImplicitRealKind { dtype }, node)]
+        some_vec![context.create_diagnostic(ImplicitRealKind { dtype }, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
+++ b/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
@@ -1,10 +1,9 @@
-use crate::AstRule;
 /// Defines rules that raise errors if implicit typing is in use.
 use crate::ast::{FortitudeNode, types::ImplicitStatement};
 use crate::diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
-use crate::settings::{CheckSettings, FortranStandard};
-use crate::symbol_table::SymbolTables;
+use crate::settings::FortranStandard;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_source_file::SourceFile;
@@ -166,12 +165,7 @@ impl Violation for ImplicitTyping {
 }
 
 impl AstRule for ImplicitTyping {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // Run on functions and subroutines only if they aren't in a module,
         // program, or submodule. This rule will catch implicit typing in the
         // parent enttity, so we don't need to check it in the children.
@@ -182,12 +176,13 @@ impl AstRule for ImplicitTyping {
         }
 
         let ImplicitTypingEdit { edit, error_type } =
-            ImplicitTypingEdit::try_from_scope(node, src)?;
+            ImplicitTypingEdit::try_from_scope(node, context.source_file())?;
         let entity = node.kind().to_string();
         let block_stmt = node.child(0)?;
 
         some_vec![
-            Diagnostic::from_node(Self { entity, error_type }, &block_stmt)
+            context
+                .create_diagnostic(Self { entity, error_type }, block_stmt)
                 .with_fix(Fix::unsafe_edit(edit))
         ]
     }
@@ -224,12 +219,7 @@ impl Violation for InterfaceImplicitTyping {
 }
 
 impl AstRule for InterfaceImplicitTyping {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // Exit early if we're not in an interface.
         let parent = node.parent()?;
         if parent.kind() != "interface" {
@@ -237,12 +227,13 @@ impl AstRule for InterfaceImplicitTyping {
         }
 
         let ImplicitTypingEdit { edit, error_type } =
-            ImplicitTypingEdit::try_from_scope(node, src)?;
+            ImplicitTypingEdit::try_from_scope(node, context.source_file())?;
         let name = node.kind().to_string();
         let interface_stmt = node.child(0)?;
 
         some_vec![
-            Diagnostic::from_node(Self { name, error_type }, &interface_stmt)
+            context
+                .create_diagnostic(Self { name, error_type }, interface_stmt)
                 .with_fix(Fix::unsafe_edit(edit))
         ]
     }
@@ -280,19 +271,14 @@ impl Violation for ImplicitExternalProcedures {
 }
 
 impl AstRule for ImplicitExternalProcedures {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // implicit none (type, external) was added in Fortran 2018, so don't
         // run this rule if we're targeting an older standard.
-        if settings.target_std < FortranStandard::F2018 {
+        if context.settings().target_std < FortranStandard::F2018 {
             return None;
         }
 
-        let stmt = ImplicitStatement::try_from_node(*node, src)?;
+        let stmt = ImplicitStatement::try_from_node(*node, context.source_file())?;
 
         if stmt.is_implicit_none_external() {
             // If `external` is already present, then it's correct.
@@ -306,8 +292,12 @@ impl AstRule for ImplicitExternalProcedures {
 
         // If we get here, it's either `implicit none` or `implicit none
         // (type)`, so we want to add `external` to it.
-        let edit = add_external_to_implicit_none(stmt.node(), src);
-        some_vec!(Diagnostic::from_node(Self {}, node).with_fix(Fix::unsafe_edit(edit)))
+        let edit = add_external_to_implicit_none(stmt.node(), context.source_file());
+        some_vec!(
+            context
+                .create_diagnostic(Self {}, node)
+                .with_fix(Fix::unsafe_edit(edit))
+        )
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/correctness/init_decls.rs
+++ b/crates/fortitude_linter/src/rules/correctness/init_decls.rs
@@ -1,11 +1,9 @@
 use crate::ast::FortitudeNode;
 use crate::ast::types::{AttributeKind, get_name_node_of_declarator};
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::{AstRule, SymbolTables};
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -83,25 +81,20 @@ impl Violation for InitialisationInDeclaration {
 }
 
 impl AstRule for InitialisationInDeclaration {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = src.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
         // Only check in procedures
         node.ancestors().find(|parent| {
             ["function", "subroutine", "module_procedure"].contains(&parent.kind())
         })?;
 
         let name = get_name_node_of_declarator(node).to_text(src)?.to_string();
-        let decl = symbol_table.get(name.as_str())?;
+        let decl = context.symbol_table().get(name.as_str())?;
         if decl.has_any_attributes(&[AttributeKind::Save, AttributeKind::Parameter]) {
             return None;
         }
 
-        some_vec![Diagnostic::from_node(Self { name }, node)]
+        some_vec![context.create_diagnostic(Self { name }, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {
@@ -207,13 +200,8 @@ impl Violation for PointerInitialisationInDeclaration {
 }
 
 impl AstRule for PointerInitialisationInDeclaration {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = src.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
         // Only check in procedures
         node.ancestors().find(|parent| {
             ["function", "subroutine", "module_procedure"].contains(&parent.kind())
@@ -221,7 +209,7 @@ impl AstRule for PointerInitialisationInDeclaration {
 
         let var = get_name_node_of_declarator(node);
         let name = var.to_text(src)?.to_string();
-        let decl = symbol_table.get(name.as_str())?;
+        let decl = context.symbol_table().get(name.as_str())?;
         if decl.has_attribute(AttributeKind::Save) {
             return None;
         }
@@ -229,10 +217,10 @@ impl AstRule for PointerInitialisationInDeclaration {
         // Array syntax on the variable name
         if let Some(arr) = var.child_with_name("identifier") {
             let name = arr.to_text(src)?.to_string();
-            return some_vec![Diagnostic::from_node(Self { name }, node)];
+            return some_vec![context.create_diagnostic(Self { name }, node)];
         }
 
-        some_vec![Diagnostic::from_node(Self { name }, node)]
+        some_vec![context.create_diagnostic(Self { name }, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/correctness/intent.rs
+++ b/crates/fortitude_linter/src/rules/correctness/intent.rs
@@ -1,14 +1,12 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::ast::types::AttributeKind;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::{CheckSettings, FortranStandard};
-use crate::symbol_table::SymbolTables;
+use crate::settings::FortranStandard;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -53,19 +51,16 @@ impl Violation for MissingIntent {
 }
 
 impl AstRule for MissingIntent {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let entity = node.parent()?.kind().to_string();
         Some(
             node.child_by_field_name("parameters")?
                 .named_children(&mut node.walk())
                 .filter_map(|param| {
                     // Get variable declaration
-                    symbol_table.get(param.to_text(src.source_text())?)
+                    context
+                        .symbol_table()
+                        .get(param.to_text(context.source_text())?)
                 })
                 .filter(|param| {
                     // Procedures are not allowed intent
@@ -73,7 +68,7 @@ impl AstRule for MissingIntent {
                 })
                 .filter(|param| {
                     // Intent only allowed on pointers after F2003
-                    !(settings.target_std < FortranStandard::F2003
+                    !(context.settings().target_std < FortranStandard::F2003
                         && param.has_attribute(AttributeKind::Pointer))
                 })
                 .filter(|param| {
@@ -84,7 +79,7 @@ impl AstRule for MissingIntent {
                         .any(|attr| attr.kind().is_intent() || attr.kind().is_value())
                 })
                 .map(|param| {
-                    Diagnostic::new(
+                    context.create_diagnostic(
                         Self {
                             entity: entity.clone(),
                             name: param.name().to_string(),

--- a/crates/fortitude_linter/src/rules/correctness/kind_suffixes.rs
+++ b/crates/fortitude_linter/src/rules/correctness/kind_suffixes.rs
@@ -1,12 +1,9 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use lazy_regex::regex_is_match;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -72,17 +69,12 @@ impl Violation for NoRealSuffix {
 }
 
 impl AstRule for NoRealSuffix {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // Given a number literal, match anything with one or more of a decimal place or
         // an exponentiation e or E. There should not be an underscore present.
         // Exponentiation with d or D are ignored, and should be handled with the
         // rule `double_precision_literal`.
-        let txt = node.to_text(src.source_text())?;
+        let txt = node.to_text(context.source_text())?;
         if !regex_is_match!(r"^(\d*\.\d*|\d*\.*\d*[eE]-?\d+)$", txt) {
             return None;
         }
@@ -117,7 +109,7 @@ impl AstRule for NoRealSuffix {
         // "argument_list", and the second must be "call_expression".
         if grandparent.kind() == "call_expression" {
             if let Some(identifier) = grandparent.child_with_name("identifier") {
-                let name = identifier.to_text(src.source_text())?.to_lowercase();
+                let name = identifier.to_text(context.source_text())?.to_lowercase();
                 if name == "kind"
                     || (no_loss
                         && matches!(name.as_str(), "real" | "cmplx" | "dbl" | "int" | "logical"))
@@ -128,7 +120,7 @@ impl AstRule for NoRealSuffix {
         }
 
         let literal = txt.to_string();
-        some_vec![Diagnostic::from_node(NoRealSuffix { literal }, node)]
+        some_vec![context.create_diagnostic(NoRealSuffix { literal }, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/correctness/magic_numbers.rs
+++ b/crates/fortitude_linter/src/rules/correctness/magic_numbers.rs
@@ -1,13 +1,10 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::rules::utilities::literal_as_io_unit;
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -49,15 +46,15 @@ impl Violation for MagicNumberInArraySize {
 const DEFAULT_ALLOWED_LITERALS: &[i32] = &[0, 1, 2, 3, 4];
 
 impl AstRule for MagicNumberInArraySize {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        source: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // We're either looking for `type, dimension(X) :: variable` or `type :: variable(X)`
         let size = if node.kind() == "type_qualifier" {
-            if node.child(0)?.to_text(source.source_text())?.to_lowercase() != "dimension" {
+            if node
+                .child(0)?
+                .to_text(context.source_text())?
+                .to_lowercase()
+                != "dimension"
+            {
                 return None;
             }
             node.child_with_name("argument_list")?
@@ -83,7 +80,7 @@ impl AstRule for MagicNumberInArraySize {
             .flatten()
             .filter_map(|literal| {
                 let value = literal
-                    .to_text(source.source_text())?
+                    .to_text(context.source_text())?
                     .parse::<i32>()
                     .unwrap();
                 if DEFAULT_ALLOWED_LITERALS.contains(&value) {
@@ -92,7 +89,7 @@ impl AstRule for MagicNumberInArraySize {
                     Some((literal, value))
                 }
             })
-            .map(|(child, value)| Diagnostic::from_node(Self { value }, &child))
+            .map(|(child, value)| context.create_diagnostic(Self { value }, child))
             .collect();
 
         Some(violations)
@@ -145,20 +142,15 @@ impl Violation for MagicIoUnit {
 }
 
 impl AstRule for MagicIoUnit {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let unit = literal_as_io_unit(node, src)?;
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let unit = literal_as_io_unit(node, context.source_file())?;
 
         let value = unit
-            .to_text(src.source_text())?
+            .to_text(context.source_text())?
             .parse::<i32>()
             .unwrap_or_default();
 
-        some_vec!(Diagnostic::from_node(Self { value }, &unit))
+        some_vec!(context.create_diagnostic(Self { value }, unit))
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/correctness/missing_io_specifier.rs
+++ b/crates/fortitude_linter/src/rules/correctness/missing_io_specifier.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -31,16 +28,11 @@ impl Violation for MissingActionSpecifier {
 }
 
 impl AstRule for MissingActionSpecifier {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        if node.kwarg_exists("action", src.source_text()) {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        if node.kwarg_exists("action", context.source_text()) {
             return None;
         }
-        some_vec![Diagnostic::from_node(Self {}, node)]
+        some_vec![context.create_diagnostic(Self {}, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/correctness/nonportable_shortcircuit_inquiry.rs
+++ b/crates/fortitude_linter/src/rules/correctness/nonportable_shortcircuit_inquiry.rs
@@ -1,13 +1,10 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 use tree_sitter::Node;
 
@@ -122,18 +119,12 @@ fn present_call(expr: &Node, src: &str, function: &str) -> Option<PresentCall> {
 }
 
 impl AstRule for NonportableShortcircuitInquiry {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
         let expr = node.child(1)?;
-        let text = src.source_text();
 
         let violations = ["present", "allocated", "associated"]
             .iter()
-            .flat_map(|function| find_nonportable_shortcircuits(&expr, text, function))
+            .flat_map(|function| find_nonportable_shortcircuits(context, &expr, function))
             .collect_vec();
 
         Some(violations)
@@ -144,7 +135,13 @@ impl AstRule for NonportableShortcircuitInquiry {
     }
 }
 
-fn find_nonportable_shortcircuits(node: &Node, text: &str, function: &str) -> Vec<Diagnostic> {
+fn find_nonportable_shortcircuits(
+    context: &CheckContext,
+    node: &Node,
+    function: &str,
+) -> Vec<Diagnostic> {
+    let text = context.source_text();
+
     // First find all the `present(foo)` calls
     let calls = node
         .descendants()
@@ -173,13 +170,13 @@ fn find_nonportable_shortcircuits(node: &Node, text: &str, function: &str) -> Ve
             }
         })
         .map(|(node, arg, &present)| {
-            Diagnostic::from_node(
+            context.create_diagnostic(
                 NonportableShortcircuitInquiry {
                     arg,
                     function: function.to_string(),
                     present,
                 },
-                &node,
+                node,
             )
         })
         .collect_vec()

--- a/crates/fortitude_linter/src/rules/correctness/select_default.rs
+++ b/crates/fortitude_linter/src/rules/correctness/select_default.rs
@@ -1,10 +1,7 @@
-use crate::AstRule;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -78,12 +75,7 @@ impl Violation for MissingDefaultCase {
 }
 
 impl AstRule for MissingDefaultCase {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let has_default = node
             .named_children(&mut node.walk())
             .filter(|child| child.kind() == "case_statement")
@@ -95,7 +87,7 @@ impl AstRule for MissingDefaultCase {
         if has_default {
             None
         } else {
-            some_vec!(Diagnostic::from_node(Self {}, node))
+            some_vec!(context.create_diagnostic(Self {}, node))
         }
     }
 

--- a/crates/fortitude_linter/src/rules/correctness/split_escaped_quote.rs
+++ b/crates/fortitude_linter/src/rules/correctness/split_escaped_quote.rs
@@ -1,9 +1,9 @@
+use crate::CheckContext;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic};
 use crate::diagnostics::{Edit, Fix};
 use fortitude_macros::ViolationMetadata;
 use lazy_regex::regex;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 
 /// ## What it does
@@ -50,8 +50,8 @@ impl AlwaysFixableViolation for SplitEscapedQuote {
 // text. We're looking for something that spans two lines, so it has to search the whole
 // text at once too.
 impl SplitEscapedQuote {
-    pub fn check(src: &SourceFile) -> Vec<Diagnostic> {
-        let text = src.source_text();
+    pub fn check(context: &CheckContext) -> Vec<Diagnostic> {
+        let text = context.source_text();
         let split_quote_re = regex!(r#"(?m)(['\"])(& *\r?\n *&?)(['\"])"#);
 
         split_quote_re
@@ -71,7 +71,11 @@ impl SplitEscapedQuote {
                 );
 
                 let edit = Edit::range_replacement(continuation.to_string(), range);
-                Some(Diagnostic::new(SplitEscapedQuote, range).with_fix(Fix::safe_edit(edit)))
+                Some(
+                    context
+                        .create_diagnostic(SplitEscapedQuote, range)
+                        .with_fix(Fix::safe_edit(edit)),
+                )
             })
             .collect()
     }

--- a/crates/fortitude_linter/src/rules/correctness/trailing_backslash.rs
+++ b/crates/fortitude_linter/src/rules/correctness/trailing_backslash.rs
@@ -1,12 +1,9 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-/// Defines rules that govern line length.
-use crate::settings::CheckSettings;
-use crate::{AstRule, symbol_table::SymbolTables};
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use lazy_regex::regex;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 use tree_sitter::Node;
 
@@ -54,16 +51,11 @@ impl Violation for TrailingBackslash {
 }
 
 impl AstRule for TrailingBackslash {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // Preprocessor might ignore trailing whitespace
         let trailing_backslash_re = regex!(r#".*(\\)\s*$"#);
 
-        let comment = node.to_text(src.source_text())?;
+        let comment = node.to_text(context.source_text())?;
         let captures = trailing_backslash_re.captures(comment)?;
 
         let trailing_backslash = captures.get(1)?;
@@ -72,7 +64,7 @@ impl AstRule for TrailingBackslash {
         // Regex start/end are relative to start of comment node
         let comment_start: TextSize = node.start_byte().try_into().unwrap();
         let range = TextRange::new(comment_start + start, comment_start + end);
-        some_vec!(Diagnostic::new(Self {}, range))
+        some_vec!(context.create_diagnostic(Self {}, range))
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/correctness/unreachable_statement.rs
+++ b/crates/fortitude_linter/src/rules/correctness/unreachable_statement.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::{FortitudeNode, types::BlockExit};
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -67,23 +64,18 @@ pub const EXECUTABLE_STATEMENTS: &[&str] = &[
 ];
 
 impl AstRule for UnreachableStatement {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_tables: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // TODO: Not catching returns at the end of block, associate, etc.
         // This will require going up the tree before finding the next statement.
-        let text = node.child(0)?.to_text(src.source_text())?;
+        let text = node.child(0)?.to_text(context.source_text())?;
         let _ = BlockExit::try_from(text).ok()?;
         let sibling = node.next_non_comment_sibling()?;
         if EXECUTABLE_STATEMENTS.contains(&sibling.kind()) {
-            some_vec!(Diagnostic::from_node(
+            some_vec!(context.create_diagnostic(
                 UnreachableStatement {
                     kind: text.to_string(),
                 },
-                &sibling,
+                sibling,
             ))
         } else {
             None

--- a/crates/fortitude_linter/src/rules/correctness/use_statements.rs
+++ b/crates/fortitude_linter/src/rules/correctness/use_statements.rs
@@ -1,12 +1,10 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Edit, Fix, Violation};
-use crate::settings::{CheckSettings, FortranStandard};
-use crate::symbol_table::SymbolTables;
+use crate::settings::FortranStandard;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 // TODO Check that 'used' entity is actually used somewhere
@@ -44,21 +42,17 @@ impl Violation for UseAll {
 }
 
 impl AstRule for UseAll {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let module_name = node.module_name(src.source_text())?.to_lowercase();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let module_name = node.module_name(context.source_text())?.to_lowercase();
 
-        if !settings
+        if !context
+            .settings()
             .use_statements
             .allow_bare_use
             .contains(&module_name)
             && node.child_with_name("included_items").is_none()
         {
-            return some_vec![Diagnostic::from_node(UseAll {}, node)];
+            return some_vec![context.create_diagnostic(UseAll {}, node)];
         }
         None
     }
@@ -113,22 +107,17 @@ impl Violation for MissingIntrinsic {
 }
 
 impl AstRule for MissingIntrinsic {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // Feature only available in Fortran 2003 and later
-        if settings.target_std < FortranStandard::F2003 {
+        if context.settings().target_std < FortranStandard::F2003 {
             return None;
         }
-        let module_name = node.module_name(src.source_text())?.to_lowercase();
+        let module_name = node.module_name(context.source_text())?.to_lowercase();
 
         if INTRINSIC_MODULES.iter().any(|&m| m == module_name)
             && node
                 .children(&mut node.walk())
-                .filter_map(|child| child.to_text(src.source_text()))
+                .filter_map(|child| child.to_text(context.source_text()))
                 .all(|child| child != "intrinsic" && child != "non_intrinsic")
         {
             let intrinsic = if node.child(1)?.kind() == "::" {
@@ -139,11 +128,15 @@ impl AstRule for MissingIntrinsic {
 
             let use_field = node
                 .children(&mut node.walk())
-                .find(|&child| child.to_text(src.source_text()) == Some("use"))?;
+                .find(|&child| child.to_text(context.source_text()) == Some("use"))?;
             let start_pos = use_field.end_textsize();
             let fix = Fix::unsafe_edit(Edit::insertion(intrinsic.to_string(), start_pos));
 
-            return some_vec![Diagnostic::from_node(MissingIntrinsic {}, node).with_fix(fix)];
+            return some_vec![
+                context
+                    .create_diagnostic(MissingIntrinsic {}, node)
+                    .with_fix(fix)
+            ];
         }
         None
     }

--- a/crates/fortitude_linter/src/rules/error/invalid_character.rs
+++ b/crates/fortitude_linter/src/rules/error/invalid_character.rs
@@ -1,8 +1,10 @@
-use crate::diagnostics::{Diagnostic, FixAvailability, Violation};
+use crate::{
+    CheckContext,
+    diagnostics::{Diagnostic, FixAvailability, Violation},
+};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 use tree_sitter::Node;
 
@@ -32,8 +34,9 @@ impl Violation for InvalidCharacter {
     }
 }
 
-pub fn check_invalid_character(root: &Node, src: &SourceFile) -> Vec<Diagnostic> {
-    src.source_text()
+pub(crate) fn check_invalid_character(context: &CheckContext, root: &Node) -> Vec<Diagnostic> {
+    context
+        .source_text()
         .char_indices()
         .filter(|(_, c)| !FORTRAN_VALID_CHARACTERS.contains(*c))
         .filter(|(index, _)| {
@@ -46,7 +49,7 @@ pub fn check_invalid_character(root: &Node, src: &SourceFile) -> Vec<Diagnostic>
         .map(|(index, character)| {
             let start = TextSize::try_from(index).unwrap();
             let range = TextRange::new(start, start);
-            Diagnostic::new(InvalidCharacter { character }, range)
+            context.create_diagnostic(InvalidCharacter { character }, range)
         })
         .collect_vec()
 }

--- a/crates/fortitude_linter/src/rules/error/syntax_error.rs
+++ b/crates/fortitude_linter/src/rules/error/syntax_error.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -29,13 +26,8 @@ impl Violation for SyntaxError {
 }
 
 impl AstRule for SyntaxError {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        some_vec![Diagnostic::from_node(Self {}, node)]
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        some_vec![context.create_diagnostic(Self {}, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/modernisation/double_precision.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/double_precision.rs
@@ -1,12 +1,9 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use lazy_regex::regex_captures;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -68,14 +65,9 @@ impl Violation for DoublePrecision {
 }
 
 impl AstRule for DoublePrecision {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let txt = node.to_text(src.source_text())?.to_lowercase();
-        some_vec![Diagnostic::from_node(DoublePrecision::try_new(txt)?, node)]
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let txt = node.to_text(context.source_text())?.to_lowercase();
+        some_vec![context.create_diagnostic(DoublePrecision::try_new(txt)?, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {
@@ -130,13 +122,8 @@ impl Violation for DoublePrecisionLiteral {
 }
 
 impl AstRule for DoublePrecisionLiteral {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let txt = node.to_text(src.source_text())?;
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let txt = node.to_text(context.source_text())?;
         if let Some((original, mantissa, exponent)) =
             regex_captures!(r"^(\d*\.*\d*)[dD](-?\d+)$", txt)
         {
@@ -156,7 +143,7 @@ impl AstRule for DoublePrecisionLiteral {
             // "argument_list", and the second must be "call_expression".
             if grandparent.kind() == "call_expression" {
                 if let Some(identifier) = grandparent.child_with_name("identifier") {
-                    let name = identifier.to_text(src.source_text())?.to_lowercase();
+                    let name = identifier.to_text(context.source_text())?.to_lowercase();
                     if name == "kind"
                         || matches!(name.as_str(), "real" | "cmplx" | "dbl" | "int" | "logical")
                     {
@@ -167,7 +154,7 @@ impl AstRule for DoublePrecisionLiteral {
 
             let original = original.to_string();
             let preferred = format!("{mantissa}e{exponent}_real64");
-            return some_vec![Diagnostic::from_node(
+            return some_vec![context.create_diagnostic(
                 DoublePrecisionLiteral {
                     original,
                     preferred

--- a/crates/fortitude_linter/src/rules/modernisation/include_statement.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/include_statement.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 use tree_sitter::Node;
 
@@ -36,18 +33,13 @@ impl Violation for IncludeStatement {
 }
 
 impl AstRule for IncludeStatement {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // tree-sitter-fortran 0.5.1 includes the end newline as part
         // of the node, so we discard that here
         let start = node.child(0)?.start_textsize();
         let end = node.child(1)?.end_textsize();
         let range = TextRange::new(start, end);
-        some_vec![Diagnostic::new(IncludeStatement {}, range)]
+        some_vec![context.create_diagnostic(IncludeStatement {}, range)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/modernisation/mpi.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/mpi.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -91,16 +88,11 @@ impl Violation for OldMPIModule {
 }
 
 impl AstRule for OldMPIModule {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let module_name = node.module_name(src.source_text())?.to_lowercase();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let module_name = node.module_name(context.source_text())?.to_lowercase();
 
         if module_name == "mpi" {
-            return some_vec![Diagnostic::from_node(OldMPIModule {}, node)];
+            return some_vec![context.create_diagnostic(OldMPIModule {}, node)];
         }
         None
     }

--- a/crates/fortitude_linter/src/rules/modernisation/old_style_array_literal.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/old_style_array_literal.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What does it do?
@@ -30,22 +27,20 @@ impl AlwaysFixableViolation for OldStyleArrayLiteral {
 }
 
 impl AstRule for OldStyleArrayLiteral {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let open_bracket = node.child(0)?;
 
-        if open_bracket.to_text(src.source_text())?.starts_with("(/") {
+        if open_bracket
+            .to_text(context.source_text())?
+            .starts_with("(/")
+        {
             let close_bracket = node.children(&mut node.walk()).last()?;
-
+            let src = context.source_file();
             let edit_open = open_bracket.edit_replacement(src, "[".to_string());
             let edit_close = close_bracket.edit_replacement(src, "]".to_string());
             let fix = Fix::safe_edits(edit_open, [edit_close]);
 
-            return some_vec!(Diagnostic::from_node(Self {}, node).with_fix(fix));
+            return some_vec!(context.create_diagnostic(Self {}, node).with_fix(fix));
         }
         None
     }

--- a/crates/fortitude_linter/src/rules/modernisation/out_of_line_attribute.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/out_of_line_attribute.rs
@@ -5,7 +5,7 @@ use crate::fix::edits::{
     add_attribute_to_var_decl, remove_from_comma_sep_stmt, remove_variable_decl,
 };
 use crate::traits::{HasNode, TextRanged};
-use crate::{AstRule, SymbolTables};
+use crate::{AstRule, CheckContext};
 
 use anyhow::{Context, Result};
 use fortitude_macros::ViolationMetadata;
@@ -190,13 +190,8 @@ fn make_fix(var: &Variable, new_attr: &str, extra: String, src: &SourceFile) -> 
 }
 
 impl AstRule for OutOfLineAttribute {
-    fn check(
-        _settings: &crate::settings::CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let code = src.to_source_code();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let code = context.source_file().to_source_code();
 
         if node.kind() == "parameter_statement" {
             // Parameter statements have slightly different syntax, and have
@@ -204,34 +199,42 @@ impl AstRule for OutOfLineAttribute {
             let diagnostics = node
                 .named_children(&mut node.walk())
                 .filter_map(|parameter| {
-                    ParameterStatement::try_from_node(parameter, src.source_text()).ok()
+                    ParameterStatement::try_from_node(parameter, context.source_text()).ok()
                 })
-                .filter_map(|parameter| match symbol_table.get(&parameter.name) {
-                    Some(var) => {
-                        let mut edit =
-                            fix_out_of_line_parameter(node, &parameter, &var, src).unwrap();
-                        Some(
-                            Diagnostic::from_node(
-                                OutOfLineAttribute {
-                                    variable: parameter.name,
-                                    attribute: "parameter".to_string(),
-                                    decl_location: var.textrange(),
-                                    line: code.line_index(var.node().start_textsize()),
-                                },
-                                &parameter.node,
+                .filter_map(
+                    |parameter| match context.symbol_table().get(&parameter.name) {
+                        Some(var) => {
+                            let mut edit = fix_out_of_line_parameter(
+                                node,
+                                &parameter,
+                                &var,
+                                context.source_file(),
                             )
-                            .with_fix(Fix::unsafe_edits(edit.remove(0), edit)),
-                        )
-                    }
-                    None => None,
-                })
+                            .unwrap();
+                            Some(
+                                context
+                                    .create_diagnostic(
+                                        OutOfLineAttribute {
+                                            variable: parameter.name,
+                                            attribute: "parameter".to_string(),
+                                            decl_location: var.textrange(),
+                                            line: code.line_index(var.node().start_textsize()),
+                                        },
+                                        parameter.node,
+                                    )
+                                    .with_fix(Fix::unsafe_edits(edit.remove(0), edit)),
+                            )
+                        }
+                        None => None,
+                    },
+                )
                 .collect_vec();
             return Some(diagnostics);
         }
 
         let attribute_str = node
             .child_with_name("type_qualifier")?
-            .to_text(src.source_text())?;
+            .to_text(context.source_text())?;
 
         if attribute_str.eq_ignore_ascii_case("external")
             || attribute_str.eq_ignore_ascii_case("intrinsic")
@@ -246,25 +249,28 @@ impl AstRule for OutOfLineAttribute {
                     (
                         decl,
                         get_name_node_of_declarator(&decl)
-                            .to_text(src.source_text())
+                            .to_text(context.source_text())
                             .unwrap_or_default()
                             .to_string(),
                     )
                 })
                 .filter_map(|(decl, name)| {
-                    symbol_table.get(&name).map(|var| {
-                        let mut edit = fix_out_of_line_attribute(node, &decl, &var, src).unwrap();
+                    context.symbol_table().get(&name).map(|var| {
+                        let mut edit =
+                            fix_out_of_line_attribute(node, &decl, &var, context.source_file())
+                                .unwrap();
 
-                        Diagnostic::new(
-                            OutOfLineAttribute {
-                                variable: name,
-                                attribute: attribute_str.to_string(),
-                                decl_location: decl.textrange(),
-                                line: code.line_index(var.node().start_textsize()),
-                            },
-                            decl.textrange(),
-                        )
-                        .with_fix(Fix::unsafe_edits(edit.remove(0), edit))
+                        context
+                            .create_diagnostic(
+                                OutOfLineAttribute {
+                                    variable: name,
+                                    attribute: attribute_str.to_string(),
+                                    decl_location: decl.textrange(),
+                                    line: code.line_index(var.node().start_textsize()),
+                                },
+                                decl,
+                            )
+                            .with_fix(Fix::unsafe_edits(edit.remove(0), edit))
                     })
                 })
                 .collect_vec(),

--- a/crates/fortitude_linter/src/rules/modernisation/relational_operators.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/relational_operators.rs
@@ -1,12 +1,9 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 fn map_relational_symbols(name: &str) -> Option<&'static str> {
@@ -47,22 +44,22 @@ impl AlwaysFixableViolation for DeprecatedRelationalOperator {
     }
 }
 impl AstRule for DeprecatedRelationalOperator {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let relation = node.child(1)?;
         let symbol = relation
-            .to_text(src.source_text())?
+            .to_text(context.source_text())?
             .to_lowercase()
             .to_string();
         let new_symbol = map_relational_symbols(symbol.as_str())?.to_string();
 
-        let fix = Fix::safe_edit(relation.edit_replacement(src, new_symbol.clone()));
+        let fix =
+            Fix::safe_edit(relation.edit_replacement(context.source_file(), new_symbol.clone()));
 
-        some_vec![Diagnostic::from_node(Self { symbol, new_symbol }, &relation).with_fix(fix)]
+        some_vec![
+            context
+                .create_diagnostic(Self { symbol, new_symbol }, relation)
+                .with_fix(fix)
+        ]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/modernisation/save.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/save.rs
@@ -2,7 +2,9 @@ use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 
-use crate::{AstRule, ast::FortitudeNode, settings::FortranStandard, traits::TextRanged};
+use crate::{
+    AstRule, CheckContext, ast::FortitudeNode, settings::FortranStandard, traits::TextRanged,
+};
 
 /// ## What it does
 /// Checks for unnecessary `save` statements and qualifiers
@@ -49,14 +51,9 @@ impl AlwaysFixableViolation for SuperfluousSave {
 }
 
 impl AstRule for SuperfluousSave {
-    fn check(
-        settings: &crate::settings::CheckSettings,
-        node: &tree_sitter::Node,
-        source: &ruff_source_file::SourceFile,
-        _symbol_table: &crate::ast::symbol_table::SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &tree_sitter::Node) -> Option<Vec<Diagnostic>> {
         // Only F2008 and later made `save` at the module level implicit
-        if settings.target_std < FortranStandard::F2008 {
+        if context.settings().target_std < FortranStandard::F2008 {
             return None;
         }
 
@@ -71,7 +68,7 @@ impl AstRule for SuperfluousSave {
             let save_qualifier = node
                 .named_children(&mut node.walk())
                 .filter(|c| c.grammar_name() == "type_qualifier")
-                .find(|c| c.to_text(source.source_text()) == Some("save"))?;
+                .find(|c| c.to_text(context.source_text()) == Some("save"))?;
 
             let start_node = match save_qualifier.prev_sibling() {
                 None => save_qualifier,
@@ -85,28 +82,32 @@ impl AstRule for SuperfluousSave {
             };
 
             some_vec![
-                Diagnostic::from_node(
-                    Self {
-                        entity: "attribute"
-                    },
-                    &save_qualifier
-                )
-                .with_fix(Fix::safe_edit(Edit::deletion(
-                    start_node.start_textsize(),
-                    save_qualifier.end_textsize()
-                )))
+                context
+                    .create_diagnostic(
+                        Self {
+                            entity: "attribute"
+                        },
+                        save_qualifier
+                    )
+                    .with_fix(Fix::safe_edit(Edit::deletion(
+                        start_node.start_textsize(),
+                        save_qualifier.end_textsize()
+                    )))
             ]
         } else {
             let save_statement = node.child_with_name("save_statement")?;
 
             some_vec![
-                Diagnostic::from_node(
-                    Self {
-                        entity: "statement"
-                    },
-                    &save_statement
-                )
-                .with_fix(Fix::safe_edit(save_statement.edit_delete(source)))
+                context
+                    .create_diagnostic(
+                        Self {
+                            entity: "statement"
+                        },
+                        save_statement
+                    )
+                    .with_fix(Fix::safe_edit(
+                        save_statement.edit_delete(context.source_file())
+                    ))
             ]
         }
     }

--- a/crates/fortitude_linter/src/rules/obsolescent/arithmetic_if.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/arithmetic_if.rs
@@ -1,8 +1,7 @@
 use crate::ast::{ControlFlow, ControlFlowNode, FortitudeNode};
 use crate::diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
-use crate::settings::CheckSettings;
 use crate::traits::TextRanged;
-use crate::{AstRule, SymbolTables};
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use log::debug;
@@ -347,14 +346,9 @@ fn end_of_replacement(node: &Node, src: &str, base_indentation: &str) -> (TextSi
 }
 
 impl AstRule for ArithmeticIf {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let mut diagnostic = Diagnostic::from_node(ArithmeticIf {}, node);
-        if let Some(fix) = fix_arithmetic_if(node, src) {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
+        let mut diagnostic = context.create_diagnostic(ArithmeticIf {}, node);
+        if let Some(fix) = fix_arithmetic_if(node, context.source_file()) {
             diagnostic.set_fix(fix);
         }
         some_vec![diagnostic]

--- a/crates/fortitude_linter/src/rules/obsolescent/block_data_construct.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/block_data_construct.rs
@@ -1,10 +1,9 @@
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::{CheckSettings, FortranStandard};
-use crate::{AstRule, SymbolTables};
+use crate::settings::FortranStandard;
+use crate::{AstRule, CheckContext};
 
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -29,18 +28,13 @@ impl Violation for BlockDataConstruct {
 }
 
 impl AstRule for BlockDataConstruct {
-    fn check<'a>(
-        settings: &CheckSettings,
-        node: &'a Node,
-        _src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
         // Only made obsolescent in F2018
-        if settings.target_std < FortranStandard::F2018 {
+        if context.settings().target_std < FortranStandard::F2018 {
             return None;
         }
 
-        some_vec![Diagnostic::from_node(BlockDataConstruct {}, node)]
+        some_vec![context.create_diagnostic(BlockDataConstruct {}, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/obsolescent/common_blocks.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/common_blocks.rs
@@ -1,10 +1,7 @@
-use crate::AstRule;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -77,13 +74,8 @@ impl Violation for CommonBlock {
 }
 
 impl AstRule for CommonBlock {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        some_vec![Diagnostic::from_node(CommonBlock {}, node)]
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        some_vec![context.create_diagnostic(CommonBlock {}, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/obsolescent/computed_goto.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/computed_goto.rs
@@ -1,10 +1,7 @@
-use crate::AstRule;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -82,12 +79,7 @@ impl Violation for ComputedGoTo {
 }
 
 impl AstRule for ComputedGoTo {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         if matches!(node.child(0)?.kind(), "goto" | "go")
             && node
                 .children(&mut node.walk())
@@ -95,7 +87,7 @@ impl AstRule for ComputedGoTo {
                 .count()
                 > 1
         {
-            return some_vec![Diagnostic::from_node(ComputedGoTo {}, node)];
+            return some_vec![context.create_diagnostic(ComputedGoTo {}, node)];
         }
         None
     }

--- a/crates/fortitude_linter/src/rules/obsolescent/deprecated_character_syntax.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/deprecated_character_syntax.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What does it do?
@@ -36,13 +33,8 @@ impl AlwaysFixableViolation for DeprecatedCharacterSyntax {
 }
 
 impl AstRule for DeprecatedCharacterSyntax {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        source_file: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = source_file.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
 
         // Rule only applies to `character`.
         // Expect child(0) to always be present.
@@ -78,17 +70,18 @@ impl AstRule for DeprecatedCharacterSyntax {
         let original = node.to_text(src)?.to_string();
         let dtype = dtype.to_text(src)?.to_string();
         let replacement = format!("{dtype}(len={length})");
-        let fix = Fix::safe_edit(node.edit_replacement(source_file, replacement));
+        let fix = Fix::safe_edit(node.edit_replacement(context.source_file(), replacement));
         some_vec![
-            Diagnostic::from_node(
-                Self {
-                    original,
-                    dtype,
-                    length
-                },
-                node
-            )
-            .with_fix(fix)
+            context
+                .create_diagnostic(
+                    Self {
+                        original,
+                        dtype,
+                        length
+                    },
+                    node
+                )
+                .with_fix(fix)
         ]
     }
 

--- a/crates/fortitude_linter/src/rules/obsolescent/entry_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/entry_statement.rs
@@ -1,10 +1,7 @@
-use crate::AstRule;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -34,13 +31,8 @@ impl Violation for EntryStatement {
 }
 
 impl AstRule for EntryStatement {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        some_vec![Diagnostic::from_node(EntryStatement {}, node)]
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        some_vec![context.create_diagnostic(EntryStatement {}, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/obsolescent/equivalence_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/equivalence_statement.rs
@@ -1,9 +1,8 @@
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::{CheckSettings, FortranStandard};
-use crate::{AstRule, SymbolTables};
+use crate::settings::FortranStandard;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -37,18 +36,13 @@ impl Violation for EquivalenceStatement {
 }
 
 impl AstRule for EquivalenceStatement {
-    fn check<'a>(
-        settings: &CheckSettings,
-        node: &'a Node,
-        _src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
         // Only made obsolescent in F2018
-        if settings.target_std < FortranStandard::F2018 {
+        if context.settings().target_std < FortranStandard::F2018 {
             return None;
         }
 
-        some_vec![Diagnostic::from_node(EquivalenceStatement {}, node)]
+        some_vec![context.create_diagnostic(EquivalenceStatement {}, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/obsolescent/forall_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/forall_statement.rs
@@ -1,9 +1,8 @@
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::{CheckSettings, FortranStandard};
-use crate::{AstRule, SymbolTables};
+use crate::settings::FortranStandard;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -53,18 +52,13 @@ impl Violation for ForallStatement {
 }
 
 impl AstRule for ForallStatement {
-    fn check<'a>(
-        settings: &CheckSettings,
-        node: &'a Node,
-        _src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
         // Only made obsolescent in F2018
-        if settings.target_std < FortranStandard::F2018 {
+        if context.settings().target_std < FortranStandard::F2018 {
             return None;
         }
 
-        some_vec![Diagnostic::from_node(ForallStatement {}, &node.child(0)?)]
+        some_vec![context.create_diagnostic(ForallStatement {}, node.child(0)?)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/obsolescent/mpi.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/mpi.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use std::path::Path;
 use tree_sitter::Node;
 
@@ -108,22 +105,17 @@ impl Violation for DeprecatedMPIInclude {
 }
 
 impl AstRule for DeprecatedMPIInclude {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let include_file = node
             .child_with_name("filename")?
-            .to_text(_src.source_text())?
+            .to_text(context.source_text())?
             .to_lowercase();
 
         // Strip quotes from the include file name
         let include_file = include_file.trim_matches('"').trim_matches('\'');
 
         if Path::new(&include_file).file_name() == Some("mpif.h".as_ref()) {
-            return some_vec![Diagnostic::from_node(DeprecatedMPIInclude {}, node)];
+            return some_vec![context.create_diagnostic(DeprecatedMPIInclude {}, node)];
         }
         None
     }

--- a/crates/fortitude_linter/src/rules/obsolescent/non_block_do.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/non_block_do.rs
@@ -1,8 +1,7 @@
 use crate::ast::{ControlFlow, ControlFlowNode, FortitudeNode};
 use crate::diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
-use crate::settings::CheckSettings;
 use crate::traits::TextRanged;
-use crate::{AstRule, SymbolTables};
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use log::debug;
 use ruff_macros::derive_message_formats;
@@ -50,18 +49,13 @@ impl Violation for LabelledDoLoop {
 }
 
 impl AstRule for LabelledDoLoop {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
         // `do_label` is the obsolete node that we're trying to catch
         let label = node.child_by_field_name("do_label")?;
         let do_loop = node.parent()?;
 
-        let mut diagnostic = Diagnostic::from_node(LabelledDoLoop {}, &label);
-        if let Some(fix) = fix_labelled_do(&do_loop, &label, src) {
+        let mut diagnostic = context.create_diagnostic(LabelledDoLoop {}, label);
+        if let Some(fix) = fix_labelled_do(&do_loop, &label, context.source_file()) {
             diagnostic.set_fix(fix);
         }
         some_vec![diagnostic]
@@ -112,17 +106,12 @@ impl Violation for SharedDoTermination {
 }
 
 impl AstRule for SharedDoTermination {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
         // We only want to give one warning, so pick the node that has the
         // statement label. For multiple shared terminations, only first gets
         // the label, and the others get the following whitespace (something
         // about non-overlapping nodes).
-        if node.to_text(src.source_text())?.is_empty() {
+        if node.to_text(context.source_text())?.is_empty() {
             return None;
         }
 
@@ -131,8 +120,8 @@ impl AstRule for SharedDoTermination {
         let end = node.next_non_comment_statement()?.end_textsize();
         let range = TextRange::new(start, end);
 
-        let mut diagnostic = Diagnostic::new(Self {}, range);
-        if let Some(fix) = fix_shared_termination(node, src) {
+        let mut diagnostic = context.create_diagnostic(Self {}, range);
+        if let Some(fix) = fix_shared_termination(node, context.source_file()) {
             diagnostic.set_fix(fix);
         }
         some_vec![diagnostic]
@@ -179,12 +168,7 @@ impl Violation for BadDoTermination {
 }
 
 impl AstRule for BadDoTermination {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        source: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let end_do_label = node.child_by_field_name("do_label")?;
         // Don't catch shared termination
         if end_do_label.kind() == "do_label_virtual" {
@@ -194,14 +178,15 @@ impl AstRule for BadDoTermination {
 
         let mut diagnostics = Vec::new();
 
-        let src = source.source_text();
+        let src = context.source_text();
 
         match end_action.kind() {
             "end" | "enddo" => (),
             "keyword_statement" if ControlFlow::maybe_from(&end_action, src)?.is_continue() => (),
             _ => {
-                let mut diagnostic = Diagnostic::from_node(Self {}, &end_action);
-                if let Some(fix) = fix_bad_do_termination(node, &end_action, &end_do_label, source)
+                let mut diagnostic = context.create_diagnostic(Self {}, end_action);
+                if let Some(fix) =
+                    fix_bad_do_termination(node, &end_action, &end_do_label, context.source_file())
                 {
                     diagnostic.set_fix(fix);
                 }
@@ -264,13 +249,8 @@ impl Violation for GotoEndDo {
 }
 
 impl AstRule for GotoEndDo {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        source: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = source.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
 
         let goto = ControlFlowNode::maybe_from(*node, src)?;
         let label_ref = goto.goto_ref()?;
@@ -285,8 +265,8 @@ impl AstRule for GotoEndDo {
             return None;
         }
         // TODO: extra annotation with `goto` target
-        let mut diagnostic = Diagnostic::from_node(Self {}, node);
-        if let Some(fix) = fix_goto_end_do(node, &label_node, source) {
+        let mut diagnostic = context.create_diagnostic(Self {}, node);
+        if let Some(fix) = fix_goto_end_do(node, &label_node, context.source_file()) {
             diagnostic.set_fix(fix);
         }
 

--- a/crates/fortitude_linter/src/rules/obsolescent/openmp.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/openmp.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use std::path::Path;
 use tree_sitter::Node;
 
@@ -34,22 +31,17 @@ impl Violation for DeprecatedOmpInclude {
 }
 
 impl AstRule for DeprecatedOmpInclude {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let include_file = node
             .child_with_name("filename")?
-            .to_text(_src.source_text())?
+            .to_text(context.source_text())?
             .to_lowercase();
 
         // Strip quotes from the include file name
         let include_file = include_file.trim_matches('"').trim_matches('\'');
 
         if Path::new(&include_file).file_name() == Some("omp_lib.h".as_ref()) {
-            return some_vec![Diagnostic::from_node(DeprecatedOmpInclude {}, node)];
+            return some_vec![context.create_diagnostic(DeprecatedOmpInclude {}, node)];
         }
         None
     }

--- a/crates/fortitude_linter/src/rules/obsolescent/pause_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/pause_statement.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Fix, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -34,18 +31,24 @@ impl Violation for PauseStatement {
 }
 
 impl AstRule for PauseStatement {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        if node.child(0)?.to_text(src.source_text())?.to_lowercase() != "pause" {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        if node
+            .child(0)?
+            .to_text(context.source_text())?
+            .to_lowercase()
+            != "pause"
+        {
             return None;
         }
 
-        let fix = Fix::unsafe_edit(node.edit_replacement(src, "read(*, *)".to_string()));
-        some_vec![Diagnostic::from_node(PauseStatement {}, node).with_fix(fix)]
+        let fix = Fix::unsafe_edit(
+            node.edit_replacement(context.source_file(), "read(*, *)".to_string()),
+        );
+        some_vec![
+            context
+                .create_diagnostic(PauseStatement {}, node)
+                .with_fix(fix)
+        ]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/obsolescent/specific_names.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/specific_names.rs
@@ -1,12 +1,9 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Fix, Violation};
 use crate::rules::utilities;
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 fn map_specific_intrinsic_functions(name: &str) -> Option<&'static str> {
@@ -90,28 +87,26 @@ impl Violation for SpecificName {
 }
 
 impl AstRule for SpecificName {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let name_node = node.child_with_name("identifier")?;
-        let func = name_node.to_text(src.source_text())?;
+        let func = name_node.to_text(context.source_text())?;
 
         let new_func = map_specific_intrinsic_functions(func.to_uppercase().as_str())?;
         let matched_case = utilities::match_original_case(func, new_func)?;
 
-        let fix = Fix::unsafe_edit(name_node.edit_replacement(src, matched_case.clone()));
+        let fix = Fix::unsafe_edit(
+            name_node.edit_replacement(context.source_file(), matched_case.clone()),
+        );
         some_vec![
-            Diagnostic::from_node(
-                Self {
-                    func: func.to_string(),
-                    new_func: matched_case
-                },
-                &name_node
-            )
-            .with_fix(fix)
+            context
+                .create_diagnostic(
+                    Self {
+                        func: func.to_string(),
+                        new_func: matched_case
+                    },
+                    name_node
+                )
+                .with_fix(fix)
         ]
     }
 

--- a/crates/fortitude_linter/src/rules/obsolescent/statement_functions.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/statement_functions.rs
@@ -1,10 +1,7 @@
-use crate::AstRule;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -50,13 +47,8 @@ impl Violation for StatementFunction {
 }
 
 impl AstRule for StatementFunction {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        some_vec![Diagnostic::from_node(StatementFunction {}, node)]
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        some_vec![context.create_diagnostic(StatementFunction {}, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/portability/invalid_tab.rs
+++ b/crates/fortitude_linter/src/rules/portability/invalid_tab.rs
@@ -1,12 +1,12 @@
-use crate::diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use crate::{
+    CheckContext,
+    diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation},
+};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 use tree_sitter::Node;
-
-use crate::settings::CheckSettings;
 
 /// ## What it does
 /// Checks for the use of tab characters as whitespace
@@ -33,12 +33,9 @@ impl Violation for InvalidTab {
     }
 }
 
-pub fn check_invalid_tab(
-    root: &Node,
-    src: &SourceFile,
-    settings: &CheckSettings,
-) -> Vec<Diagnostic> {
-    src.source_text()
+pub(crate) fn check_invalid_tab(context: &CheckContext, root: &Node) -> Vec<Diagnostic> {
+    context
+        .source_text()
         .char_indices()
         .filter(|(_, c)| *c == '\t')
         .filter(|(index, _)| {
@@ -51,10 +48,12 @@ pub fn check_invalid_tab(
         .map(|(index, _)| {
             let start = TextSize::try_from(index).unwrap();
             let range = TextRange::new(start, start + TextSize::new(1));
-            let width = settings.invalid_tab.indent_width.as_usize();
+            let width = context.settings().invalid_tab.indent_width.as_usize();
             let indent = format!("{:width$}", " ");
             let edit = Edit::range_replacement(indent, range);
-            Diagnostic::new(InvalidTab, range).with_fix(Fix::unsafe_edit(edit))
+            context
+                .create_diagnostic(InvalidTab, range)
+                .with_fix(Fix::unsafe_edit(edit))
         })
         .collect_vec()
 }

--- a/crates/fortitude_linter/src/rules/portability/literal_kinds.rs
+++ b/crates/fortitude_linter/src/rules/portability/literal_kinds.rs
@@ -1,12 +1,9 @@
-use crate::AstRule;
 use crate::ast::{FortitudeNode, dtype_is_plain_number};
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use lazy_regex::regex_is_match;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 fn iso_fortran_env_param<S: AsRef<str>>(dtype: S, literal: u8) -> Option<String> {
@@ -106,13 +103,8 @@ impl Violation for LiteralKind {
 }
 
 impl AstRule for LiteralKind {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = src.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
         let dtype = node.child(0)?.to_text(src)?.to_lowercase();
         // TODO: Deal with characters
         if !dtype_is_plain_number(dtype.as_str()) {
@@ -122,10 +114,7 @@ impl AstRule for LiteralKind {
         let kind_node = node.child_by_field_name("kind")?;
         let literal_node = integer_literal_kind(&kind_node, src)?;
         let literal: u8 = literal_node.to_text(src)?.parse().ok()?;
-        some_vec![Diagnostic::from_node(
-            Self { dtype, literal },
-            &literal_node
-        )]
+        some_vec![context.create_diagnostic(Self { dtype, literal }, literal_node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {
@@ -198,20 +187,15 @@ impl Violation for LiteralKindSuffix {
 }
 
 impl AstRule for LiteralKindSuffix {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let src = src.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_text();
         let kind = node.child_by_field_name("kind")?;
         if kind.kind() != "number_literal" {
             return None;
         }
         let literal = node.to_text(src)?.to_string();
         let suffix: u8 = kind.to_text(src)?.parse().ok()?;
-        some_vec![Diagnostic::from_node(Self { literal, suffix }, &kind)]
+        some_vec![context.create_diagnostic(Self { literal, suffix }, kind)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/portability/non_portable_io_unit.rs
+++ b/crates/fortitude_linter/src/rules/portability/non_portable_io_unit.rs
@@ -1,12 +1,9 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::rules::utilities::literal_as_io_unit;
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -47,16 +44,11 @@ impl Violation for NonPortableIoUnit {
 }
 
 impl AstRule for NonPortableIoUnit {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let unit = literal_as_io_unit(node, src)?;
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let unit = literal_as_io_unit(node, context.source_file())?;
 
         let value = unit
-            .to_text(src.source_text())?
+            .to_text(context.source_text())?
             .parse::<i32>()
             .unwrap_or_default();
         let is_read = node.kind() == "read_statement";
@@ -68,7 +60,7 @@ impl AstRule for NonPortableIoUnit {
         let mut stdout = vec![6];
         let mut stderr = vec![0];
 
-        if !settings.portability.allow_cray_file_units {
+        if !context.settings().portability.allow_cray_file_units {
             stdin.push(100);
             stdout.push(101);
             stderr.push(102);
@@ -85,13 +77,13 @@ impl AstRule for NonPortableIoUnit {
         }
         .to_string();
 
-        some_vec!(Diagnostic::from_node(
+        some_vec!(context.create_diagnostic(
             Self {
                 value,
                 kind,
                 replacement
             },
-            &unit
+            unit
         ))
     }
 

--- a/crates/fortitude_linter/src/rules/portability/star_kinds.rs
+++ b/crates/fortitude_linter/src/rules/portability/star_kinds.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::{FortitudeNode, dtype_is_plain_number, strip_line_breaks};
 use crate::diagnostics::{Diagnostic, Fix, FixAvailability, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -49,13 +46,8 @@ impl Violation for StarKind {
 }
 
 impl AstRule for StarKind {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let text = src.source_text();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let text = context.source_text();
         let dtype = node.child(0)?.to_text(text)?.to_lowercase();
         // TODO: Handle characters
         if !dtype_is_plain_number(dtype.as_str()) {
@@ -73,8 +65,12 @@ impl AstRule for StarKind {
         let literal = kind_node.child_with_name("number_literal")?;
         let kind = literal.to_text(text)?.to_string();
         let replacement = format!("{dtype}({kind})");
-        let fix = Fix::unsafe_edit(node.edit_replacement(src, replacement));
-        some_vec![Diagnostic::from_node(Self { dtype, size, kind }, &kind_node).with_fix(fix)]
+        let fix = Fix::unsafe_edit(node.edit_replacement(context.source_file(), replacement));
+        some_vec![
+            context
+                .create_diagnostic(Self { dtype, size, kind }, kind_node)
+                .with_fix(fix)
+        ]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/style/complexity.rs
+++ b/crates/fortitude_linter/src/rules/style/complexity.rs
@@ -1,12 +1,9 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 use tree_sitter::Node;
 
@@ -108,23 +105,18 @@ impl Violation for TooComplex {
 }
 
 impl AstRule for TooComplex {
-    fn check<'a>(
-        settings: &CheckSettings,
-        node: &'a Node,
-        _src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
         let procedure_stmt = node.named_child(0)?;
         let actual_complexity = cyclomatic_complexity(node);
-        let max_complexity = settings.complexity.max_complexity;
+        let max_complexity = context.settings().complexity.max_complexity;
 
         if actual_complexity > max_complexity {
-            return some_vec![Diagnostic::from_node(
+            return some_vec![context.create_diagnostic(
                 TooComplex {
                     actual_complexity,
                     max_complexity,
                 },
-                &procedure_stmt,
+                procedure_stmt,
             )];
         }
         None
@@ -241,12 +233,7 @@ impl Violation for TooManyArguments {
 }
 
 impl AstRule for TooManyArguments {
-    fn check<'a>(
-        settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
         // Do not check procedures in interface blocks
         if node
             .ancestors()
@@ -255,7 +242,7 @@ impl AstRule for TooManyArguments {
             return None;
         }
 
-        let src = src.source_text();
+        let src = context.source_text();
         let procedure_stmt = node.named_child(0)?;
         let procedure_name = procedure_stmt
             .child_with_name("name")?
@@ -281,7 +268,7 @@ impl AstRule for TooManyArguments {
             })
             .collect();
         let arg_count = args.len();
-        let max_args = settings.complexity.max_args;
+        let max_args = context.settings().complexity.max_args;
 
         if arg_count > max_args {
             // arg_count must be at least 1, so args.first() and args.last() are guaranteed to exist
@@ -289,7 +276,7 @@ impl AstRule for TooManyArguments {
                 args.first().unwrap().start_textsize(),
                 args.last().unwrap().end_textsize(),
             );
-            return some_vec![Diagnostic::new(
+            return some_vec![context.create_diagnostic(
                 TooManyArguments {
                     arg_count,
                     max_args,

--- a/crates/fortitude_linter/src/rules/style/double_colon_in_decl.rs
+++ b/crates/fortitude_linter/src/rules/style/double_colon_in_decl.rs
@@ -1,12 +1,9 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What does it do?
@@ -29,21 +26,16 @@ impl AlwaysFixableViolation for MissingDoubleColon {
     }
 }
 impl AstRule for MissingDoubleColon {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         if node
             .children(&mut node.walk())
-            .filter_map(|child| child.to_text(src.source_text()))
+            .filter_map(|child| child.to_text(context.source_text()))
             .all(|child| child != "::")
         {
             let first_decl = node.child_by_field_name("declarator")?;
             let start_pos = first_decl.start_textsize();
             let fix = Fix::safe_edit(Edit::insertion(":: ".to_string(), start_pos));
-            some_vec!(Diagnostic::from_node(Self {}, node).with_fix(fix))
+            some_vec!(context.create_diagnostic(Self {}, node).with_fix(fix))
         } else {
             None
         }

--- a/crates/fortitude_linter/src/rules/style/end_statements.rs
+++ b/crates/fortitude_linter/src/rules/style/end_statements.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What does it do?
@@ -70,12 +67,7 @@ fn map_declaration(kind: &str) -> (&'static str, &'static str) {
 }
 
 impl AstRule for UnnamedEndStatement {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
         // If end node is named, move on.
         // Not catching incorrect end statement name here, as the compiler should
         // do that for us.
@@ -92,11 +84,11 @@ impl AstRule for UnnamedEndStatement {
         };
         let name = statement_node
             .child_with_name(name_kind)?
-            .to_text(src.source_text())?
+            .to_text(context.source_text())?
             .to_string();
 
         // Preserve existing case of end statement
-        let text = node.to_text(src.source_text())?;
+        let text = node.to_text(context.source_text())?;
         let is_lower_case = text == text.to_lowercase();
         let end_statement = if is_lower_case {
             format!("end {statement}")
@@ -105,8 +97,12 @@ impl AstRule for UnnamedEndStatement {
         };
 
         let replacement = format!("{end_statement} {name}");
-        let fix = Fix::safe_edit(node.edit_replacement(src, replacement.clone()));
-        some_vec![Diagnostic::from_node(Self { replacement }, node).with_fix(fix)]
+        let fix = Fix::safe_edit(node.edit_replacement(context.source_file(), replacement.clone()));
+        some_vec![
+            context
+                .create_diagnostic(Self { replacement }, node)
+                .with_fix(fix)
+        ]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/style/file_contents.rs
+++ b/crates/fortitude_linter/src/rules/style/file_contents.rs
@@ -1,10 +1,7 @@
-use crate::AstRule;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -25,19 +22,14 @@ impl Violation for MultipleModules {
 }
 
 impl AstRule for MultipleModules {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let violations: Vec<Diagnostic> = node
             .children(&mut node.walk())
             .filter(|node| node.kind() == "module")
             .skip(1)
             .map(|m| -> Diagnostic {
                 let m_first = m.child(0).unwrap_or(m);
-                Diagnostic::from_node(MultipleModules {}, &m_first)
+                context.create_diagnostic(MultipleModules {}, m_first)
             })
             .collect();
 
@@ -67,12 +59,7 @@ impl Violation for ProgramWithModule {
 }
 
 impl AstRule for ProgramWithModule {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        _src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         // There must be a program statement to trigger this rule
         if !node
             .children(&mut node.walk())
@@ -88,7 +75,7 @@ impl AstRule for ProgramWithModule {
             .skip(1)
             .map(|m| -> Diagnostic {
                 let m_first = m.child(0).unwrap_or(m);
-                Diagnostic::from_node(ProgramWithModule {}, &m_first)
+                context.create_diagnostic(ProgramWithModule {}, m_first)
             })
             .collect();
 

--- a/crates/fortitude_linter/src/rules/style/functions.rs
+++ b/crates/fortitude_linter/src/rules/style/functions.rs
@@ -1,11 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -82,18 +79,13 @@ impl Violation for FunctionMissingResult {
 }
 
 impl AstRule for FunctionMissingResult {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        _src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check<'a>(context: &'a CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {
         // Just need to check for the presence of the function_result node
         if node.child_with_name("function_result").is_some() {
             return None;
         }
 
-        some_vec![Diagnostic::from_node(Self {}, node)]
+        some_vec![context.create_diagnostic(Self {}, node)]
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/style/implicit_none.rs
+++ b/crates/fortitude_linter/src/rules/style/implicit_none.rs
@@ -1,12 +1,9 @@
-use crate::AstRule;
 /// Defines rules that raise errors if implicit typing is in use.
 use crate::ast::{FortitudeNode, types::ImplicitStatement};
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use tree_sitter::Node;
 
 /// ## What it does
@@ -33,12 +30,8 @@ impl AlwaysFixableViolation for SuperfluousImplicitNone {
 }
 
 impl AstRule for SuperfluousImplicitNone {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let src = context.source_file();
         let stmt = ImplicitStatement::try_from_node(*node, src)?;
         // If this isn't an `implicit none` statement, then we don't care about it.
         if stmt.is_not_implicit_none() {
@@ -69,7 +62,9 @@ impl AstRule for SuperfluousImplicitNone {
                                     let entity = kind.to_string();
                                     let fix = Fix::safe_edit(node.edit_delete(src));
                                     return some_vec![
-                                        Diagnostic::from_node(Self { entity }, node).with_fix(fix)
+                                        context
+                                            .create_diagnostic(Self { entity }, node)
+                                            .with_fix(fix)
                                     ];
                                 } else {
                                     break;

--- a/crates/fortitude_linter/src/rules/style/inconsistent_dimension.rs
+++ b/crates/fortitude_linter/src/rules/style/inconsistent_dimension.rs
@@ -1,10 +1,10 @@
+use crate::CheckContext;
 use crate::Rule;
 use crate::ast::FortitudeNode;
 use crate::ast::types::NameDecl;
 use crate::ast::types::VariableDeclaration;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use crate::fix::edits::remove_variable_decl;
-use crate::settings::CheckSettings;
 use crate::traits::{HasNode, TextRanged};
 use anyhow::{Context, Result};
 use fortitude_macros::ViolationMetadata;
@@ -96,11 +96,13 @@ fn dimension_attribute_and_shape(
 }
 
 fn fix_inconsistent_dimension(
+    context: &CheckContext,
     var: &NameDecl,
     decl: &VariableDeclaration,
-    src: &SourceFile,
-    prefer_attribute: PreferAttribute,
 ) -> Result<Vec<Edit>> {
+    let prefer_attribute = context.settings().inconsistent_dimension.prefer_attribute;
+    let src = context.source_file();
+
     let mut edits = vec![remove_variable_decl(var.node(), decl, src)?];
 
     let (new_attr, var_str) =
@@ -137,9 +139,8 @@ fn fix_inconsistent_dimension(
 }
 
 fn check_inconsistent_dimension(
+    context: &CheckContext,
     decl_line: &VariableDeclaration,
-    src: &SourceFile,
-    prefer_attribute: PreferAttribute,
 ) -> Option<Vec<Diagnostic>> {
     if !decl_line
         .attributes()
@@ -155,10 +156,10 @@ fn check_inconsistent_dimension(
             .iter()
             .filter(|name| name.size().is_some())
             .filter_map(|node| {
-                let mut edits =
-                    fix_inconsistent_dimension(node, decl_line, src, prefer_attribute).ok()?;
+                let mut edits = fix_inconsistent_dimension(context, node, decl_line).ok()?;
                 Some(
-                    Diagnostic::from_node(InconsistentArrayDeclaration, node.node())
+                    context
+                        .create_diagnostic(InconsistentArrayDeclaration, node)
                         .with_fix(Fix::unsafe_edits(edits.remove(0), edits)),
                 )
             })
@@ -211,9 +212,8 @@ impl AlwaysFixableViolation for MixedScalarArrayDeclaration {
 }
 
 fn check_mixed_scalar_array(
+    context: &CheckContext,
     decl_line: &VariableDeclaration,
-    src: &SourceFile,
-    prefer_attribute: PreferAttribute,
 ) -> Option<Vec<Diagnostic>> {
     if decl_line
         .attributes()
@@ -236,10 +236,10 @@ fn check_mixed_scalar_array(
             .filter_map(|node| {
                 // FIXME: use of `.ok()?` means error in fix skips the
                 // diagnostic completely, hiding bugs.
-                let mut edits =
-                    fix_inconsistent_dimension(node, decl_line, src, prefer_attribute).ok()?;
+                let mut edits = fix_inconsistent_dimension(context, node, decl_line).ok()?;
                 Some(
-                    Diagnostic::from_node(MixedScalarArrayDeclaration, node.node())
+                    context
+                        .create_diagnostic(MixedScalarArrayDeclaration, node)
                         .with_fix(Fix::unsafe_edits(edits.remove(0), edits)),
                 )
             })
@@ -295,14 +295,15 @@ impl AlwaysFixableViolation for BadArrayDeclaration {
 }
 
 fn check_bad_array_decl(
+    context: &CheckContext,
     decl_line: &VariableDeclaration,
-    src: &SourceFile,
-    prefer_attribute: PreferAttribute,
 ) -> Option<Vec<Diagnostic>> {
     let has_dim = decl_line
         .attributes()
         .iter()
         .any(|attr| attr.kind().is_dimension());
+
+    let prefer_attribute = context.settings().inconsistent_dimension.prefer_attribute;
 
     if has_dim && prefer_attribute.is_always() {
         // We've got a `dimension` attriute and want one
@@ -322,45 +323,37 @@ fn check_bad_array_decl(
             })
             .map(|node| {
                 // FIXME: use of `ok` hides bugs
-                let mut edits = fix_inconsistent_dimension(node, decl_line, src, prefer_attribute)
+                let mut edits = fix_inconsistent_dimension(context, node, decl_line)
                     .ok()
                     .unwrap();
-                Diagnostic::from_node(BadArrayDeclaration { prefer_attribute }, node.node())
+                context
+                    .create_diagnostic(BadArrayDeclaration { prefer_attribute }, node)
                     .with_fix(Fix::unsafe_edits(edits.remove(0), edits))
             })
             .collect_vec(),
     )
 }
 
-pub fn check_inconsistent_dimension_rules(
-    settings: &CheckSettings,
+pub(crate) fn check_inconsistent_dimension_rules(
+    context: &CheckContext,
     decl_line: &VariableDeclaration,
-    src: &SourceFile,
 ) -> Vec<Diagnostic> {
     let mut violations = Vec::new();
 
-    let rules = &settings.rules;
-    let prefer_attribute = settings.inconsistent_dimension.prefer_attribute;
-
-    if rules.enabled(Rule::InconsistentArrayDeclaration) {
-        if let Some(violation) = check_inconsistent_dimension(decl_line, src, prefer_attribute) {
+    if context.is_rule_enabled(Rule::InconsistentArrayDeclaration) {
+        if let Some(violation) = check_inconsistent_dimension(context, decl_line) {
             violations.extend(violation);
         }
     }
-    if rules.enabled(Rule::MixedScalarArrayDeclaration) {
-        if let Some(violation) = check_mixed_scalar_array(decl_line, src, prefer_attribute) {
+    if context.is_rule_enabled(Rule::MixedScalarArrayDeclaration) {
+        if let Some(violation) = check_mixed_scalar_array(context, decl_line) {
             violations.extend(violation);
         }
     }
-    if rules.enabled(Rule::BadArrayDeclaration) {
-        match prefer_attribute {
-            // Do nothing!
-            PreferAttribute::Keep => (),
-            _ => {
-                if let Some(violation) = check_bad_array_decl(decl_line, src, prefer_attribute) {
-                    violations.extend(violation);
-                }
-            }
+    let prefer_attribute = context.settings().inconsistent_dimension.prefer_attribute;
+    if context.is_rule_enabled(Rule::BadArrayDeclaration) && !prefer_attribute.is_keep() {
+        if let Some(violation) = check_bad_array_decl(context, decl_line) {
+            violations.extend(violation);
         }
     }
     violations

--- a/crates/fortitude_linter/src/rules/style/keywords.rs
+++ b/crates/fortitude_linter/src/rules/style/keywords.rs
@@ -1,16 +1,13 @@
-use crate::AstRule;
 /// Defines rules that govern the use of keywords.
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{
     AlwaysFixableViolation, Diagnostic, Edit, Fix, FixAvailability, Violation,
 };
-use crate::settings::CheckSettings;
 use crate::stylist::ToCapitalisation;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 use std::str::FromStr;
 use tree_sitter::Node;
@@ -117,32 +114,31 @@ impl AlwaysFixableViolation for KeywordsMissingSpace {
 }
 
 impl AstRule for KeywordsMissingSpace {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let first_child = if node.kind() == "inout" {
             *node
         } else {
             node.child(0)?
         };
-        let text = first_child.to_text(src.source_text())?;
+        let text = first_child.to_text(context.source_text())?;
         let keywords = DoubleKeyword::from_str(text).ok()?;
 
         // Exit early if the keyword is permitted
-        if matches!(keywords, DoubleKeyword::InOut) && !settings.keyword_whitespace.inout_with_space
-        {
+        let keyword_settings = &context.settings().keyword_whitespace;
+        if matches!(keywords, DoubleKeyword::InOut) && !keyword_settings.inout_with_space {
             return None;
         }
-        if matches!(keywords, DoubleKeyword::GoTo) && !settings.keyword_whitespace.goto_with_space {
+        if matches!(keywords, DoubleKeyword::GoTo) && !keyword_settings.goto_with_space {
             return None;
         }
 
         let space_pos = node.start_textsize() + TextSize::try_from(keywords.offset()).unwrap();
         let fix = Fix::safe_edit(Edit::insertion(" ".to_string(), space_pos));
-        some_vec!(Diagnostic::from_node(Self { keywords }, &first_child).with_fix(fix))
+        some_vec!(
+            context
+                .create_diagnostic(Self { keywords }, first_child)
+                .with_fix(fix)
+        )
     }
 
     fn entrypoints() -> Vec<&'static str> {
@@ -208,16 +204,13 @@ impl Violation for KeywordHasWhitespace {
 }
 
 impl AstRule for KeywordHasWhitespace {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        if node.kind() == "in" && settings.keyword_whitespace.inout_with_space {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        if node.kind() == "in" && context.settings().keyword_whitespace.inout_with_space {
             return None;
         }
-        if node.kind() == "keyword_statement" && settings.keyword_whitespace.goto_with_space {
+        if node.kind() == "keyword_statement"
+            && context.settings().keyword_whitespace.goto_with_space
+        {
             return None;
         }
         let (first, second, first_child, violation) = if node.kind() == "in" {
@@ -251,21 +244,25 @@ impl AstRule for KeywordHasWhitespace {
             )
         };
         // Verify that the node is 'in' / 'go'
-        if first_child.to_text(src.source_text())?.to_lowercase() != first {
+        if first_child.to_text(context.source_text())?.to_lowercase() != first {
             return None;
         }
         // Check if immediate sibling is 'out'/'to'
         let sibling = first_child.next_sibling()?;
-        if sibling.to_text(src.source_text())?.to_lowercase() == second {
+        if sibling.to_text(context.source_text())?.to_lowercase() == second {
             let start = first_child.start_textsize();
             let end = sibling.end_textsize();
             let fix_start = first_child.end_textsize();
             let fix_end = sibling.start_textsize();
             let fix = Fix::safe_edit(Edit::deletion(fix_start, fix_end));
-            return some_vec!(Diagnostic::new(violation, TextRange::new(start, end)).with_fix(fix));
+            return some_vec!(
+                context
+                    .create_diagnostic(violation, TextRange::new(start, end))
+                    .with_fix(fix)
+            );
         }
         // Can't fix this case, it may contain line continuations, comments, etc.
-        some_vec!(Diagnostic::from_node(violation, &first_child))
+        some_vec!(context.create_diagnostic(violation, first_child))
     }
 
     fn entrypoints() -> Vec<&'static str> {
@@ -370,12 +367,7 @@ impl AlwaysFixableViolation for IncorrectKeywordCase {
 }
 
 impl AstRule for IncorrectKeywordCase {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         if node.child_count() > 0 {
             // Filter node that wrap other nodes, we want only leafs
             return None;
@@ -385,9 +377,10 @@ impl AstRule for IncorrectKeywordCase {
             return None;
         }
 
-        let text = node.to_text(src.source_text())?;
+        let text = node.to_text(context.source_text())?;
 
-        let expected = text.to_capitalisation(settings.incorrect_keyword_case.keyword_case);
+        let expected =
+            text.to_capitalisation(context.settings().incorrect_keyword_case.keyword_case);
         if text == expected {
             return None;
         }
@@ -400,14 +393,15 @@ impl AstRule for IncorrectKeywordCase {
         ));
 
         some_vec!(
-            Diagnostic::from_node(
-                Self {
-                    actual: text.to_string(),
-                    expected
-                },
-                node
-            )
-            .with_fix(fix)
+            context
+                .create_diagnostic(
+                    Self {
+                        actual: text.to_string(),
+                        expected
+                    },
+                    node
+                )
+                .with_fix(fix)
         )
     }
 

--- a/crates/fortitude_linter/src/rules/style/line_length.rs
+++ b/crates/fortitude_linter/src/rules/style/line_length.rs
@@ -1,9 +1,8 @@
 /// Defines rules that govern line length.
+use crate::CheckContext;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::settings::CheckSettings;
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use std::collections::HashSet;
@@ -77,19 +76,16 @@ impl Violation for LineTooLong {
 }
 
 impl LineTooLong {
-    pub fn check(
-        root: &Node,
-        settings: &CheckSettings,
-        source_file: &SourceFile,
-    ) -> Vec<Diagnostic> {
-        let source = source_file.to_source_code();
+    pub fn check(context: &CheckContext, root: &Node) -> Vec<Diagnostic> {
+        let source = context.source_file().to_source_code();
+        let settings = context.settings();
         let limit = settings.line_length;
         let ignore_comments = settings.line_too_long.ignore_comments;
         let mut violations = Vec::new();
 
         let tab_size = settings.invalid_tab.indent_width.as_usize();
 
-        let comment_positions: HashSet<Point> = source_file
+        let comment_positions: HashSet<Point> = context
             .source_text()
             .char_indices()
             .filter(|(index, _)| {
@@ -167,7 +163,7 @@ impl LineTooLong {
                 .map(TextLen::text_len)
                 .sum();
             let range = TextRange::new(line.end() - extra_bytes, line.end());
-            violations.push(Diagnostic::new(
+            violations.push(context.create_diagnostic(
                 Self {
                     max_length: limit,
                     actual_length: width,

--- a/crates/fortitude_linter/src/rules/style/literals.rs
+++ b/crates/fortitude_linter/src/rules/style/literals.rs
@@ -1,12 +1,9 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::TextSize;
 use tree_sitter::Node;
 
@@ -46,13 +43,8 @@ impl AlwaysFixableViolation for BareDecimal {
 }
 
 impl AstRule for BareDecimal {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let txt = node.to_text(src.source_text())?;
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let txt = node.to_text(context.source_text())?;
         // Three cases to match:
         // 1. Leading decimal point, e.g. `.5`
         // 2. Trailing decimal point, e.g. `2.`
@@ -85,15 +77,16 @@ impl AstRule for BareDecimal {
             (preferred, is_trailing, edit)
         };
         some_vec![
-            Diagnostic::from_node(
-                BareDecimal {
-                    literal: txt.to_string(),
-                    preferred,
-                    is_trailing
-                },
-                node
-            )
-            .with_fix(Fix::safe_edit(edit))
+            context
+                .create_diagnostic(
+                    BareDecimal {
+                        literal: txt.to_string(),
+                        preferred,
+                        is_trailing
+                    },
+                    node
+                )
+                .with_fix(Fix::safe_edit(edit))
         ]
     }
 

--- a/crates/fortitude_linter/src/rules/style/semicolons.rs
+++ b/crates/fortitude_linter/src/rules/style/semicolons.rs
@@ -1,14 +1,11 @@
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::TextSize;
 use tree_sitter::Node;
 
-use crate::AstRule;
 use crate::ast::FortitudeNode;
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
+use crate::{AstRule, CheckContext};
 
 fn semicolon_is_superfluous(node: &Node) -> bool {
     let line_number = node.start_position().row;
@@ -76,15 +73,14 @@ impl AlwaysFixableViolation for SuperfluousSemicolon {
 }
 
 impl AstRule for SuperfluousSemicolon {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         if semicolon_is_superfluous(node) {
-            let edit = node.edit_delete(src);
-            return some_vec!(Diagnostic::from_node(Self {}, node).with_fix(Fix::safe_edit(edit)));
+            let edit = node.edit_delete(context.source_file());
+            return some_vec!(
+                context
+                    .create_diagnostic(Self {}, node)
+                    .with_fix(Fix::safe_edit(edit))
+            );
         }
         None
     }
@@ -114,19 +110,14 @@ impl AlwaysFixableViolation for MultipleStatementsPerLine {
 }
 
 impl AstRule for MultipleStatementsPerLine {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         if semicolon_is_superfluous(node) {
             return None;
         }
-        let indentation = node.indentation(src);
+        let indentation = node.indentation(context.source_file());
         let start = node.start_byte();
         let mut end = node.end_byte();
-        let text = src.source_text().as_bytes();
+        let text = context.source_text().as_bytes();
         while text[end] == b' ' || text[end] == b'\t' {
             end += 1;
         }
@@ -136,7 +127,11 @@ impl AstRule for MultipleStatementsPerLine {
             TextSize::try_from(end).unwrap(),
         );
 
-        some_vec!(Diagnostic::from_node(Self {}, node).with_fix(Fix::safe_edit(edit)))
+        some_vec!(
+            context
+                .create_diagnostic(Self {}, node)
+                .with_fix(Fix::safe_edit(edit))
+        )
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/style/strings.rs
+++ b/crates/fortitude_linter/src/rules/style/strings.rs
@@ -3,16 +3,13 @@ use crate::diagnostics::{
 };
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::{TextLen, TextSize};
 use tree_sitter::Node;
 
-use crate::AstRule;
 use crate::ast::FortitudeNode;
-use crate::settings::CheckSettings;
 use crate::stylist::Quote;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 
 /// ## What does it do?
 /// Catches use of single- or double-quoted strings, depending on the value of
@@ -64,16 +61,11 @@ impl Violation for BadQuoteString {
 }
 
 impl AstRule for BadQuoteString {
-    fn check(
-        settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let preferred_quote: Quote = settings.strings.quotes.into();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let preferred_quote: Quote = context.settings().strings.quotes.into();
         let bad_quote = preferred_quote.opposite();
 
-        let text = node.to_text(src.source_text())?;
+        let text = node.to_text(context.source_text())?;
         if text.starts_with(bad_quote.as_char())
             && text.ends_with(bad_quote.as_char())
             && !text.contains(preferred_quote.as_char())
@@ -81,7 +73,7 @@ impl AstRule for BadQuoteString {
             // Search for occurrence of escaped single quotes within the string.
             // These are double single quotes, e.g. "''"
             if text.contains(bad_quote.escaped()) && text.len() > 2 {
-                return Some(vec![Diagnostic::from_node(
+                return Some(vec![context.create_diagnostic(
                     Self {
                         preferred_quote,
                         contains_escaped_quotes: true,
@@ -103,14 +95,15 @@ impl AstRule for BadQuoteString {
                 end_byte,
             );
             return some_vec!(
-                Diagnostic::from_node(
-                    Self {
-                        preferred_quote,
-                        contains_escaped_quotes: false,
-                    },
-                    node,
-                )
-                .with_fix(Fix::safe_edits(edit_start, [edit_end]))
+                context
+                    .create_diagnostic(
+                        Self {
+                            preferred_quote,
+                            contains_escaped_quotes: false,
+                        },
+                        node,
+                    )
+                    .with_fix(Fix::safe_edits(edit_start, [edit_end]))
             );
         }
         None
@@ -153,13 +146,8 @@ impl AlwaysFixableViolation for AvoidableEscapedQuote {
 }
 
 impl AstRule for AvoidableEscapedQuote {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let text = node.to_text(src.source_text())?;
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let text = node.to_text(context.source_text())?;
         if text.len() <= 2 {
             return None;
         }
@@ -173,7 +161,7 @@ impl AstRule for AvoidableEscapedQuote {
         // Because the kind appears as a child node, the interesting
         // literal bit doesn't start at the beginning of the node
         let (start, kind) = if let Some(kind) = node.child_by_field_name("kind") {
-            let kind_text = kind.to_text(src.source_text())?;
+            let kind_text = kind.to_text(context.source_text())?;
             (kind_text.len() + 1, format!("{kind_text}_"))
         } else {
             (0, "".to_string())
@@ -187,12 +175,16 @@ impl AstRule for AvoidableEscapedQuote {
             value = unescape_string(contents, quote_style.as_char())
         );
 
-        let edit = node.edit_replacement(src, fixed);
+        let edit = node.edit_replacement(context.source_file(), fixed);
         // Offset start of node by kind, if any
         let range = node
             .textrange()
             .add_start(TextSize::try_from(start).unwrap());
-        some_vec!(Diagnostic::new(Self, range).with_fix(Fix::safe_edit(edit)))
+        some_vec!(
+            context
+                .create_diagnostic(Self, range)
+                .with_fix(Fix::safe_edit(edit))
+        )
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -1,10 +1,8 @@
-use crate::AstRule;
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic};
 use crate::diagnostics::{Edit, Fix};
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_source_file::{LineRanges, SourceFile};
@@ -50,16 +48,11 @@ impl AlwaysFixableViolation for UnsortedUses {
 }
 
 impl AstRule for UnsortedUses {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let use_statements: Vec<UseStatementData> = node
             .children(&mut node.walk())
             .filter(|child| child.kind() == "use_statement")
-            .map(|child| extract_use_statement_data(&child, src))
+            .map(|child| extract_use_statement_data(&child, context.source_file()))
             .collect();
 
         if use_statements.len() <= 1 {
@@ -87,12 +80,9 @@ impl AstRule for UnsortedUses {
                 continue;
             }
 
-            let block_start = src
-                .source_text()
-                .line_start(block.first()?.text_range.start());
-            let block_end = src
-                .source_text()
-                .full_line_end(block.last()?.text_range.end());
+            let text = context.source_text();
+            let block_start = text.line_start(block.first()?.text_range.start());
+            let block_end = text.full_line_end(block.last()?.text_range.end());
 
             let replacement = sorted.iter().map(|s| s.text.as_str()).collect::<String>();
             let edit = Edit::range_replacement(replacement, TextRange::new(block_start, block_end));
@@ -101,7 +91,9 @@ impl AstRule for UnsortedUses {
             let first = block.first()?;
             let last = block.last()?;
             let range = TextRange::new(first.start_textsize(), last.end_textsize());
-            let diag = Diagnostic::new(UnsortedUses {}, range).with_fix(fix);
+            let diag = context
+                .create_diagnostic(UnsortedUses {}, range)
+                .with_fix(fix);
             diagnostics.push(diag);
         }
 

--- a/crates/fortitude_linter/src/rules/style/useless_return.rs
+++ b/crates/fortitude_linter/src/rules/style/useless_return.rs
@@ -4,10 +4,10 @@ use crate::diagnostics::{
 };
 use crate::fix::edits::redent;
 use crate::settings::CheckSettings;
-use crate::stylist::{Stylist, ToCapitalisation};
+use crate::stylist::ToCapitalisation;
 use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
-use crate::{AstRule, Rule};
+use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use log::debug;
 use ruff_macros::derive_message_formats;
@@ -313,11 +313,11 @@ impl Violation for SuperfluousElseStop {
 }
 
 pub(crate) fn check_superfluous_returns<'a>(
-    settings: &CheckSettings,
+    context: &'a CheckContext,
     node: &'a Node,
-    src: &'a SourceFile,
 ) -> Option<Diagnostic> {
-    let text = node.child(0)?.to_text(src.source_text())?;
+    let src = context.source_text();
+    let text = node.child(0)?.to_text(src)?;
     let kind = BlockExit::try_from(text).ok()?;
 
     // Skip this node if it's inside an inline IF, because the rule does not apply
@@ -333,36 +333,23 @@ pub(crate) fn check_superfluous_returns<'a>(
     .to_string();
 
     let mut diagnostic = match kind {
-        BlockExit::Return => Diagnostic::from_node_if_rule_enabled(
-            settings,
-            Rule::SuperfluousElseReturn,
-            SuperfluousElseReturn { branch },
-            node,
-        ),
-        BlockExit::Cycle => Diagnostic::from_node_if_rule_enabled(
-            settings,
-            Rule::SuperfluousElseCycle,
-            SuperfluousElseCycle { branch },
-            node,
-        ),
-        BlockExit::Exit => Diagnostic::from_node_if_rule_enabled(
-            settings,
-            Rule::SuperfluousElseExit,
-            SuperfluousElseExit { branch },
-            node,
-        ),
-        BlockExit::Stop => Diagnostic::from_node_if_rule_enabled(
-            settings,
-            Rule::SuperfluousElseStop,
+        BlockExit::Return => {
+            context.create_diagnostic_if_enabled(SuperfluousElseReturn { branch }, node)
+        }
+        BlockExit::Cycle => {
+            context.create_diagnostic_if_enabled(SuperfluousElseCycle { branch }, node)
+        }
+        BlockExit::Exit => {
+            context.create_diagnostic_if_enabled(SuperfluousElseExit { branch }, node)
+        }
+        BlockExit::Stop => context.create_diagnostic_if_enabled(
             SuperfluousElseStop {
                 branch,
                 stop: "stop".to_string(),
             },
             node,
         ),
-        BlockExit::Error => Diagnostic::from_node_if_rule_enabled(
-            settings,
-            Rule::SuperfluousElseStop,
+        BlockExit::Error => context.create_diagnostic_if_enabled(
             SuperfluousElseStop {
                 branch,
                 stop: "error stop".to_string(),
@@ -372,7 +359,7 @@ pub(crate) fn check_superfluous_returns<'a>(
     };
 
     if let Some(ref mut diagnostic) = diagnostic
-        && let Some(fix) = fix_superfluous_return(&sibling, src)
+        && let Some(fix) = fix_superfluous_return(context, &sibling)
     {
         diagnostic.set_fix(fix);
     }
@@ -380,9 +367,9 @@ pub(crate) fn check_superfluous_returns<'a>(
     diagnostic
 }
 
-fn fix_superfluous_return<'a>(branch: &'a Node, src: &'a SourceFile) -> Option<Fix> {
-    // TODO(peter): use passed-in stylist
-    let stylist = Stylist::from_ast(branch, src);
+fn fix_superfluous_return<'a>(context: &'a CheckContext, branch: &'a Node) -> Option<Fix> {
+    let src = context.source_file();
+    let stylist = context.stylist();
 
     let parent_if = branch.parent()?;
     if let Some(block_label) = parent_if.child_with_name("block_label_start_expression") {

--- a/crates/fortitude_linter/src/rules/style/useless_return.rs
+++ b/crates/fortitude_linter/src/rules/style/useless_return.rs
@@ -3,15 +3,12 @@ use crate::diagnostics::{
     AlwaysFixableViolation, Diagnostic, Edit, Fix, FixAvailability, Violation,
 };
 use crate::fix::edits::redent;
-use crate::settings::CheckSettings;
 use crate::stylist::ToCapitalisation;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
 use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use log::debug;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 use tree_sitter::Node;
 
@@ -63,14 +60,10 @@ impl AlwaysFixableViolation for UselessReturn {
 }
 
 impl AstRule for UselessReturn {
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let _ = context;
         if !node
-            .to_text(src.source_text())?
+            .to_text(context.source_text())?
             .eq_ignore_ascii_case("return")
         {
             return None;
@@ -82,8 +75,12 @@ impl AstRule for UselessReturn {
         ) {
             return None;
         }
-        let edit = node.edit_delete(src);
-        some_vec!(Diagnostic::from_node(Self, node).with_fix(Fix::safe_edit(edit)))
+        let edit = node.edit_delete(context.source_file());
+        some_vec!(
+            context
+                .create_diagnostic(Self, node)
+                .with_fix(Fix::safe_edit(edit))
+        )
     }
 
     fn entrypoints() -> Vec<&'static str> {

--- a/crates/fortitude_linter/src/rules/style/whitespace.rs
+++ b/crates/fortitude_linter/src/rules/style/whitespace.rs
@@ -2,15 +2,13 @@
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
-use ruff_source_file::{SourceFile, UniversalNewlines};
+use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use tree_sitter::Node;
 
-use crate::AstRule;
 use crate::ast::FortitudeNode;
-use crate::settings::CheckSettings;
-use crate::symbol_table::SymbolTables;
 use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext};
 
 /// ## What does it do?
 /// Checks for trailing whitespace.
@@ -34,10 +32,9 @@ impl AlwaysFixableViolation for TrailingWhitespace {
 }
 
 impl TrailingWhitespace {
-    pub fn check(source_file: &SourceFile) -> Vec<Diagnostic> {
-        let source = source_file.to_source_code();
+    pub fn check(context: &CheckContext) -> Vec<Diagnostic> {
         let mut violations = Vec::new();
-        for line in source.text().universal_newlines() {
+        for line in context.source_text().universal_newlines() {
             let whitespace_bytes: TextSize = line
                 .chars()
                 .rev()
@@ -47,7 +44,11 @@ impl TrailingWhitespace {
             if whitespace_bytes > 0.into() {
                 let range = TextRange::new(line.end() - whitespace_bytes, line.end());
                 let edit = Edit::range_deletion(range);
-                violations.push(Diagnostic::new(Self {}, range).with_fix(Fix::safe_edit(edit)));
+                violations.push(
+                    context
+                        .create_diagnostic(Self {}, range)
+                        .with_fix(Fix::safe_edit(edit)),
+                );
             }
         }
         violations
@@ -77,9 +78,8 @@ impl AlwaysFixableViolation for MissingNewlineAtEndOfFile {
 }
 
 impl MissingNewlineAtEndOfFile {
-    pub fn check(source_file: &SourceFile) -> Option<Diagnostic> {
-        let source = source_file.to_source_code();
-        let text = source.text();
+    pub fn check(context: &CheckContext) -> Option<Diagnostic> {
+        let text = context.source_text();
 
         // Ignore empty and BOM only files.
         if text.is_empty() || text == "\u{feff}" {
@@ -98,7 +98,9 @@ impl MissingNewlineAtEndOfFile {
             };
             let range = TextRange::empty(text.text_len());
             let edit = Edit::insertion(newline.to_string(), range.start());
-            let diagnostic = Diagnostic::new(Self {}, range).with_fix(Fix::safe_edit(edit));
+            let diagnostic = context
+                .create_diagnostic(Self {}, range)
+                .with_fix(Fix::safe_edit(edit));
             Some(diagnostic)
         } else {
             None
@@ -131,13 +133,8 @@ impl AlwaysFixableViolation for IncorrectSpaceBeforeComment {
     }
 }
 impl AstRule for IncorrectSpaceBeforeComment {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let source = src.to_source_code();
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let source = context.source_file().to_source_code();
         let comment_start = node.start_textsize();
         // Get the line up to the start of the comment
         let line_index = source.line_index(comment_start);
@@ -159,7 +156,11 @@ impl AstRule for IncorrectSpaceBeforeComment {
                 .unwrap();
 
             let span = TextRange::new(span_start, comment_start);
-            return some_vec!(Diagnostic::new(Self {}, span).with_fix(Fix::safe_edit(edit)));
+            return some_vec!(
+                context
+                    .create_diagnostic(Self {}, span)
+                    .with_fix(Fix::safe_edit(edit))
+            );
         }
         None
     }
@@ -195,16 +196,11 @@ impl AlwaysFixableViolation for IncorrectSpaceAroundDoubleColon {
     }
 }
 impl AstRule for IncorrectSpaceAroundDoubleColon {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let double_colon_start = node.start_byte();
         let double_colon_end = node.end_byte();
 
-        let bytes = src.source_text().as_bytes();
+        let bytes = context.source_text().as_bytes();
         let has_space_before =
             double_colon_start > 0 && bytes[double_colon_start - 1].is_ascii_whitespace();
         let has_space_after =
@@ -215,16 +211,21 @@ impl AstRule for IncorrectSpaceAroundDoubleColon {
         if !has_space_before {
             if !has_space_after {
                 return some_vec!(
-                    Diagnostic::from_node(Self {}, node)
+                    context
+                        .create_diagnostic(Self {}, node)
                         .with_fix(Fix::safe_edits(before_edit, [after_edit]))
                 );
             }
             return some_vec!(
-                Diagnostic::from_node(Self {}, node).with_fix(Fix::safe_edit(before_edit))
+                context
+                    .create_diagnostic(Self {}, node)
+                    .with_fix(Fix::safe_edit(before_edit))
             );
         } else if !has_space_after {
             return some_vec!(
-                Diagnostic::from_node(Self {}, node).with_fix(Fix::safe_edit(after_edit))
+                context
+                    .create_diagnostic(Self {}, node)
+                    .with_fix(Fix::safe_edit(after_edit))
             );
         }
         None
@@ -262,15 +263,10 @@ impl AlwaysFixableViolation for IncorrectSpaceBetweenBrackets {
     }
 }
 impl AstRule for IncorrectSpaceBetweenBrackets {
-    fn check(
-        _settings: &CheckSettings,
-        node: &Node,
-        src: &SourceFile,
-        _symbol_table: &SymbolTables,
-    ) -> Option<Vec<Diagnostic>> {
-        let node_as_str = node.to_text(src.source_text())?;
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        let node_as_str = node.to_text(context.source_text())?;
 
-        let source = src.to_source_code();
+        let source = context.source_file().to_source_code();
         let bracket_start = node.start_textsize();
         let bracket_end = node.end_textsize();
         let line_index = source.line_index(bracket_end);
@@ -324,7 +320,8 @@ impl AstRule for IncorrectSpaceBetweenBrackets {
         }
 
         some_vec!(
-            Diagnostic::new(Self { is_open_bracket }, whitespace_range)
+            context
+                .create_diagnostic(Self { is_open_bracket }, whitespace_range)
                 .with_fix(Fix::safe_edit(Edit::range_deletion(whitespace_range)))
         )
     }

--- a/crates/fortitude_linter/src/traits.rs
+++ b/crates/fortitude_linter/src/traits.rs
@@ -15,6 +15,12 @@ where
     }
 }
 
+impl<'a> HasNode<'a> for &'a Node<'a> {
+    fn node(&self) -> &Node<'a> {
+        self
+    }
+}
+
 #[macro_export]
 macro_rules! impl_has_node {
     ($ty: ty) => {
@@ -67,5 +73,13 @@ impl<'a> TextRanged for Node<'a> {
     #[inline]
     fn textrange(&self) -> TextRange {
         TextRange::new(self.start_textsize(), self.end_textsize())
+    }
+}
+
+impl TextRanged for TextRange {
+    // This makes a copy, do we really want to do this?
+    #[inline]
+    fn textrange(&self) -> TextRange {
+        *self
     }
 }

--- a/crates/fortitude_macros/src/map_codes.rs
+++ b/crates/fortitude_macros/src/map_codes.rs
@@ -467,7 +467,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
             });
 
             ast_rule_check_match_arms.extend(quote! {
-                #(#attrs)* Self::#name => #path::check(settings, node, source, symbol_table),
+                #(#attrs)* Self::#name => #path::check(context, node),
             });
 
             ast_rule_entrypoint_match_arms.extend(quote! {
@@ -480,10 +480,8 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
         use std::path::Path;
         use ruff_source_file::SourceFile;
         use tree_sitter::Node;
-        use crate::AstRule;
+        use crate::{AstRule, CheckContext};
         use crate::diagnostics::{Diagnostic, Violation};
-        use crate::settings::CheckSettings;
-        use crate::symbol_table::SymbolTables;
 
         #[derive(
             Debug,
@@ -563,7 +561,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
         }
 
         impl AstRuleEnum {
-            pub fn check(&self, settings: &CheckSettings, node: &Node, source: &SourceFile, symbol_table: &SymbolTables) -> Option<Vec<Diagnostic>> {
+            pub fn check(&self, context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
                 match self {
                     #ast_rule_check_match_arms
                 }

--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -78,8 +78,7 @@ def main(*, name: str, prefix: str, code: str, category: str) -> None:
         fp.write(
             f"""\
 use crate::ast::FortitudeNode;
-use crate::settings::CheckSettings;
-use crate::{{AstRule, SymbolTables}};
+use crate::{{AstRule, CheckContext}};
 use crate::diagnostics::{{Diagnostic, Edit, Fix, FixAvailability, Violation}};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
@@ -109,12 +108,7 @@ impl Violation for {name} {{
 }}
 
 impl AstRule for {name} {{
-    fn check<'a>(
-        _settings: &CheckSettings,
-        node: &'a Node,
-        src: &'a SourceFile,
-        _symbol_table: &SymbolTables
-    ) -> Option<Vec<Diagnostic>> {{
+    fn check<'a>(context: &CheckContext, node: &'a Node) -> Option<Vec<Diagnostic>> {{
         None
     }}
 


### PR DESCRIPTION
`CheckContext` bundles up a bunch of things that we might want to use in `check` functions:

- `SourceFile`
- `Stylist`
- `Settings`
- `SymbolTable`

and provides a `.create_diagnostic()` method. At the moment this isn't super useful, but when changing `Diagnostics` to allow multiple annotations, creating a "normal" diagnostic will be a bit more complicated, and this will wrap that complexity up and keep the call sites clean.

We also now have `Stylist` available in every rule, so we can start modifying fixes to make them match the local formatting.