### PR TITLE
Allow long lines for pFUnit directives

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/style/S001_line_length_pfunit_ok.pf
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S001_line_length_pfunit_ok.pf
@@ -1,0 +1,17 @@
+module pfunit_long_line
+    ! allow(C121)
+    use funit
+    implicit none (type, external)
+    private
+
+contains
+    @Test
+    subroutine simple_test_with_long_line_assertion()
+        integer :: long_name_for_first_variable, long_name_for_second_variable
+
+        long_name_for_first_variable = 1
+        long_name_for_second_variable = 1
+
+        @assertEqual(long_name_for_first_variable, long_name_for_second_variable, message="I cannot wrap lines within a pFUnit directive")
+    end subroutine simple_test_with_long_line_assertion
+end module pfunit_long_line

--- a/crates/fortitude_linter/src/rules/style/line_length.rs
+++ b/crates/fortitude_linter/src/rules/style/line_length.rs
@@ -34,6 +34,8 @@ use tree_sitter::Point;
 /// 3. Ignores SPDX license identifiers and copyright notices (for example, `!
 ///    SPDX-License-Identifier: MIT`), which are machine-readable and should
 ///    _not_ wrap over multiple lines.
+/// 4. Ignores pFUnit test directives, as these must be defined on a single
+///    line.
 ///
 /// Note that the Fortran standard states a maximum line length of 132
 /// characters[^1], and while most modern compilers will support longer lines[^2],
@@ -134,6 +136,12 @@ impl LineTooLong {
                 (first_chunk, second_chunk),
                 ("!", "SPDX-License-Identifier:" | "SPDX-FileCopyrightText:")
             ) {
+                continue;
+            }
+
+            // Do not enforce the line length limit for pFUnit test directives,
+            // which must be defined on a single line.
+            if first_chunk.starts_with("@") {
                 continue;
             }
 

--- a/crates/fortitude_linter/src/rules/style/mod.rs
+++ b/crates/fortitude_linter/src/rules/style/mod.rs
@@ -70,6 +70,7 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Rule::LineTooLong, Path::new("S001_line_length_pfunit_ok.pf"))]
     #[test_case(Rule::SuperfluousImplicitNone, Path::new("S201_ok.f90"))]
     #[test_case(Rule::UnsortedUses, Path::new("S271_ok.f90"))]
     fn rules_pass(rule_code: Rule, path: &Path) -> Result<()> {

--- a/docs/rules/line-too-long.md
+++ b/docs/rules/line-too-long.md
@@ -26,6 +26,8 @@ determining whether a line is overlong. Namely, it:
 3. Ignores SPDX license identifiers and copyright notices (for example, `!
    SPDX-License-Identifier: MIT`), which are machine-readable and should
    _not_ wrap over multiple lines.
+4. Ignores pFUnit test directives, as these must be defined on a single
+   line.
 
 Note that the Fortran standard states a maximum line length of 132
 characters[^1], and while most modern compilers will support longer lines[^2],


### PR DESCRIPTION
Closes https://github.com/PlasmaFAIR/fortitude/issues/646

I'm not sure how robust it is to allow any line that starts with `@` as its first non-whitespace character. If it's possible to have comments after pFUnit directives, then we might need to catch the edge case in which the directive finishes before the line limit, but the following comment goes over it. @connoraird Is that likely to cause issues?