### PR TITLE
Expand `SymbolTable` to cover procedures

### DIFF
--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -54,6 +54,19 @@ impl<'a> SymbolTable<'a> {
             .filter_map(|decl| VariableDeclaration::try_from_node(&decl, src).ok())
             .for_each(|line| new_table.insert_from_decl_line(line));
 
+        // The `function` statement itself _may_ also be the declaration line if
+        // it has a type as a procedure attribute. If it doesn't, then it will
+        // either have an explicit decl line, which is handled above, or it's
+        // implicitly typed, which we don't currently handle here at all
+        if scope.is_named() && scope.kind() == "function" {
+            let stmt = scope
+                .child(0)
+                .expect("`function` must have `function_statement` as zeroth child");
+            if let Ok(decl) = VariableDeclaration::try_from_fn_stmt(&stmt, src) {
+                new_table.insert_from_decl_line(decl);
+            }
+        }
+
         new_table
     }
 
@@ -343,6 +356,90 @@ end subroutine foo
             assert!(dim.ranks[1].is_assumed_size());
         }
         assert!(y.has_attribute(AttributeKind::Intent(Intent::InOut)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn function_variable_with_attributes() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = r#"
+function foo(x)
+  integer, intent(in) :: x
+  integer, allocatable, dimension(:) :: foo
+end function foo
+"#;
+        let tree = parser.parse(code, None).context("Failed to parse")?;
+        let root = tree.root_node().child(0).context("Missing child")?;
+
+        let mut symbol_table = SymbolTables::default();
+        symbol_table.push_table(SymbolTable::new(&root, code));
+
+        let foo = symbol_table.get("foo");
+        assert!(foo.is_some());
+        let foo = foo.unwrap();
+        assert!(foo.has_attribute(AttributeKind::Allocatable));
+        assert!(
+            foo.attributes()
+                .iter()
+                .any(|attr| attr.kind().is_dimension())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn function_variable() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = r#"
+integer function foo(x)
+  integer, intent(in) :: x
+end function foo
+"#;
+        let tree = parser.parse(code, None).context("Failed to parse")?;
+        let root = tree.root_node().child(0).context("Missing child")?;
+
+        let mut symbol_table = SymbolTables::default();
+        symbol_table.push_table(SymbolTable::new(&root, code));
+
+        let foo = symbol_table.get("foo");
+        assert!(foo.is_some());
+        let foo = foo.unwrap();
+        assert!(foo.type_().is_intrinsic());
+
+        Ok(())
+    }
+
+    #[test]
+    fn function_result() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = r#"
+integer function foo(x) result(y)
+  integer, intent(in) :: x
+end function foo
+"#;
+        let tree = parser.parse(code, None).context("Failed to parse")?;
+        let root = tree.root_node().child(0).context("Missing child")?;
+
+        let mut symbol_table = SymbolTables::default();
+        symbol_table.push_table(SymbolTable::new(&root, code));
+
+        let y = symbol_table.get("y");
+        assert!(y.is_some());
+        let y = y.unwrap();
+        assert!(y.type_().is_intrinsic());
 
         Ok(())
     }

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -1,10 +1,14 @@
 use std::{collections::HashMap, rc::Rc};
 
+use strum_macros::EnumIs;
 use tree_sitter::Node;
 
-use crate::traits::HasNode;
+use crate::{ast::types::ProcedureKind, traits::HasNode};
 
-use super::types::{Variable, VariableDeclaration};
+use super::{
+    FortitudeNode,
+    types::{Procedure, Variable, VariableDeclaration},
+};
 
 pub const BEGIN_SCOPE_NODES: &[&str] = &[
     "program",
@@ -24,9 +28,11 @@ pub const END_SCOPE_NODES: &[&str] = &[
 ];
 
 /// A named symbol
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, EnumIs)]
 pub enum Symbol<'a> {
     Variable(Variable<'a>),
+    Function(Procedure<'a>),
+    Subroutine(Procedure<'a>),
 }
 
 /// A table of symbols in a given scope
@@ -65,6 +71,26 @@ impl<'a> SymbolTable<'a> {
             if let Ok(decl) = VariableDeclaration::try_from_fn_stmt(&stmt, src) {
                 new_table.insert_from_decl_line(decl);
             }
+        }
+
+        if let Some(procs) = scope.child_with_name("internal_procedures") {
+            procs
+                .named_children(&mut procs.walk())
+                .filter_map(|proc| match proc.kind() {
+                    "function" | "subroutine" => Procedure::try_from_node(&proc, src).ok(),
+                    _ => None,
+                })
+                .for_each(|proc| {
+                    let name = proc.name().to_owned();
+                    match proc.kind() {
+                        ProcedureKind::Function => {
+                            new_table.inner.insert(name, Symbol::Function(proc))
+                        }
+                        ProcedureKind::Subroutine => {
+                            new_table.inner.insert(name, Symbol::Subroutine(proc))
+                        }
+                    };
+                })
         }
 
         new_table
@@ -123,7 +149,27 @@ impl<'a> SymbolTables<'a> {
                 Some(Symbol::Variable(var)) => {
                     return Some(var);
                 }
+                // We found a name, but it isn't a variable and will shadow any
+                // variables with the same name further up the stack, so quit
+                // now so we don't find them
+                Some(_) => {
+                    return None;
+                }
+                // Nothing in this scope, keep looking
                 None => (),
+            }
+        }
+        None
+    }
+
+    /// Return the symbol with the given name if it exists
+    pub fn get(&'_ self, name: &str) -> Option<&Symbol<'_>> {
+        let name = name.to_ascii_lowercase();
+
+        // Check the most recently inserted table first
+        for table in self.inner.iter().rev() {
+            if let Some(var) = table.get(&name) {
+                return Some(var);
             }
         }
         None
@@ -442,6 +488,43 @@ end function foo
         assert!(y.is_some());
         let y = y.unwrap();
         assert!(y.type_().is_intrinsic());
+
+        Ok(())
+    }
+
+    #[test]
+    fn internal_procedures() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = r#"
+program foo
+contains
+  integer function bar(x) result(y)
+    integer, intent(in) :: x
+  end function bar
+
+  subroutine zing()
+  end subroutine zing
+end program foo
+"#;
+        let tree = parser.parse(code, None).context("Failed to parse")?;
+        let root = tree.root_node().child(0).context("Missing child")?;
+
+        let mut symbol_table = SymbolTables::default();
+        symbol_table.push_table(SymbolTable::new(&root, code));
+
+        let bar = symbol_table.get("bar");
+        assert!(bar.is_some());
+        let bar = bar.unwrap();
+        assert!(bar.is_function());
+
+        let zing = symbol_table.get("zing");
+        assert!(zing.is_some());
+        let zing = zing.unwrap();
+        assert!(zing.is_subroutine());
 
         Ok(())
     }

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -83,16 +83,8 @@ impl<'a> SymbolTable<'a> {
     }
 
     /// Return the symbol with the given name if it exists
-    pub fn get(&self, name: &str) -> Option<Variable<'_>> {
-        // TODO(peter): avoid calling to_ascii_lowercase every time. Strong type?
-        let name = name.to_ascii_lowercase();
-        match self.inner.get(&name) {
-            Some(Symbol::Variable(node, index)) => {
-                let decl: &VariableDeclaration = &self.decl_lines[*index];
-                Some(Variable::new(name, *node, decl))
-            }
-            None => None,
-        }
+    pub fn get(&self, name: &str) -> Option<&Symbol<'_>> {
+        self.inner.get(name)
     }
 
     /// Iterator over the variable declaration lines
@@ -119,13 +111,19 @@ impl<'a> SymbolTables<'a> {
         self.inner.pop();
     }
 
-    /// Return the symbol with the given name if it exists
-    pub fn get(&'_ self, name: &str) -> Option<Variable<'_>> {
+    /// Return the symbol with the given name if it exists and is a variable
+    pub fn get_var(&'_ self, name: &str) -> Option<Variable<'_>> {
+        let name = name.to_ascii_lowercase();
+
         // Check the most recently inserted table first
         for table in self.inner.iter().rev() {
-            if let Some(node) = table.get(name) {
-                return Some(node);
-            }
+            match table.get(&name) {
+                Some(Symbol::Variable(node, index)) => {
+                    let decl: &VariableDeclaration = &table.decl_lines[*index];
+                    return Some(Variable::new(name, *node, decl));
+                },
+                None => ()
+        }
         }
         None
     }
@@ -165,12 +163,13 @@ end program foo
         let first_decl_range = TextRange::new(TextSize::new(15), TextSize::new(40));
         let second_decl_range = TextRange::new(TextSize::new(43), TextSize::new(71));
 
-        let symbol_table = SymbolTable::new(&root, code);
+        let mut symbol_table = SymbolTables::default();
+        symbol_table.push_table(SymbolTable::new(&root, code));
 
-        let x = symbol_table.get("x");
-        let y = symbol_table.get("y");
-        let z = symbol_table.get("Z");
-        let a = symbol_table.get("a");
+        let x = symbol_table.get_var("x");
+        let y = symbol_table.get_var("y");
+        let z = symbol_table.get_var("Z");
+        let a = symbol_table.get_var("a");
         assert!(x.is_some());
         let x = x.unwrap();
         assert_eq!(
@@ -260,8 +259,10 @@ end program foo
         let tree = parser.parse(code, None).context("Failed to parse")?;
         let root = tree.root_node().child(0).context("Missing child")?;
 
-        let symbol_table = SymbolTable::new(&root, code);
-        let x = symbol_table.get("X");
+        let mut symbol_table = SymbolTables::default();
+        symbol_table.push_table(SymbolTable::new(&root, code));
+
+        let x = symbol_table.get_var("X");
         assert!(x.is_some());
         assert_eq!(
             x.unwrap().textrange(),
@@ -297,14 +298,14 @@ end program foo
             .context("Missing block")?;
         symbol_table.push_table(SymbolTable::new(&block, code));
 
-        let x = symbol_table.get("X");
+        let x = symbol_table.get_var("X");
         assert!(x.is_some());
         assert_eq!(
             x.unwrap().textrange(),
             TextRange::new(TextSize::new(26), TextSize::new(27))
         );
 
-        let a = symbol_table.get("a");
+        let a = symbol_table.get_var("a");
         assert!(a.is_some());
         assert_eq!(
             a.unwrap().textrange(),
@@ -312,7 +313,7 @@ end program foo
         );
 
         symbol_table.pop_table();
-        assert!(symbol_table.get("a").is_none());
+        assert!(symbol_table.get_var("a").is_none());
 
         Ok(())
     }
@@ -336,13 +337,13 @@ end subroutine foo
         let mut symbol_table = SymbolTables::default();
         symbol_table.push_table(SymbolTable::new(&root, code));
 
-        let x = symbol_table.get("x");
+        let x = symbol_table.get_var("x");
         assert!(x.is_some());
         let x = x.unwrap();
         assert!(x.attributes().iter().any(|attr| attr.kind().is_dimension()));
         assert!(x.has_attribute(AttributeKind::Intent(Intent::In)));
 
-        let y = symbol_table.get("y");
+        let y = symbol_table.get_var("y");
         assert!(y.is_some());
         let y = y.unwrap();
         let y_dim = y
@@ -379,7 +380,7 @@ end function foo
         let mut symbol_table = SymbolTables::default();
         symbol_table.push_table(SymbolTable::new(&root, code));
 
-        let foo = symbol_table.get("foo");
+        let foo = symbol_table.get_var("foo");
         assert!(foo.is_some());
         let foo = foo.unwrap();
         assert!(foo.has_attribute(AttributeKind::Allocatable));
@@ -410,7 +411,7 @@ end function foo
         let mut symbol_table = SymbolTables::default();
         symbol_table.push_table(SymbolTable::new(&root, code));
 
-        let foo = symbol_table.get("foo");
+        let foo = symbol_table.get_var("foo");
         assert!(foo.is_some());
         let foo = foo.unwrap();
         assert!(foo.type_().is_intrinsic());
@@ -436,7 +437,7 @@ end function foo
         let mut symbol_table = SymbolTables::default();
         symbol_table.push_table(SymbolTable::new(&root, code));
 
-        let y = symbol_table.get("y");
+        let y = symbol_table.get_var("y");
         assert!(y.is_some());
         let y = y.unwrap();
         assert!(y.type_().is_intrinsic());

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, rc::Rc};
 
 use tree_sitter::Node;
 
@@ -26,7 +26,7 @@ pub const END_SCOPE_NODES: &[&str] = &[
 /// A named symbol
 #[derive(Clone, Debug)]
 pub enum Symbol<'a> {
-    Variable(Node<'a>, usize),
+    Variable(Variable<'a>),
 }
 
 /// A table of symbols in a given scope
@@ -39,7 +39,7 @@ pub enum Symbol<'a> {
 #[derive(Clone, Debug, Default)]
 pub struct SymbolTable<'a> {
     inner: HashMap<String, Symbol<'a>>,
-    decl_lines: Vec<VariableDeclaration<'a>>,
+    decl_lines: Vec<Rc<VariableDeclaration<'a>>>,
 }
 
 impl<'a> SymbolTable<'a> {
@@ -72,11 +72,13 @@ impl<'a> SymbolTable<'a> {
 
     /// Insert all symbols found in a single variable declaration statement
     pub fn insert_from_decl_line(&mut self, decl: VariableDeclaration<'a>) {
-        let index = self.decl_lines.len();
+        let decl = Rc::new(decl);
         for name in decl.names().iter() {
+            let node = *name.node();
+            let name = name.name().to_ascii_lowercase();
             self.inner.insert(
-                name.name().to_ascii_lowercase(),
-                Symbol::Variable(*name.node(), index),
+                name.clone(),
+                Symbol::Variable(Variable::new(name, node, decl.clone())),
             );
         }
         self.decl_lines.push(decl);
@@ -88,7 +90,7 @@ impl<'a> SymbolTable<'a> {
     }
 
     /// Iterator over the variable declaration lines
-    pub fn iter_decl_lines(&self) -> impl Iterator<Item = &VariableDeclaration<'a>> {
+    pub fn iter_decl_lines(&self) -> impl Iterator<Item = &Rc<VariableDeclaration<'a>>> {
         self.decl_lines.iter()
     }
 }
@@ -112,18 +114,17 @@ impl<'a> SymbolTables<'a> {
     }
 
     /// Return the symbol with the given name if it exists and is a variable
-    pub fn get_var(&'_ self, name: &str) -> Option<Variable<'_>> {
+    pub fn get_var(&'_ self, name: &str) -> Option<&Variable<'_>> {
         let name = name.to_ascii_lowercase();
 
         // Check the most recently inserted table first
         for table in self.inner.iter().rev() {
             match table.get(&name) {
-                Some(Symbol::Variable(node, index)) => {
-                    let decl: &VariableDeclaration = &table.decl_lines[*index];
-                    return Some(Variable::new(name, *node, decl));
-                },
-                None => ()
-        }
+                Some(Symbol::Variable(var)) => {
+                    return Some(var);
+                }
+                None => (),
+            }
         }
         None
     }

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -35,6 +35,24 @@ pub enum Symbol<'a> {
     Subroutine(Procedure<'a>),
 }
 
+impl<'a> Symbol<'a> {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Variable(var) => var.name(),
+            Self::Function(proc) | Self::Subroutine(proc) => proc.name(),
+        }
+    }
+}
+
+impl<'a> HasNode<'a> for Symbol<'a> {
+    fn node(&self) -> &Node<'a> {
+        match self {
+            Self::Variable(var) => var.node(),
+            Self::Function(proc) | Self::Subroutine(proc) => proc.node(),
+        }
+    }
+}
+
 /// A table of symbols in a given scope
 ///
 /// Variables are not stored directly in the hashmap because we want to be able
@@ -118,6 +136,21 @@ impl<'a> SymbolTable<'a> {
     /// Iterator over the variable declaration lines
     pub fn iter_decl_lines(&self) -> impl Iterator<Item = &Rc<VariableDeclaration<'a>>> {
         self.decl_lines.iter()
+    }
+
+    /// Iterator over symbols in this scope
+    pub fn iter_symbols(&self) -> impl Iterator<Item = &Symbol<'_>> {
+        self.inner.values()
+    }
+
+    /// Iterator over names in this scope
+    pub fn iter_names(&self) -> impl Iterator<Item = &String> {
+        self.inner.keys()
+    }
+
+    /// Iterator over symbol names and values
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Symbol<'_>)> {
+        self.inner.iter()
     }
 }
 
@@ -525,6 +558,36 @@ end program foo
         assert!(zing.is_some());
         let zing = zing.unwrap();
         assert!(zing.is_subroutine());
+
+        Ok(())
+    }
+
+    #[test]
+    fn all_symbols() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = r#"
+program foo
+  integer :: a, b
+contains
+  integer function bar(x) result(y)
+    integer, intent(in) :: x
+  end function bar
+
+  subroutine zing()
+  end subroutine zing
+end program foo
+"#;
+        let tree = parser.parse(code, None).context("Failed to parse")?;
+        let root = tree.root_node().child(0).context("Missing child")?;
+
+        let symbol_table = SymbolTable::new(&root, code);
+
+        let count = symbol_table.iter_symbols().count();
+        assert_eq!(count, 4);
 
         Ok(())
     }

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -598,3 +598,130 @@ impl<'a> ImplicitStatement<'a> {
         self.none_type.contains(ImplicitNoneType::EXTERNAL)
     }
 }
+
+#[derive(Clone, Debug, EnumIs, EnumString, IntoStaticStr, PartialEq)]
+#[strum(serialize_all = "snake_case", ascii_case_insensitive)]
+pub enum ProcedureAttributeKind {
+    Elemental,
+    Impure,
+    Module,
+    NonRecursive,
+    Pure,
+    Recursive,
+    Simple,
+}
+
+/// A procedure attribute and where it is
+#[derive(Clone, Debug, HasNode)]
+pub struct ProcedureAttribute<'a> {
+    kind: ProcedureAttributeKind,
+    node: Node<'a>,
+}
+
+impl<'a> ProcedureAttribute<'a> {
+    pub fn try_from_node(node: Node<'a>, src: &str) -> Result<Self> {
+        let kind = ProcedureAttributeKind::from_str(node.to_text(src).context("expected text")?)?;
+        Ok(Self { kind, node })
+    }
+
+    pub fn kind(&self) -> &ProcedureAttributeKind {
+        &self.kind
+    }
+}
+
+#[derive(Copy, Clone, Debug, EnumIs, EnumString, PartialEq)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
+pub enum ProcedureKind {
+    Function,
+    Subroutine,
+}
+
+#[derive(Clone, Debug, HasNode)]
+pub struct Procedure<'a> {
+    type_: Option<Type<'a>>,
+    attributes: Vec<ProcedureAttribute<'a>>,
+    name: String,
+    args: Vec<String>,
+    kind: ProcedureKind,
+    node: Node<'a>,
+}
+
+impl<'a> Procedure<'a> {
+    pub fn try_from_node(node: &Node<'a>, src: &str) -> Result<Self> {
+        if !node.is_named() || !matches!(node.kind(), "function" | "subroutine") {
+            return Err(anyhow!("not a procedure"));
+        }
+
+        let kind = ProcedureKind::from_str(node.kind()).unwrap();
+
+        let stmt = node.child(0).context("expected child")?;
+
+        let type_ = if let Some(child) = stmt.child_by_field_name("type") {
+            Some(Type::try_from_node(child, src)?)
+        } else {
+            None
+        };
+
+        let attributes: Result<Vec<_>> = stmt
+            .named_children(&mut stmt.walk())
+            .filter(|attr| attr.kind() == "procedure_qualifier")
+            .map(|attr| ProcedureAttribute::try_from_node(attr, src))
+            .collect();
+        let attributes = attributes?;
+
+        let name = stmt
+            .child_by_field_name("name")
+            .context("procedure should have `name` field")?
+            .to_text(src)
+            .context("name should have text")?
+            .to_ascii_lowercase();
+
+        let args = stmt
+            .child_with_name("parameters")
+            .map(|params| {
+                params
+                    .named_children(&mut params.walk())
+                    .flat_map(|param| param.to_text(src))
+                    .map(|param| param.to_ascii_lowercase())
+                    .collect_vec()
+            })
+            .unwrap_or_default();
+
+        Ok(Self {
+            type_,
+            attributes,
+            name,
+            args,
+            kind,
+            node: *node,
+        })
+    }
+
+    pub const fn type_(&self) -> &Option<Type<'_>> {
+        &self.type_
+    }
+
+    pub const fn attributes(&self) -> &Vec<ProcedureAttribute<'_>> {
+        &self.attributes
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub const fn args(&self) -> &Vec<String> {
+        &self.args
+    }
+
+    pub const fn kind(&self) -> ProcedureKind {
+        self.kind
+    }
+
+    pub const fn is_function(&self) -> bool {
+        self.kind.is_function()
+    }
+
+    pub const fn is_subroutine(&self) -> bool {
+        self.kind.is_subroutine()
+    }
+}

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -4,12 +4,13 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result, anyhow};
 use bitflags::bitflags;
+use fortitude_macros::HasNode;
 use itertools::Itertools;
 use ruff_source_file::SourceFile;
 use strum_macros::{Display, EnumIs, EnumString, IntoStaticStr};
 use tree_sitter::Node;
 
-use crate::{ast::FortitudeNode, impl_has_node, traits::HasNode};
+use crate::{ast::FortitudeNode, traits::HasNode};
 
 #[derive(Clone, Debug)]
 pub struct ParameterStatement<'a> {
@@ -39,7 +40,7 @@ impl<'a> ParameterStatement<'a> {
 }
 
 /// A declaration of a single variable
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, HasNode)]
 pub struct NameDecl<'a> {
     name: String,
     node: Node<'a>,
@@ -72,8 +73,6 @@ impl<'a> NameDecl<'a> {
     }
 }
 
-impl_has_node!(NameDecl<'a>);
-
 #[derive(Clone, Copy, Debug, EnumIs, PartialEq)]
 pub enum ExtentSize<'a> {
     Expression(Node<'a>),
@@ -99,7 +98,7 @@ impl<'a> HasNode<'a> for ExtentSize<'a> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, HasNode)]
 pub struct Extent<'a> {
     start: Option<Node<'a>>,
     stop: Option<ExtentSize<'a>>,
@@ -127,8 +126,6 @@ impl<'a> Extent<'a> {
         })
     }
 }
-
-impl_has_node!(Extent<'a>);
 
 /// One rank of a dimension's array-spec
 #[derive(Clone, Copy, Debug, EnumIs, PartialEq)]
@@ -256,7 +253,7 @@ impl<'a> AttributeKind<'a> {
 }
 
 /// A variable attribute and where it is
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, HasNode)]
 pub struct Attribute<'a> {
     kind: AttributeKind<'a>,
     node: Node<'a>,
@@ -274,8 +271,6 @@ impl<'a> Attribute<'a> {
         &self.kind
     }
 }
-
-impl_has_node!(Attribute<'a>);
 
 #[derive(Clone, Debug)]
 pub struct TypeInner<'a> {
@@ -326,7 +321,7 @@ impl<'a> HasNode<'a> for Type<'a> {
 }
 
 /// A variable declaration line
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, HasNode)]
 pub struct VariableDeclaration<'a> {
     type_: Type<'a>,
     attributes: Vec<Attribute<'a>>,
@@ -445,8 +440,6 @@ impl<'a> VariableDeclaration<'a> {
     }
 }
 
-impl_has_node!(VariableDeclaration<'a>);
-
 /// Returns the tree-sitter node corresponding to the actual name of a
 /// declarator node, and not, say, the initialiser
 pub fn get_name_node_of_declarator<'a>(node: &Node<'a>) -> Node<'a> {
@@ -485,7 +478,7 @@ pub fn get_init_node_of_declarator<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
 }
 
 /// A single Fortran variable
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, HasNode)]
 pub struct Variable<'a> {
     name: String,
     node: Node<'a>,
@@ -522,8 +515,6 @@ impl<'a> Variable<'a> {
         self.decl.has_any_attributes(attrs)
     }
 }
-
-impl_has_node!(Variable<'a>);
 
 #[derive(EnumString, Display)]
 #[strum(ascii_case_insensitive)]

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -1,6 +1,6 @@
 //! Strong types for working with the tree-sitter AST
 
-use std::str::FromStr;
+use std::{rc::Rc, str::FromStr};
 
 use anyhow::{Context, Result, anyhow};
 use bitflags::bitflags;
@@ -483,11 +483,11 @@ pub struct Variable<'a> {
     name: String,
     node: Node<'a>,
     /// Reference to the statement in which the variable is declared
-    decl: &'a VariableDeclaration<'a>,
+    decl: Rc<VariableDeclaration<'a>>,
 }
 
 impl<'a> Variable<'a> {
-    pub fn new(name: String, node: Node<'a>, decl: &'a VariableDeclaration<'a>) -> Self {
+    pub fn new(name: String, node: Node<'a>, decl: Rc<VariableDeclaration<'a>>) -> Self {
         Self { name, node, decl }
     }
 
@@ -496,7 +496,7 @@ impl<'a> Variable<'a> {
     }
 
     pub fn decl_statement(&'a self) -> &'a VariableDeclaration<'a> {
-        self.decl
+        self.decl.as_ref()
     }
 
     pub fn type_(&self) -> &Type<'_> {

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -333,9 +333,11 @@ pub struct VariableDeclaration<'a> {
     names: Vec<NameDecl<'a>>,
     node: Node<'a>,
     has_colon: bool,
+    is_function: bool,
 }
 
 impl<'a> VariableDeclaration<'a> {
+    /// Create from `variable_declaration` node
     pub fn try_from_node(node: &Node<'a>, src: &str) -> Result<Self> {
         if node.kind() != "variable_declaration" {
             return Err(anyhow!("wrong node type"));
@@ -367,6 +369,47 @@ impl<'a> VariableDeclaration<'a> {
             names,
             node: *node,
             has_colon,
+            is_function: false,
+        })
+    }
+
+    /// Create from `function_statement`. Will fail if the statement has no `type`
+    pub fn try_from_fn_stmt(node: &Node<'a>, src: &str) -> Result<Self> {
+        if node.kind() != "function_statement" {
+            return Err(anyhow!("wrong node type"));
+        }
+
+        let type_ = Type::try_from_node(
+            node.child_by_field_name("type").context("expected type")?,
+            src,
+        )?;
+
+        let name = if let Some(result) = node.child_with_name("function_result") {
+            let id = result
+                .child_with_name("identifier")
+                .expect("`function_result` should have `identifier` child");
+            NameDecl::from_node(&id, src)
+        } else {
+            let id = node
+                .child_by_field_name("name")
+                .expect("`function_statement` must have `name` field");
+            NameDecl {
+                name: id
+                    .to_text(src)
+                    .context("`name` must have text")?
+                    .to_string(),
+                node: id,
+            }
+        };
+        let names = vec![name];
+
+        Ok(Self {
+            type_,
+            attributes: vec![],
+            names,
+            node: *node,
+            has_colon: false,
+            is_function: true,
         })
     }
 
@@ -392,8 +435,13 @@ impl<'a> VariableDeclaration<'a> {
             .any(|attr| attrs.contains(&attr.kind))
     }
 
-    pub fn has_colon(&self) -> bool {
+    pub const fn has_colon(&self) -> bool {
         self.has_colon
+    }
+
+    /// Is this variable declaration actually a function statement?
+    pub const fn is_function(&self) -> bool {
+        self.is_function
     }
 }
 

--- a/crates/fortitude_linter/src/fix/edits.rs
+++ b/crates/fortitude_linter/src/fix/edits.rs
@@ -184,7 +184,7 @@ pub fn redent(s: &str, indentation: &str, line_ending: LineEnding) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::symbol_table::SymbolTable;
+    use crate::ast::symbol_table::{SymbolTable, SymbolTables};
 
     use super::*;
     use anyhow::{Context, Result};
@@ -211,14 +211,16 @@ end program foo
         let tree = parser.parse(code, None).context("Failed to parse")?;
         let root = tree.root_node().child(0).context("Missing child")?;
 
-        let symbol_table = SymbolTable::new(&root, code);
+        let mut symbol_table = SymbolTables::default();
+        symbol_table.push_table(SymbolTable::new(&root, code));
+
         let test_source = SourceFileBuilder::new("test.f90", code).finish();
 
-        let x = symbol_table.get("x").unwrap();
-        let y = symbol_table.get("y").unwrap();
-        let z = symbol_table.get("Z").unwrap();
-        let a = symbol_table.get("a").unwrap();
-        let e = symbol_table.get("e").unwrap();
+        let x = symbol_table.get_var("x").unwrap();
+        let y = symbol_table.get_var("y").unwrap();
+        let z = symbol_table.get_var("Z").unwrap();
+        let a = symbol_table.get_var("a").unwrap();
+        let e = symbol_table.get_var("e").unwrap();
 
         let remove_x = remove_variable_decl(x.node(), x.decl_statement(), &test_source)?;
         assert_eq!(
@@ -270,11 +272,12 @@ end program foo
         let tree = parser.parse(code, None).context("Failed to parse")?;
         let root = tree.root_node().child(0).context("Missing child")?;
 
-        let symbol_table = SymbolTable::new(&root, code);
+        let mut symbol_table = SymbolTables::default();
+        symbol_table.push_table(SymbolTable::new(&root, code));
 
-        let x = symbol_table.get("x").unwrap();
-        let y = symbol_table.get("y").unwrap();
-        let z = symbol_table.get("z").unwrap();
+        let x = symbol_table.get_var("x").unwrap();
+        let y = symbol_table.get_var("y").unwrap();
+        let z = symbol_table.get_var("z").unwrap();
 
         let add_x = add_attribute_to_var_decl(x.decl_statement(), "parameter");
         assert_eq!(

--- a/crates/fortitude_linter/src/rules/correctness/init_decls.rs
+++ b/crates/fortitude_linter/src/rules/correctness/init_decls.rs
@@ -89,7 +89,7 @@ impl AstRule for InitialisationInDeclaration {
         })?;
 
         let name = get_name_node_of_declarator(node).to_text(src)?.to_string();
-        let decl = context.symbol_table().get(name.as_str())?;
+        let decl = context.symbol_table().get_var(name.as_str())?;
         if decl.has_any_attributes(&[AttributeKind::Save, AttributeKind::Parameter]) {
             return None;
         }
@@ -209,7 +209,7 @@ impl AstRule for PointerInitialisationInDeclaration {
 
         let var = get_name_node_of_declarator(node);
         let name = var.to_text(src)?.to_string();
-        let decl = context.symbol_table().get(name.as_str())?;
+        let decl = context.symbol_table().get_var(name.as_str())?;
         if decl.has_attribute(AttributeKind::Save) {
             return None;
         }

--- a/crates/fortitude_linter/src/rules/correctness/intent.rs
+++ b/crates/fortitude_linter/src/rules/correctness/intent.rs
@@ -60,7 +60,7 @@ impl AstRule for MissingIntent {
                     // Get variable declaration
                     context
                         .symbol_table()
-                        .get(param.to_text(context.source_text())?)
+                        .get_var(param.to_text(context.source_text())?)
                 })
                 .filter(|param| {
                     // Procedures are not allowed intent

--- a/crates/fortitude_linter/src/rules/modernisation/out_of_line_attribute.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/out_of_line_attribute.rs
@@ -202,12 +202,12 @@ impl AstRule for OutOfLineAttribute {
                     ParameterStatement::try_from_node(parameter, context.source_text()).ok()
                 })
                 .filter_map(
-                    |parameter| match context.symbol_table().get(&parameter.name) {
+                    |parameter| match context.symbol_table().get_var(&parameter.name) {
                         Some(var) => {
                             let mut edit = fix_out_of_line_parameter(
                                 node,
                                 &parameter,
-                                &var,
+                                var,
                                 context.source_file(),
                             )
                             .unwrap();
@@ -255,9 +255,9 @@ impl AstRule for OutOfLineAttribute {
                     )
                 })
                 .filter_map(|(decl, name)| {
-                    context.symbol_table().get(&name).map(|var| {
+                    context.symbol_table().get_var(&name).map(|var| {
                         let mut edit =
-                            fix_out_of_line_attribute(node, &decl, &var, context.source_file())
+                            fix_out_of_line_attribute(node, &decl, var, context.source_file())
                                 .unwrap();
 
                         context

--- a/crates/fortitude_linter/src/traits.rs
+++ b/crates/fortitude_linter/src/traits.rs
@@ -21,18 +21,6 @@ impl<'a> HasNode<'a> for &'a Node<'a> {
     }
 }
 
-#[macro_export]
-macro_rules! impl_has_node {
-    ($ty: ty) => {
-        impl<'a> HasNode<'a> for $ty {
-            #[inline]
-            fn node(&self) -> &Node<'a> {
-                &self.node
-            }
-        }
-    };
-}
-
 /// A ranged item in the source text.
 ///
 /// A kind of shim for [`ruff_text_size::Ranged`] for compatibility with

--- a/crates/fortitude_macros/src/has_node.rs
+++ b/crates/fortitude_macros/src/has_node.rs
@@ -1,0 +1,27 @@
+use quote::quote;
+use syn::{Data, DataStruct, DeriveInput, Error};
+
+/// Derive [`HasNode`] on a struct
+pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let DeriveInput {
+        ident,
+        data: Data::Struct(DataStruct { .. }),
+        generics,
+        ..
+    } = input
+    else {
+        return Err(Error::new(input.ident.span(), "only structs are supported"));
+    };
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics HasNode<'a> for #ident #ty_generics #where_clause {
+            #[inline]
+            fn node(&self) -> &Node<'a> {
+                &self.node
+            }
+        }
+    })
+}

--- a/crates/fortitude_macros/src/lib.rs
+++ b/crates/fortitude_macros/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::violation_metadata::violation_metadata;
 
+mod has_node;
 mod map_codes;
 mod rule_code_prefix;
 mod rule_namespace;
@@ -30,6 +31,15 @@ pub fn derive_rule_namespace(input: TokenStream) -> TokenStream {
 pub fn map_codes(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let func = parse_macro_input!(item as ItemFn);
     map_codes::map_codes(&func)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_derive(HasNode)]
+pub fn derive_has_node(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    has_node::derive_impl(input)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }


### PR DESCRIPTION
This captures procedure names in a scope, including `function` `result` variables, moving us towards a more complete semantic parsing. The `function` name (or `result` name) appears as a `Variable` in its own scope, and as a `Procedure` otherwise.

`SymbolTable` gets a few methods to iterate over everything in a scope -- might be useful to have these on `SymbolTables` as well? And/or something to get the current scope?

I also reworked `HasNode` to be a normal `derive` macro.

Thinking ahead to e.g. #645, maybe `SymbolTables` should hold `Vec<Scope>` with `Scope` something like an enum with each variant holding a `SymbolTable`:

```rust
enum Scope {
  Function(Function),
  ..
}

struct Function {
  name: String,
  locals: OnceCell<SymbolTable>,
  args: OnceCell<SymbolTable>,
  attrs: .. // and so on
}
```

Using `OnceCell` here so that we a) don't need multiple passes over the AST, and b) we only need to create them if needed.
