### PR TITLE
Add options to set manually (no-)exit-zero on specific rules)

### DIFF
--- a/crates/fortitude/src/check.rs
+++ b/crates/fortitude/src/check.rs
@@ -202,6 +202,7 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
         unsafe_fixes,
         show_fixes,
         output_format,
+        ref non_zero_on,
         ..
     } = file_configuration.settings.check;
 
@@ -273,11 +274,20 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
     }
 
     let diagnostics = results.diagnostics;
+    let has_blocking_diagnostics = diagnostics
+        .messages
+        .iter()
+        .any(|message| non_zero_on.contains(message.rule()));
+    let has_blocking_fixes = diagnostics
+        .fixed
+        .values()
+        .any(|fix_table| fix_table.keys().any(|rule| non_zero_on.contains(*rule)));
+
     if !cli.exit_zero {
         if fix_only {
             // If we're only fixing, we want to exit zero (since we've fixed all fixable
             // violations), unless we're explicitly asked to exit non-zero on fix.
-            if cli.exit_non_zero_on_fix && !diagnostics.fixed.is_empty() {
+            if cli.exit_non_zero_on_fix && has_blocking_fixes {
                 return Ok(ExitCode::FAILURE);
             }
         } else {
@@ -285,10 +295,10 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
             // there are any violations, unless we're explicitly asked to exit zero on
             // fix.
             if cli.exit_non_zero_on_fix {
-                if !diagnostics.fixed.is_empty() || !diagnostics.messages.is_empty() {
+                if has_blocking_fixes || has_blocking_diagnostics {
                     return Ok(ExitCode::FAILURE);
                 }
-            } else if !diagnostics.messages.is_empty() {
+            } else if has_blocking_diagnostics {
                 return Ok(ExitCode::FAILURE);
             }
         }

--- a/crates/fortitude/src/cli.rs
+++ b/crates/fortitude/src/cli.rs
@@ -413,11 +413,41 @@ pub struct CheckCommand {
         short,
         long,
         help_heading = "Miscellaneous",
+        conflicts_with = "exit_zero_on",
+        conflicts_with = "exit_non_zero_on",
         conflicts_with = "exit_non_zero_on_fix",
         conflicts_with = "statistics"
     )]
     pub exit_zero: bool,
-    /// Exit with a non-zero status code if any files were modified via fix, even if no lint violations remain.
+
+    /// Rule codes or prefixes whose violations should not cause a non-zero exit status.
+    ///
+    /// Diagnostics are still shown normally. More-specific selectors passed to
+    /// `--exit-non-zero-on` override broader matches here.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        value_parser = RuleSelectorParser,
+        help_heading = "Miscellaneous",
+        hide_possible_values = true
+    )]
+    pub exit_zero_on: Option<Vec<RuleSelector>>,
+
+    /// Rule codes or prefixes whose violations should still cause a non-zero
+    /// exit status, even if they were matched by `--exit-zero-on`.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        value_parser = RuleSelectorParser,
+        help_heading = "Miscellaneous",
+        hide_possible_values = true
+    )]
+    pub exit_non_zero_on: Option<Vec<RuleSelector>>,
+
+    /// Exit with a non-zero status code if any files were modified via fix,
+    /// even if no blocking lint violations remain.
     #[arg(
         long,
         help_heading = "Miscellaneous",
@@ -535,6 +565,8 @@ impl CheckCommand {
             select: self.select,
             ignore: self.ignore,
             extend_select: self.extend_select,
+            exit_zero_on: self.exit_zero_on,
+            exit_non_zero_on: self.exit_non_zero_on,
             fixable: self.fixable,
             unfixable: self.unfixable,
             extend_fixable: self.extend_fixable,
@@ -568,6 +600,8 @@ struct ExplicitConfigOverrides {
     select: Option<Vec<RuleSelector>>,
     extend_select: Option<Vec<RuleSelector>>,
     ignore: Option<Vec<RuleSelector>>,
+    exit_zero_on: Option<Vec<RuleSelector>>,
+    exit_non_zero_on: Option<Vec<RuleSelector>>,
     fixable: Option<Vec<RuleSelector>>,
     unfixable: Option<Vec<RuleSelector>>,
     extend_fixable: Option<Vec<RuleSelector>>,
@@ -638,6 +672,12 @@ impl ConfigurationTransformer for ExplicitConfigOverrides {
         }
         if let Some(ignore) = &self.ignore {
             config.ignore.extend(ignore.clone());
+        }
+        if let Some(exit_zero_on) = &self.exit_zero_on {
+            config.exit_zero_on = exit_zero_on.clone();
+        }
+        if let Some(exit_non_zero_on) = &self.exit_non_zero_on {
+            config.exit_non_zero_on = exit_non_zero_on.clone();
         }
         if let Some(fixable) = &self.fixable {
             config.fixable = Some(fixable.clone());

--- a/crates/fortitude/tests/check.rs
+++ b/crates/fortitude/tests/check.rs
@@ -613,6 +613,176 @@ select = ["C001", "style"]
 }
 
 #[test]
+fn check_exit_zero_on_cli() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f90");
+    fs::write(
+        &test_file,
+        r#"
+program test
+  logical*4, parameter :: true = .true.
+end program
+"#,
+    )?;
+
+    apply_common_filters!();
+    assert_cmd_snapshot!(FortitudeCheck::default()
+                         .file(&test_file)
+                         .args(["--select=C001,S061", "--exit-zero-on=ALL"]).build(),
+                         @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_FILE] C001 program uses implicit typing
+      |
+    2 | program test
+      | ^^^^^^^^^^^^ C001
+    3 |   logical*4, parameter :: true = .true.
+    4 | end program
+      |
+      = help: Insert `implicit none`
+
+    [TEMP_FILE] S061 [*] end statement should be named.
+      |
+    2 | program test
+    3 |   logical*4, parameter :: true = .true.
+    4 | end program
+      | ^^^^^^^^^^^ S061
+      |
+      = help: Write as 'end program test'.
+
+    fortitude: 1 files scanned.
+    Number of errors: 2
+
+    For more information about specific rules, run:
+
+        fortitude explain X001,Y002,...
+
+    [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
+#[test]
+fn check_exit_non_zero_on_cli() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f90");
+    fs::write(
+        &test_file,
+        r#"
+program test
+  logical*4, parameter :: true = .true.
+end program
+"#,
+    )?;
+
+    apply_common_filters!();
+    assert_cmd_snapshot!(FortitudeCheck::default()
+                         .file(&test_file)
+                         .args(["--select=C001,S061", "--exit-zero-on=ALL", "--exit-non-zero-on=S061"]).build(),
+                         @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    [TEMP_FILE] C001 program uses implicit typing
+      |
+    2 | program test
+      | ^^^^^^^^^^^^ C001
+    3 |   logical*4, parameter :: true = .true.
+    4 | end program
+      |
+      = help: Insert `implicit none`
+
+    [TEMP_FILE] S061 [*] end statement should be named.
+      |
+    2 | program test
+    3 |   logical*4, parameter :: true = .true.
+    4 | end program
+      | ^^^^^^^^^^^ S061
+      |
+      = help: Write as 'end program test'.
+
+    fortitude: 1 files scanned.
+    Number of errors: 2
+
+    For more information about specific rules, run:
+
+        fortitude explain X001,Y002,...
+
+    [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
+#[test]
+fn check_exit_non_zero_on_file() -> anyhow::Result<()> {
+    let tempdir = TempDir::new()?;
+    let test_file = tempdir.path().join("test.f90");
+    fs::write(
+        &test_file,
+        r#"
+program test
+  logical*4, parameter :: true = .true.
+end program
+"#,
+    )?;
+
+    let config_file = tempdir.path().join("fortitude.toml");
+    fs::write(
+        &config_file,
+        r#"
+[check]
+select = ["C001", "S061"]
+exit-zero-on = ["ALL"]
+exit-non-zero-on = ["S061"]
+"#,
+    )?;
+
+    apply_common_filters!();
+    assert_cmd_snapshot!(FortitudeCheck::default()
+                         .config(&config_file)
+                         .file(&test_file).build(),
+                         @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    [TEMP_FILE] C001 program uses implicit typing
+      |
+    2 | program test
+      | ^^^^^^^^^^^^ C001
+    3 |   logical*4, parameter :: true = .true.
+    4 | end program
+      |
+      = help: Insert `implicit none`
+
+    [TEMP_FILE] S061 [*] end statement should be named.
+      |
+    2 | program test
+    3 |   logical*4, parameter :: true = .true.
+    4 | end program
+      | ^^^^^^^^^^^ S061
+      |
+      = help: Write as 'end program test'.
+
+    fortitude: 1 files scanned.
+    Number of errors: 2
+
+    For more information about specific rules, run:
+
+        fortitude explain X001,Y002,...
+
+    [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
+#[test]
 fn apply_fixes() -> anyhow::Result<()> {
     let tempdir = TempDir::new()?;
     let test_file = tempdir.path().join("test.f90");
@@ -1339,9 +1509,9 @@ program test
   write (*, '("╔════════════════════════════════════════════╗")')
   write (*, '("║  UTF-8 LOGO BOX                            ║")')
   write (*, '("╚════════════════════════════════════════════╝")')
-  !-- transform into g/cm³   
+  !-- transform into g/cm³
   dens = dens * ( 0.001d0 / (1.0d-30*bohr**3.0d0))
-  !-- transform³ into³ g/cm³   
+  !-- transform³ into³ g/cm³
   dens = dens * ( 0.001d0 / (1.0d-30*bohr**3.0d0))
 end program test
 "#,
@@ -1390,7 +1560,7 @@ end program test
     7 |   write (*, '("║  UTF-8 LOGO BOX                            ║")')
       |                                                             ^^^^^ S001
     8 |   write (*, '("╚════════════════════════════════════════════╝")')
-    9 |   !-- transform into g/cm³   
+    9 |   !-- transform into g/cm³
       |
 
     [TEMP_FILE] S001 line length of 65, exceeds maximum 60
@@ -1399,7 +1569,7 @@ end program test
      7 |   write (*, '("║  UTF-8 LOGO BOX                            ║")')
      8 |   write (*, '("╚════════════════════════════════════════════╝")')
        |                                                             ^^^^^ S001
-     9 |   !-- transform into g/cm³   
+     9 |   !-- transform into g/cm³
     10 |   dens = dens * ( 0.001d0 / (1.0d-30*bohr**3.0d0))
        |
 
@@ -1407,18 +1577,18 @@ end program test
        |
      7 |   write (*, '("║  UTF-8 LOGO BOX                            ║")')
      8 |   write (*, '("╚════════════════════════════════════════════╝")')
-     9 |   !-- transform into g/cm³   
+     9 |   !-- transform into g/cm³
        |                           ^^^ S101
     10 |   dens = dens * ( 0.001d0 / (1.0d-30*bohr**3.0d0))
-    11 |   !-- transform³ into³ g/cm³   
+    11 |   !-- transform³ into³ g/cm³
        |
        = help: Remove trailing whitespace
 
     [TEMP_FILE] S101 [*] trailing whitespace
        |
-     9 |   !-- transform into g/cm³   
+     9 |   !-- transform into g/cm³
     10 |   dens = dens * ( 0.001d0 / (1.0d-30*bohr**3.0d0))
-    11 |   !-- transform³ into³ g/cm³   
+    11 |   !-- transform³ into³ g/cm³
        |                             ^^^ S101
     12 |   dens = dens * ( 0.001d0 / (1.0d-30*bohr**3.0d0))
     13 | end program test
@@ -1935,7 +2105,7 @@ program test
   ! allow(star-kind)
   logical*4, parameter :: true = .true.
   ! allow(trailing-whitespace)
-  logical*4, parameter :: false = .false.  
+  logical*4, parameter :: false = .false.
 end program
 "#,
     )?;
@@ -1952,7 +2122,7 @@ end program
       |
     5 |   logical*4, parameter :: true = .true.
     6 |   ! allow(trailing-whitespace)
-    7 |   logical*4, parameter :: false = .false.  
+    7 |   logical*4, parameter :: false = .false.
       |          ^^ PORT021
     8 | end program
       |
@@ -1985,7 +2155,7 @@ program test
   ! allow(star-kind)
   logical*4, parameter :: true = .true.
   ! allow(trailing-whitespace)
-  logical*4, parameter :: false = .false.  
+  logical*4, parameter :: false = .false.
 end program
 "#,
     )?;
@@ -2016,7 +2186,7 @@ end program
     5 |   logical*4, parameter :: true = .true.
       |          ^^ PORT021
     6 |   ! allow(trailing-whitespace)
-    7 |   logical*4, parameter :: false = .false.  
+    7 |   logical*4, parameter :: false = .false.
       |
       = help: Replace with 'logical(4)'
 
@@ -2027,7 +2197,7 @@ end program
     5 |   logical*4, parameter :: true = .true.
       |           ^ PORT011
     6 |   ! allow(trailing-whitespace)
-    7 |   logical*4, parameter :: false = .false.  
+    7 |   logical*4, parameter :: false = .false.
       |
       = help: Use the parameter 'int32' from 'iso_fortran_env'
 
@@ -2035,7 +2205,7 @@ end program
       |
     5 |   logical*4, parameter :: true = .true.
     6 |   ! allow(trailing-whitespace)
-    7 |   logical*4, parameter :: false = .false.  
+    7 |   logical*4, parameter :: false = .false.
       |          ^^ PORT021
     8 | end program
       |
@@ -2045,7 +2215,7 @@ end program
       |
     5 |   logical*4, parameter :: true = .true.
     6 |   ! allow(trailing-whitespace)
-    7 |   logical*4, parameter :: false = .false.  
+    7 |   logical*4, parameter :: false = .false.
       |           ^ PORT011
     8 | end program
       |
@@ -2055,7 +2225,7 @@ end program
       |
     5 |   logical*4, parameter :: true = .true.
     6 |   ! allow(trailing-whitespace)
-    7 |   logical*4, parameter :: false = .false.  
+    7 |   logical*4, parameter :: false = .false.
       |                                          ^^ S101
     8 | end program
       |
@@ -2064,7 +2234,7 @@ end program
     [TEMP_FILE] S061 [*] end statement should be named.
       |
     6 |   ! allow(trailing-whitespace)
-    7 |   logical*4, parameter :: false = .false.  
+    7 |   logical*4, parameter :: false = .false.
     8 | end program
       | ^^^^^^^^^^^ S061
       |
@@ -2459,7 +2629,7 @@ fn show_statistics() -> anyhow::Result<()> {
         r#"
 program test
   logical*4, parameter :: true = .true.
-  logical*4, parameter :: false = .false.  
+  logical*4, parameter :: false = .false.
 end program test
 "#,
     )?;
@@ -2500,7 +2670,7 @@ fn show_statistics_unsafe_fixes() -> anyhow::Result<()> {
         r#"
 program test
   logical*4, parameter :: true = .true.
-  logical*4, parameter :: false = .false.  
+  logical*4, parameter :: false = .false.
 end program test
 "#,
     )?;
@@ -2541,7 +2711,7 @@ fn show_statistics_json() -> anyhow::Result<()> {
         r#"
 program test
   logical*4, parameter :: true = .true.
-  logical*4, parameter :: false = .false.  
+  logical*4, parameter :: false = .false.
 end program test
 "#,
     )?;
@@ -2747,7 +2917,7 @@ end program foo
     --- [TEMP_FILE]
     +++ [TEMP_FILE]
     @@ -1,5 +1,5 @@
-     
+
      program foo
     -  implicit none
     +  implicit none (type, external)

--- a/crates/fortitude_linter/src/settings.rs
+++ b/crates/fortitude_linter/src/settings.rs
@@ -16,7 +16,7 @@ use strum::IntoEnumIterator;
 
 use crate::display_settings;
 use crate::fs::{EXCLUDE_BUILTINS, FilePatternSet, INCLUDE};
-use crate::registry::Rule;
+use crate::registry::{Rule, RuleSet};
 use crate::rule_selector::{CompiledPerFileIgnoreList, PreviewOptions, RuleSelector};
 use crate::rule_table::RuleTable;
 use crate::rules::correctness::{exit_labels, use_statements};
@@ -58,6 +58,7 @@ pub struct CheckSettings {
     pub project_root: PathBuf,
 
     pub rules: RuleTable,
+    pub non_zero_on: RuleSet,
     pub per_file_ignores: CompiledPerFileIgnoreList,
 
     pub line_length: usize,
@@ -98,6 +99,7 @@ impl CheckSettings {
                 .iter()
                 .flat_map(|selector| selector.rules(&PreviewOptions::default()))
                 .collect(),
+            non_zero_on: RuleSet::from_iter(Rule::iter()),
             per_file_ignores: CompiledPerFileIgnoreList::default(),
             line_length: 100,
             fix: false,

--- a/crates/fortitude_workspace/src/configuration.rs
+++ b/crates/fortitude_workspace/src/configuration.rs
@@ -6,7 +6,7 @@ use crate::options::{
 use fortitude_linter::fs::{
     EXCLUDE_BUILTINS, FORTRAN_EXTS, FilePattern, FilePatternSet, GlobPath, INCLUDE,
 };
-use fortitude_linter::registry::RuleNamespace;
+use fortitude_linter::registry::{RuleNamespace, RuleSet};
 use fortitude_linter::rule_redirects::get_redirect;
 use fortitude_linter::rule_selector::{
     CompiledPerFileIgnoreList, PerFileIgnore, PreviewOptions, RuleSelector, Specificity,
@@ -225,6 +225,8 @@ pub struct Configuration {
     pub ignore: Vec<RuleSelector>,
     pub select: Option<Vec<RuleSelector>>,
     pub extend_select: Vec<RuleSelector>,
+    pub exit_zero_on: Vec<RuleSelector>,
+    pub exit_non_zero_on: Vec<RuleSelector>,
     pub fixable: Option<Vec<RuleSelector>>,
     pub unfixable: Vec<RuleSelector>,
     pub extend_fixable: Vec<RuleSelector>,
@@ -272,6 +274,8 @@ impl Configuration {
             ignore: check.ignore.into_iter().flatten().collect(),
             select: check.select,
             extend_select: check.extend_select.unwrap_or_default(),
+            exit_zero_on: check.exit_zero_on.unwrap_or_default(),
+            exit_non_zero_on: check.exit_non_zero_on.unwrap_or_default(),
             fixable: check.fixable,
             unfixable: check.unfixable.unwrap_or_default(),
             extend_fixable: check.extend_fixable.unwrap_or_default(),
@@ -365,6 +369,11 @@ impl Configuration {
             check: CheckSettings {
                 project_root: project_root.to_path_buf(),
                 rules,
+                non_zero_on: to_non_zero_rule_set(
+                    &self.exit_zero_on,
+                    &self.exit_non_zero_on,
+                    &preview,
+                ),
                 fix: self.fix.unwrap_or_default(),
                 fix_only: self.fix_only.unwrap_or_default(),
                 line_length: self
@@ -459,6 +468,16 @@ impl Configuration {
                 .extend_select
                 .into_iter()
                 .chain(config.extend_select)
+                .collect(),
+            exit_zero_on: self
+                .exit_zero_on
+                .into_iter()
+                .chain(config.exit_zero_on)
+                .collect(),
+            exit_non_zero_on: self
+                .exit_non_zero_on
+                .into_iter()
+                .chain(config.exit_non_zero_on)
                 .collect(),
             fixable: self.fixable.or(config.fixable),
             unfixable: self.unfixable.into_iter().chain(config.unfixable).collect(),
@@ -743,6 +762,41 @@ pub fn to_rule_table(args: RuleSelection, preview: &PreviewMode) -> anyhow::Resu
     }
 
     Ok(rules)
+}
+
+fn to_non_zero_rule_set(
+    exit_zero_on: &[RuleSelector],
+    exit_non_zero_on: &[RuleSelector],
+    preview: &PreviewMode,
+) -> RuleSet {
+    let preview = PreviewOptions {
+        mode: *preview,
+        require_explicit: false,
+    };
+
+    let mut non_zero_on: BTreeSet<Rule> = Rule::iter().collect();
+
+    for spec in Specificity::iter() {
+        for selector in exit_zero_on
+            .iter()
+            .filter(|selector| selector.specificity() == spec)
+        {
+            for rule in selector.rules(&preview) {
+                non_zero_on.remove(&rule);
+            }
+        }
+
+        for selector in exit_non_zero_on
+            .iter()
+            .filter(|selector| selector.specificity() == spec)
+        {
+            for rule in selector.rules(&preview) {
+                non_zero_on.insert(rule);
+            }
+        }
+    }
+
+    RuleSet::from_iter(non_zero_on)
 }
 
 // Taken from Ruff

--- a/crates/fortitude_workspace/src/options.rs
+++ b/crates/fortitude_workspace/src/options.rs
@@ -228,6 +228,42 @@ pub struct CheckOptions {
     )]
     pub extend_select: Option<Vec<RuleSelector>>,
 
+    /// A list of rule codes or prefixes whose violations should not cause a
+    /// non-zero exit status.
+    ///
+    /// This only affects the exit code. Diagnostics are still shown normally.
+    /// Prefixes can specify exact rules (like `S201` or
+    /// `superfluous-implicit-none`), entire categories (like `C` or
+    /// `correctness`), or anything in between. More-specific selectors in
+    /// [`exit-non-zero-on`](#check_exit_non_zero_on) override broader matches
+    /// here.
+    #[option(
+        default = "[]",
+        value_type = "list[RuleSelector]",
+        example = r#"
+            exit-zero-on = ["ALL"]
+        "#
+    )]
+    pub exit_zero_on: Option<Vec<RuleSelector>>,
+
+    /// A list of rule codes or prefixes whose violations should still cause a
+    /// non-zero exit status, even if they were matched by
+    /// [`exit-zero-on`](#check_exit_zero_on).
+    ///
+    /// This only affects the exit code. Diagnostics are still shown normally.
+    /// Use this with `["ALL"]` in [`exit-zero-on`](#check_exit_zero_on) to make
+    /// only a small subset of rules blocking while you adopt Fortitude
+    /// gradually.
+    #[option(
+        default = "[]",
+        value_type = "list[RuleSelector]",
+        example = r#"
+            exit-zero-on = ["ALL"]
+            exit-non-zero-on = ["C001"]
+        "#
+    )]
+    pub exit_non_zero_on: Option<Vec<RuleSelector>>,
+
     /// A list of rule codes or prefixes to consider fixable, in addition to those
     /// specified by [`fixable`](#check_fixable).
     #[option(


### PR DESCRIPTION
This PR addresses https://github.com/PlasmaFAIR/fortitude/issues/621 and allows to exit with zero on specific rules or, vice-versa, exit with an error on specific rules. This is useful in CI to make the script fail only on specified rules