### PR TITLE
[JOSS] Edits for review 1

### DIFF
--- a/docs/editors/index.md
+++ b/docs/editors/index.md
@@ -15,4 +15,4 @@ written in Rust and is available as part of the `fortitude` CLI via `fortitude s
 The server supports surfacing Fortitude diagnostics, providing Code Actions to fix
 them. Currently, the server is intended to be used alongside another Fortran Language
 Server (such as [`fortls`](https://github.com/fortran-lang/fortls/) in order to support
-features like navigation and autocompletion.
+features like navigation and autocompletion).

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -98,8 +98,9 @@ so on.
 
 ## Configuration
 
-We can control Fortitude's behaviour with a configuration file, one of `fpm.toml`,
-`fortitude.toml`, or `.fortitude.toml`. Let's add a new file:
+We can control Fortitude's behaviour with a configuration file, one of
+`fortitude.toml`, `.fortitude.toml`, `fpm.toml`, or `pyproject.toml`. Let's add
+a new file:
 
 
 === "`fpm.toml`"
@@ -114,6 +115,14 @@ We can control Fortitude's behaviour with a configuration file, one of `fpm.toml
 
     ```toml
     [check]
+    # Add check for implicit kinds on real variables
+    extend-select = ["implicit-real-kind"]
+    ```
+
+=== "`pyproject.toml`"
+
+    ```toml
+    [tool.fortitude.check]
     # Add check for implicit kinds on real variables
     extend-select = ["implicit-real-kind"]
     ```
@@ -140,6 +149,7 @@ For more information about specific rules, run:
     fortitude explain X001,Y002,...
 ```
 
+For more information on configuration files, see [_Configuration_](configuration.md).
 For a complete description of supported settings, see [_Settings_](settings.md).
 
 ### Rule Selection

--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -95,7 +95,7 @@
     year = {2026},
     publisher = {Tree-sitter Collaboration},
     journal = {GitHub repository},
-    url = {https://github.com/stadelmanman/tree-sitter-fortran}
+    url = {https://github.com/stadelmanma/tree-sitter-fortran}
 }
 
 @misc{lfric,

--- a/joss/paper.md
+++ b/joss/paper.md
@@ -51,7 +51,7 @@ common style guides, use of outdated features, and, generally, suggestions to
 improve the code in some way.
 
 Fortitude is a linter targeting Fortran, which has hitherto lacked a standard
-open-source solution. It is two orders of magnitude faster than its open-source
+open-source solution. It is over an order of magnitude faster than its open-source
 counterparts, is highly customisable, has robust parsing capabilities, can
 automatically fix many linting issues, and can integrate either into a CI/CD
 pipeline or directly into a user’s editor or IDE.


### PR DESCRIPTION
Closes https://github.com/PlasmaFAIR/fortitude/issues/649

Fixes issues flagged by @fjebaker for our JOSS review (https://github.com/openjournals/joss-reviews/issues/10570):

- Fix missing parenthesis in the docs
- Fix misleading claim of being 'two orders of magnitude faster than our competitors' (we were until some recent rule additions slowed us down a little!)
- Fix author typo for the tree-sitter-fortran reference
- Add `pyproject.toml` to the getting started guide, and link to the configuration page

I didn't add anything to `CONTRIBUTING.md` for building the docs, as on checking I found we already had that information (https://github.com/PlasmaFAIR/fortitude/blob/main/CONTRIBUTING.md#building-docs), but in fairness it's quite easy to miss!