### PR TITLE
More use of `CheckContext::create_diagnostic`

### DIFF
--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -271,7 +271,7 @@ pub(crate) fn check_path(
 
     // Check file paths directly
     if context.is_rule_enabled(Rule::NonStandardFileExtension) {
-        if let Some(violation) = NonStandardFileExtension::check(path) {
+        if let Some(violation) = NonStandardFileExtension::check(&context) {
             violations.push(violation);
         }
     }
@@ -364,21 +364,25 @@ pub(crate) fn check_path(
                 continue;
             }
             let diagnostic = match test_rule {
-                Rule::StableTestRule => test_rules::StableTestRule::check(),
-                Rule::StableTestRuleSafeFix => test_rules::StableTestRuleSafeFix::check(),
-                Rule::StableTestRuleUnsafeFix => test_rules::StableTestRuleUnsafeFix::check(),
-                Rule::StableTestRuleDisplayOnlyFix => {
-                    test_rules::StableTestRuleDisplayOnlyFix::check()
+                Rule::StableTestRule => test_rules::StableTestRule::check(&context),
+                Rule::StableTestRuleSafeFix => test_rules::StableTestRuleSafeFix::check(&context),
+                Rule::StableTestRuleUnsafeFix => {
+                    test_rules::StableTestRuleUnsafeFix::check(&context)
                 }
-                Rule::PreviewTestRule => test_rules::PreviewTestRule::check(),
-                Rule::DeprecatedTestRule => test_rules::DeprecatedTestRule::check(),
-                Rule::AnotherDeprecatedTestRule => test_rules::AnotherDeprecatedTestRule::check(),
-                Rule::RemovedTestRule => test_rules::RemovedTestRule::check(),
-                Rule::AnotherRemovedTestRule => test_rules::AnotherRemovedTestRule::check(),
-                Rule::RedirectedToTestRule => test_rules::RedirectedToTestRule::check(),
-                Rule::RedirectedFromTestRule => test_rules::RedirectedFromTestRule::check(),
+                Rule::StableTestRuleDisplayOnlyFix => {
+                    test_rules::StableTestRuleDisplayOnlyFix::check(&context)
+                }
+                Rule::PreviewTestRule => test_rules::PreviewTestRule::check(&context),
+                Rule::DeprecatedTestRule => test_rules::DeprecatedTestRule::check(&context),
+                Rule::AnotherDeprecatedTestRule => {
+                    test_rules::AnotherDeprecatedTestRule::check(&context)
+                }
+                Rule::RemovedTestRule => test_rules::RemovedTestRule::check(&context),
+                Rule::AnotherRemovedTestRule => test_rules::AnotherRemovedTestRule::check(&context),
+                Rule::RedirectedToTestRule => test_rules::RedirectedToTestRule::check(&context),
+                Rule::RedirectedFromTestRule => test_rules::RedirectedFromTestRule::check(&context),
                 Rule::RedirectedFromPrefixTestRule => {
-                    test_rules::RedirectedFromPrefixTestRule::check()
+                    test_rules::RedirectedFromPrefixTestRule::check(&context)
                 }
                 _ => unreachable!("All test rules must have an implementation"),
             };

--- a/crates/fortitude_linter/src/rules/style/file_extensions.rs
+++ b/crates/fortitude_linter/src/rules/style/file_extensions.rs
@@ -1,4 +1,7 @@
-use crate::diagnostics::{Diagnostic, Violation};
+use crate::{
+    CheckContext,
+    diagnostics::{Diagnostic, Violation},
+};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_text_size::TextRange;
@@ -25,56 +28,18 @@ impl Violation for NonStandardFileExtension {
 }
 
 impl NonStandardFileExtension {
-    pub fn check(path: &Path) -> Option<Diagnostic> {
+    pub fn check(context: &CheckContext) -> Option<Diagnostic> {
+        let path = Path::new(context.file.name());
         match path.extension() {
             Some(ext) => {
                 // Must check like this as ext is an OsStr
                 if ["f90", "F90", "pf"].iter().any(|&x| x == ext) {
                     None
                 } else {
-                    Some(Diagnostic::new(Self {}, TextRange::default()))
+                    Some(context.create_diagnostic(Self {}, TextRange::default()))
                 }
             }
-            None => Some(Diagnostic::new(Self {}, TextRange::default())),
+            None => Some(context.create_diagnostic(Self {}, TextRange::default())),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_bad_file_extension() {
-        let path = Path::new("my/dir/to/file.f95");
-        assert_eq!(
-            NonStandardFileExtension::check(path),
-            Some(Diagnostic::new(
-                NonStandardFileExtension {},
-                TextRange::default()
-            )),
-        );
-    }
-
-    #[test]
-    fn test_missing_file_extension() {
-        let path = Path::new("my/dir/to/file");
-        assert_eq!(
-            NonStandardFileExtension::check(path),
-            Some(Diagnostic::new(
-                NonStandardFileExtension {},
-                TextRange::default()
-            )),
-        );
-    }
-
-    #[test]
-    fn test_correct_file_extensions() {
-        let path1 = Path::new("my/dir/to/file.f90");
-        let path2 = Path::new("my/dir/to/file.F90");
-        let path3 = Path::new("my/dir/to/file.pf");
-        assert_eq!(NonStandardFileExtension::check(path1), None);
-        assert_eq!(NonStandardFileExtension::check(path2), None);
-        assert_eq!(NonStandardFileExtension::check(path3), None);
     }
 }

--- a/crates/fortitude_linter/src/rules/style/mod.rs
+++ b/crates/fortitude_linter/src/rules/style/mod.rs
@@ -22,6 +22,7 @@ mod tests {
 
     use anyhow::Result;
     use insta::assert_snapshot;
+    use ruff_source_file::SourceFileBuilder;
     use test_case::test_case;
 
     use crate::apply_common_filters;
@@ -29,7 +30,7 @@ mod tests {
     use crate::rules::style::inconsistent_dimension::settings::PreferAttribute;
     use crate::rules::style::{complexity, inconsistent_dimension, keywords, line_length, strings};
     use crate::settings::CheckSettings;
-    use crate::test::test_path;
+    use crate::test::{test_contents, test_path};
 
     use super::strings::settings::Quote;
 
@@ -257,6 +258,33 @@ mod tests {
         let diagnostics = test_path(Path::new("style").join(path).as_path(), &settings)?;
         apply_common_filters!();
         assert_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Path::new("my/dir/to/file.f95"))]
+    #[test_case(Path::new("my/dir/to/file"))]
+    fn file_extensions(path: &Path) -> Result<()> {
+        let rule_code = Rule::NonStandardFileExtension;
+        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+
+        let file = SourceFileBuilder::new(path.to_string_lossy(), "").finish();
+        let diagnostics = test_contents(path, &file, &CheckSettings::for_rule(rule_code));
+        apply_common_filters!();
+        assert_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Path::new("my/dir/to/file.f90"); "lowercase f90")]
+    #[test_case(Path::new("my/dir/to/file.F90"); "uppercase F90")]
+    #[test_case(Path::new("my/dir/to/file.pf"); "pfunit")]
+    fn ok_file_extensions(path: &Path) -> Result<()> {
+        let rule_code = Rule::NonStandardFileExtension;
+        let file = SourceFileBuilder::new(path.to_string_lossy(), "").finish();
+        let diagnostics = test_contents(path, &file, &CheckSettings::for_rule(rule_code));
+        assert!(
+            diagnostics.is_empty(),
+            "Test source has no warnings, but some were raised:\n{diagnostics}"
+        );
         Ok(())
     }
 }

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__non-standard-file-extension_my__dir__to__file.f95.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__non-standard-file-extension_my__dir__to__file.f95.snap
@@ -1,0 +1,6 @@
+---
+source: crates/fortitude_linter/src/rules/style/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+my/dir/to/file.f95:1:1: S091 file extension should be '.f90' or '.F90'

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__non-standard-file-extension_my__dir__to__file.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__non-standard-file-extension_my__dir__to__file.snap
@@ -1,0 +1,6 @@
+---
+source: crates/fortitude_linter/src/rules/style/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+my/dir/to/file:1:1: S091 file extension should be '.f90' or '.F90'

--- a/crates/fortitude_linter/src/rules/testing/test_rules.rs
+++ b/crates/fortitude_linter/src/rules/testing/test_rules.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: MIT
 
 /// Fake rules for testing fortitude's behaviour
-use crate::diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use crate::{
+    CheckContext,
+    diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation},
+};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_text_size::{TextRange, TextSize};
@@ -26,7 +29,7 @@ pub const TEST_RULES: &[Rule] = &[
 ];
 
 pub trait TestRule {
-    fn check() -> Option<Diagnostic>;
+    fn check(context: &CheckContext) -> Option<Diagnostic>;
 }
 
 /// ## What it does
@@ -57,8 +60,8 @@ impl Violation for StableTestRule {
 }
 
 impl TestRule for StableTestRule {
-    fn check() -> Option<Diagnostic> {
-        Some(Diagnostic::new(Self {}, TextRange::default()))
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
+        Some(context.create_diagnostic(Self {}, TextRange::default()))
     }
 }
 
@@ -90,11 +93,12 @@ impl Violation for StableTestRuleSafeFix {
 }
 
 impl TestRule for StableTestRuleSafeFix {
-    fn check() -> Option<Diagnostic> {
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
         let comment = "! fix from stable-test-rule-safe-fix\n".to_string();
 
         Some(
-            Diagnostic::new(Self {}, TextRange::default())
+            context
+                .create_diagnostic(Self {}, TextRange::default())
                 .with_fix(Fix::safe_edit(Edit::insertion(comment, TextSize::new(0)))),
         )
     }
@@ -128,10 +132,11 @@ impl Violation for StableTestRuleUnsafeFix {
 }
 
 impl TestRule for StableTestRuleUnsafeFix {
-    fn check() -> Option<Diagnostic> {
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
         let comment = "! fix from stable-test-rule-unsafe-fix\n".to_string();
         Some(
-            Diagnostic::new(Self {}, TextRange::default())
+            context
+                .create_diagnostic(Self {}, TextRange::default())
                 .with_fix(Fix::unsafe_edit(Edit::insertion(comment, TextSize::new(0)))),
         )
     }
@@ -165,12 +170,15 @@ impl Violation for StableTestRuleDisplayOnlyFix {
 }
 
 impl TestRule for StableTestRuleDisplayOnlyFix {
-    fn check() -> Option<Diagnostic> {
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
         let comment = "! fix from stable-test-rule-display-only-fix\n".to_string();
         Some(
-            Diagnostic::new(Self {}, TextRange::default()).with_fix(Fix::display_only_edit(
-                Edit::insertion(comment, TextSize::new(0)),
-            )),
+            context
+                .create_diagnostic(Self {}, TextRange::default())
+                .with_fix(Fix::display_only_edit(Edit::insertion(
+                    comment,
+                    TextSize::new(0),
+                ))),
         )
     }
 }
@@ -203,8 +211,8 @@ impl Violation for PreviewTestRule {
 }
 
 impl TestRule for PreviewTestRule {
-    fn check() -> Option<Diagnostic> {
-        Some(Diagnostic::new(Self {}, TextRange::default()))
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
+        Some(context.create_diagnostic(Self {}, TextRange::default()))
     }
 }
 
@@ -236,8 +244,8 @@ impl Violation for DeprecatedTestRule {
 }
 
 impl TestRule for DeprecatedTestRule {
-    fn check() -> Option<Diagnostic> {
-        Some(Diagnostic::new(Self {}, TextRange::default()))
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
+        Some(context.create_diagnostic(Self {}, TextRange::default()))
     }
 }
 
@@ -269,8 +277,8 @@ impl Violation for AnotherDeprecatedTestRule {
 }
 
 impl TestRule for AnotherDeprecatedTestRule {
-    fn check() -> Option<Diagnostic> {
-        Some(Diagnostic::new(Self {}, TextRange::default()))
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
+        Some(context.create_diagnostic(Self {}, TextRange::default()))
     }
 }
 
@@ -302,8 +310,8 @@ impl Violation for RemovedTestRule {
 }
 
 impl TestRule for RemovedTestRule {
-    fn check() -> Option<Diagnostic> {
-        Some(Diagnostic::new(Self {}, TextRange::default()))
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
+        Some(context.create_diagnostic(Self {}, TextRange::default()))
     }
 }
 
@@ -335,8 +343,8 @@ impl Violation for AnotherRemovedTestRule {
 }
 
 impl TestRule for AnotherRemovedTestRule {
-    fn check() -> Option<Diagnostic> {
-        Some(Diagnostic::new(Self {}, TextRange::default()))
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
+        Some(context.create_diagnostic(Self {}, TextRange::default()))
     }
 }
 
@@ -368,8 +376,8 @@ impl Violation for RedirectedFromTestRule {
 }
 
 impl TestRule for RedirectedFromTestRule {
-    fn check() -> Option<Diagnostic> {
-        Some(Diagnostic::new(Self {}, TextRange::default()))
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
+        Some(context.create_diagnostic(Self {}, TextRange::default()))
     }
 }
 
@@ -401,8 +409,8 @@ impl Violation for RedirectedToTestRule {
 }
 
 impl TestRule for RedirectedToTestRule {
-    fn check() -> Option<Diagnostic> {
-        Some(Diagnostic::new(Self {}, TextRange::default()))
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
+        Some(context.create_diagnostic(Self {}, TextRange::default()))
     }
 }
 
@@ -434,7 +442,7 @@ impl Violation for RedirectedFromPrefixTestRule {
 }
 
 impl TestRule for RedirectedFromPrefixTestRule {
-    fn check() -> Option<Diagnostic> {
-        Some(Diagnostic::new(Self {}, TextRange::default()))
+    fn check(context: &CheckContext) -> Option<Diagnostic> {
+        Some(context.create_diagnostic(Self {}, TextRange::default()))
     }
 }


### PR DESCRIPTION
The `Diagnostic::new` constructor will be changing with the incoming diagnostic changes, and construction through `CheckContext` will simplify things. This commit pulls out those changes to make the next PR smaller