### PR TITLE
Document fixed-form Fortran support status

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,6 +173,11 @@ including `.f90`, `.F90`, `.f95`. You can change the default selection using the
 
 !!! info "Introduced in Fortitude 0.8.0"
 
+Fortitude currently supports free-form Fortran source. Fixed-form source files
+such as `.f`, `.for`, or `.ftn` are not included by default, and adding them to
+`include` will not make Fortitude parse them as fixed-form source. See the
+[FAQ](faq.md#does-fortitude-handle-fixed-form-fortran) for details.
+
 ## Command-line interface
 
 Some settings can be given or overidden explicitly on the command line, particularly those

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,6 +13,17 @@ However, tree-sitter is fairly error tolerant, and `fortitude` should
 still run fine, you might just get spurious syntax errors. You can
 ignore these project wide with `--ignore=E001`.
 
+## Does fortitude handle fixed-form Fortran?
+
+Not currently. Fortitude's parser and rules are intended for free-form
+Fortran source. Fixed-form source files, such as files commonly using
+`.f`, `.for`, or `.ftn` extensions, are not included in Fortitude's
+default file discovery patterns.
+
+You can pass fixed-form files explicitly or add their extensions to the
+[`include`](settings.md#include) setting, but Fortitude will still parse
+them as free-form source. This may produce syntax errors or misleading
+diagnostics, so fixed-form projects are not supported yet.
 
 ## What is "preview"?
 


### PR DESCRIPTION
## Summary

- Add an FAQ entry clarifying that Fortitude currently targets free-form Fortran source.
- Note that fixed-form files such as `.f`, `.for`, and `.ftn` are not included by default.
- Clarify that adding fixed-form extensions to `include` does not make Fortitude parse them as fixed-form source.

Fixes #500.

## Verification

- git diff --check