### PR TITLE
Add helpers for handling line continuations in deletions

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/style/S301.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S301.f90
@@ -150,14 +150,13 @@ contains
         end do
     end subroutine fail_8
 
-    ! ** auto-fix not currently implemented **
     ! FAIL X -> line continuation inbetween "do" and "while".
-    ! subroutine fail_X()
-    !    do &
-    !            while (.true.)
-    !        x = x + 1
-    !        if (x > 10) exit
-    !    end do
-    !end subroutine fail_X
+    subroutine fail_X()
+       do &
+               while (.true.)
+           x = x + 1
+           if (x > 10) exit
+       end do
+    end subroutine fail_X
 
 end program test_program_superfluous_while_true

--- a/crates/fortitude_linter/src/ast.rs
+++ b/crates/fortitude_linter/src/ast.rs
@@ -157,6 +157,15 @@ pub trait FortitudeNode<'tree> {
     /// Get the next matching statement label
     fn next_statement_label<S: AsRef<str>>(&self, label: S, src: &str) -> Option<Node<'tree>>;
 
+    /// Get the preceding line continuation, if there is one
+    ///
+    /// Finds the previous *real* line-continuation character, as tree-sitter
+    /// may have inserted an implied one on the continued line
+    fn prev_line_continuation(&self) -> Option<Node<'tree>>;
+
+    /// Get the following line continuation, if there is one
+    fn next_line_continuation(&self) -> Option<Node<'tree>>;
+
     /// Get the module name from a use statement node.
     /// Returns None if the node is not a use statement or has no module_name child.
     fn module_name(&self, src: &str) -> Option<String>;
@@ -396,6 +405,28 @@ impl<'tree1> FortitudeNode<'tree1> for Node<'tree1> {
     fn try_to_controlflow(self, source_file: &SourceFile) -> Option<ControlFlowNode<'tree1>> {
         ControlFlowNode::maybe_from(self, source_file.source_text())
     }
+
+    fn prev_line_continuation(&self) -> Option<Node<'tree1>> {
+        let mut sibling = self.prev_sibling();
+        while let Some(prev_sibling) = sibling {
+            if prev_sibling.kind() == "&" && !prev_sibling.textrange().is_empty() {
+                return Some(prev_sibling);
+            }
+            sibling = prev_sibling.prev_sibling();
+        }
+        None
+    }
+
+    fn next_line_continuation(&self) -> Option<Node<'tree1>> {
+        let mut sibling = self.next_sibling();
+        while let Some(next_sibling) = sibling {
+            if next_sibling.kind() == "&" {
+                return Some(next_sibling);
+            }
+            sibling = next_sibling.next_sibling();
+        }
+        None
+    }
 }
 
 /// Strip line breaks from a string of Fortran code.
@@ -553,7 +584,7 @@ mod tests {
     use super::*;
     use anyhow::{Context, Result};
     use textwrap::dedent;
-    use tree_sitter::Parser;
+    use tree_sitter::{Parser, Point};
 
     #[test]
     fn test_comment_block() -> Result<()> {
@@ -620,6 +651,68 @@ mod tests {
             .child_with_name("module")
             .context("Missing module node")?;
         assert!(module_node.prev_attached_comment_block(&code).is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn prev_line_continuation() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = dedent(
+            r#"
+          program foo
+            do &
+              while (.true.)
+            end do
+          end program foo
+          "#,
+        );
+
+        let tree = parser.parse(&code, None).context("Failed to parse")?;
+        let root = tree.root_node();
+        let node = root
+            .descendants()
+            .find(|node| node.kind() == "while_statement")
+            .context("missing 'while'")?;
+
+        let ampersand = node.prev_line_continuation();
+        assert!(ampersand.is_some());
+        assert_eq!(ampersand.unwrap().start_position(), Point::new(2, 5));
+
+        Ok(())
+    }
+
+    #[test]
+    fn next_line_continuation() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = dedent(
+            r#"
+          program foo
+            do &
+              while (.true.)
+            end do
+          end program foo
+          "#,
+        );
+
+        let tree = parser.parse(&code, None).context("Failed to parse")?;
+        let root = tree.root_node();
+        let node = root
+            .descendants()
+            .find(|node| node.kind() == "do")
+            .context("missing 'do'")?;
+
+        let ampersand = node.next_line_continuation();
+        assert!(ampersand.is_some());
+        assert_eq!(ampersand.unwrap().start_position(), Point::new(2, 5));
 
         Ok(())
     }

--- a/crates/fortitude_linter/src/ast.rs
+++ b/crates/fortitude_linter/src/ast.rs
@@ -1,10 +1,13 @@
 pub mod symbol_table;
 pub mod types;
 
-use crate::diagnostics::Edit;
+use crate::{
+    diagnostics::Edit,
+    whitespace::{has_leading_content, has_trailing_content},
+};
 use anyhow::{Result, anyhow};
 use itertools::Itertools;
-use ruff_source_file::SourceFile;
+use ruff_source_file::{LineRanges, SourceFile};
 use ruff_text_size::{TextRange, TextSize};
 use strum_macros::EnumIs;
 /// Contains methods to parse Fortran code into a tree-sitter Tree and utilities to simplify the
@@ -249,44 +252,30 @@ impl<'tree1> FortitudeNode<'tree1> for Node<'tree1> {
     }
 
     fn indentation(&self, source_file: &SourceFile) -> String {
-        let src = source_file.to_source_code();
-        let start_byte = self.start_textsize();
-        let start_index = src.line_index(start_byte);
-        let start_line = src.line_start(start_index);
-        let start_offset = start_byte - start_line;
-        let line = src
-            .slice(TextRange::new(start_line, start_line + start_offset))
-            .to_string();
+        let src = source_file.source_text();
+        let offset = self.start_textsize();
+        let line_start = src.line_start(offset);
+        let line = &src[TextRange::new(line_start, offset)];
         line.chars().take_while(|&c| c.is_whitespace()).collect()
     }
 
     fn indentation_ignore_stmt_label(&self, source_file: &SourceFile) -> String {
-        let src = source_file.to_source_code();
+        let src = source_file.source_text();
         let start_byte = self.start_textsize();
-        let start_index = src.line_index(start_byte);
-        let start_line = src.line_start(start_index);
+        let start_line = src.line_start(start_byte);
         let width = (start_byte - start_line).to_usize();
         format!("{:width$}", " ")
     }
 
     fn edit_delete(&self, source_file: &SourceFile) -> Edit {
-        // If deletion results in an empty line (or multiple), remove it
-        // TODO handle case where removal should also remove a preceding comma
-        let src = source_file.to_source_code();
-        let start_byte = self.start_textsize();
-        let end_byte = self.end_textsize();
-        let start_index = src.line_index(start_byte);
-        let end_index = src.line_index(end_byte);
-        let start_line = src.line_start(start_index);
-        let end_line = src.line_end(end_index);
-        let mut text = src.slice(TextRange::new(start_line, end_line)).to_string();
-        let start_offset = start_byte - start_line;
-        let end_offset = end_byte - start_line;
-        text.replace_range(usize::from(start_offset)..usize::from(end_offset), "");
-        if text.trim().is_empty() {
-            Edit::range_deletion(TextRange::new(start_line, end_line))
+        let src = source_file.source_text();
+        if has_leading_content(self.start_textsize(), src)
+            || has_trailing_content(self.end_textsize(), src)
+        {
+            Edit::range_deletion(self.textrange())
         } else {
-            Edit::range_deletion(TextRange::new(start_byte, end_byte))
+            // If deletion results in an empty line (or multiple), remove it
+            Edit::range_deletion(src.full_lines_range(self.textrange()))
         }
     }
 

--- a/crates/fortitude_linter/src/fix/edits.rs
+++ b/crates/fortitude_linter/src/fix/edits.rs
@@ -1,11 +1,14 @@
 //! Interface for generating fix edits from higher-level actions (e.g., "remove an argument").
 
-use crate::diagnostics::Edit;
+use crate::{
+    diagnostics::Edit,
+    whitespace::{has_leading_content, has_trailing_content},
+};
 use anyhow::{Result, anyhow};
 use itertools::Itertools;
 use lazy_regex::lazy_regex;
-use ruff_source_file::{LineEnding, SourceFile};
-use ruff_text_size::Ranged;
+use ruff_source_file::{LineEnding, LineRanges, SourceFile};
+use ruff_text_size::{Ranged, TextSize};
 use tree_sitter::Node;
 
 use crate::{
@@ -80,6 +83,82 @@ pub(crate) fn add_attribute_to_var_decl(decl: &VariableDeclaration, attribute: &
 
     let colon = if decl.has_colon() { "" } else { " ::" };
     Edit::insertion(format!(", {attribute}{colon}"), start)
+}
+
+/// Remove part of a statement, handling line continuation characters at the
+/// start of the part correctly
+pub(crate) fn delete_stmt_part(node: &Node, src: &str) -> Vec<Edit> {
+    if let Some(mut start) = node.prev_line_continuation() {
+        // There's a preceding line continuation
+
+        let edit = delete_range(node.textrange().with_start(start.start_textsize()), src);
+
+        // If it's an explicit '&' on the same line, get the one before that
+        if start.start_position().row == node.start_position().row {
+            start = start.prev_line_continuation().expect(
+                "line continuation on continued line should have preceeding continuation character",
+            );
+        }
+
+        if let Some(next) = start.next_named_sibling()
+            && next.kind() == "comment"
+        {
+            // Preserve the comment by separately removing the first `&`
+            vec![delete_from_end_of_prev_node(&start), edit]
+        } else {
+            // Can't use `delete_range` here because it will eat the trailing
+            // newline
+            let end = if !has_trailing_content(node.end_textsize(), src) {
+                src.line_end(node.end_textsize())
+            } else {
+                node.end_textsize()
+            };
+
+            vec![Edit::deletion(start_from_end_of_prev_node(&start), end)]
+        }
+    } else if has_leading_content(node.start_textsize(), src) {
+        // There's something else on the line, so just delete this node
+        vec![delete_from_end_of_prev_node(node)]
+    } else {
+        // Nothing else on the line, we can delete the whole line(s)
+        let range = src.full_lines_range(node.textrange());
+        vec![Edit::range_deletion(range)]
+    }
+}
+
+/// Get the offset starting from the end of the previous node if it exists,
+/// otherwise use the start of this node
+pub(crate) fn start_from_end_of_prev_node(node: &Node) -> TextSize {
+    node.prev_sibling()
+        .map_or(node.start_textsize(), |prev| prev.end_textsize())
+}
+
+/// Create an edit deleting this node starting from the end of the previous node
+/// (if it exists)
+pub(crate) fn delete_from_end_of_prev_node(node: &Node) -> Edit {
+    Edit::deletion(start_from_end_of_prev_node(node), node.end_textsize())
+}
+
+/// Create an edit deleting a range, possibly including removing whitespace at
+/// the start/end of the range
+pub(crate) fn delete_range<T: TextRanged>(range: T, src: &str) -> Edit {
+    let start = range.start_textsize();
+    let end = range.end_textsize();
+
+    let leading = has_leading_content(start, src);
+    let trailing = has_trailing_content(end, src);
+
+    let range = match (leading, trailing) {
+        // Nothing in front or behind, delete the whole line(s)
+        (false, false) => src.full_lines_range(range.textrange()),
+        // Something in front/behind, delete to the beginning/end of the line
+        (true, false) => range.textrange().with_end(src.full_line_end(end)),
+        (false, true) => range.textrange().with_start(src.line_start(start)),
+        // Something in front AND behind, just delete the initial range
+        (true, true) => range.textrange(),
+    };
+
+    Edit::range_deletion(range)
 }
 
 /// Unindent and then indent each line, ignoring under-indented comments and
@@ -184,12 +263,20 @@ pub fn redent(s: &str, indentation: &str, line_ending: LineEnding) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::symbol_table::{SymbolTable, SymbolTables};
+    use crate::{
+        ast::symbol_table::{SymbolTable, SymbolTables},
+        diagnostics::test_diagnostic_builder,
+        fix::apply_fixes,
+        locator::Locator,
+        rules::Rule,
+    };
 
     use super::*;
     use anyhow::{Context, Result};
+    use ruff_diagnostics::Fix;
     use ruff_source_file::SourceFileBuilder;
-    use ruff_text_size::TextSize;
+    use ruff_text_size::{TextRange, TextSize};
+    use test_case::test_case;
     use tree_sitter::Parser;
 
     #[test]
@@ -471,5 +558,62 @@ end program foo
             "      baz",
         ].join("\n");
         assert_eq!(redent(&x, "  ", LineEnding::Lf), y);
+    }
+
+    #[test_case(" while(.true.)", ""; "single line")]
+    #[test_case("&\n  while(.true.)", ""; "implicit continuation")]
+    #[test_case("&\n  & while(.true.)", ""; "explicit continuation")]
+    #[test_case(" &\n  & while(.true.) ", ""; "surrounding whitespace")]
+    #[test_case("& ! comment\n  & while(.true.)", " ! comment"; "comment after continuation")]
+    #[test_case("&\n  & while(.true.) ! comment", " ! comment"; "trailing comment")]
+    #[test_case("& ! first\n  & while(.true.) ! second", " ! first\n ! second"; "two comments")]
+    fn edit_delete(snippet: &str, replacement: &str) -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = &format!(
+            r#"program foo
+  do{snippet}
+  end do
+end program foo"#,
+        );
+
+        let tree = parser.parse(code, None).context("Failed to parse")?;
+        let root = tree.root_node();
+        let node = root
+            .descendants()
+            .find(|node| node.kind() == "while_statement")
+            .context("missing 'while'")?;
+
+        let edits = delete_stmt_part(&node, code);
+
+        let diag = {
+            let mut iter = edits.into_iter();
+            // Choice of rule doesn't matter
+            test_diagnostic_builder(Rule::TrailingWhitespace, "test", TextRange::default())
+                .with_fix(Fix::safe_edits(
+                    iter.next().ok_or(anyhow!("expected edits nonempty"))?,
+                    iter,
+                ))
+        };
+        let locator = Locator::new(code);
+
+        let expected = &format!(
+            r#"program foo
+  do{replacement}
+  end do
+end program foo"#,
+        );
+
+        assert_eq!(
+            apply_fixes([diag].iter(), &locator, "<filename>")
+                .code
+                .source_text(),
+            expected
+        );
+
+        Ok(())
     }
 }

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -26,6 +26,7 @@ pub mod stylist;
 mod test;
 pub mod text_helpers;
 pub mod traits;
+pub mod whitespace;
 
 use allow_comments::{check_allow_comments, gather_allow_comments};
 use ast::FortitudeNode;

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-while-true_S301.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-while-true_S301.f90.snap
@@ -18,7 +18,7 @@ snapshot_kind: text
 86 |     ! FAIL 1 -> standard.
 87 |     subroutine fail_1()
    -         do while (.true.)
-88 +         do 
+88 +         do
 89 |             x = x + 1
 90 |             if (x > 10) exit
 91 |         end do
@@ -38,7 +38,7 @@ snapshot_kind: text
 94 |     ! FAIL 2 -> case insensitive.
 95 |     subroutine fail_2()
    -         do while (.TRUE.)
-96 +         do 
+96 +         do
 97 |             x = x + 1
 98 |             if (x > 10) exit
 99 |         end do
@@ -58,7 +58,7 @@ snapshot_kind: text
 102 |     ! FAIL 3 -> extra whitespace.
 103 |     subroutine fail_3()
     -         do while (  .true.  )
-104 +         do 
+104 +         do
 105 |             x = x + 1
 106 |             if (x > 10) exit
 107 |         end do
@@ -78,7 +78,7 @@ snapshot_kind: text
 110 |     ! FAIL 4 -> do loop name.
 111 |     subroutine fail_4()
     -         a_name: do while (.true.)
-112 +         a_name: do 
+112 +         a_name: do
 113 |             x = x + 1
 114 |             if (x > 10) exit
 115 |         end do a_name
@@ -98,7 +98,7 @@ snapshot_kind: text
 118 |     ! FAIL 5 -> with extra parentheses.
 119 |     subroutine fail_5()
     -         do while ((.true.))
-120 +         do 
+120 +         do
 121 |             x = x + 1
 122 |             if (x > 10) exit
 123 |         end do
@@ -118,7 +118,7 @@ snapshot_kind: text
 126 |     ! FAIL 6 -> with lots of extra parentheses.
 127 |     subroutine fail_6()
     -         do while (((((((.true.)))))))
-128 +         do 
+128 +         do
 129 |             x = x + 1
 130 |             if (x > 10) exit
 131 |         end do
@@ -143,7 +143,7 @@ snapshot_kind: text
     -         do while (&
     -                 .true.&
     -                 )
-136 +         do 
+136 +         do
 137 |             x = x + 1
 138 |             if (x > 10) some_logical = .false.
 139 |         end do
@@ -166,7 +166,28 @@ snapshot_kind: text
 145 |     subroutine fail_8()
     -         do while &
     -                 (.true.)
-146 +         do 
+146 +         do
 147 |             x = x + 1
 148 |             if (x > 10) some_logical = .false.
 149 |         end do
+
+./resources/test/fixtures/style/S301.f90:156:16: S301 [*] Superfluous boolean literal '.true.' in 'do while' statement
+    |
+154 |     subroutine fail_X()
+155 |        do &
+156 |                while (.true.)
+    |                ^^^^^^^^^^^^^^ S301
+157 |            x = x + 1
+158 |            if (x > 10) exit
+    |
+    = help: Remove 'while' statement
+
+152 |
+153 |     ! FAIL X -> line continuation inbetween "do" and "while".
+154 |     subroutine fail_X()
+    -        do &
+    -                while (.true.)
+155 +        do
+156 |            x = x + 1
+157 |            if (x > 10) exit
+158 |        end do

--- a/crates/fortitude_linter/src/rules/style/superfluous_while_true.rs
+++ b/crates/fortitude_linter/src/rules/style/superfluous_while_true.rs
@@ -1,5 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
+use crate::fix::edits::delete_stmt_part;
 use crate::{AstRule, CheckContext};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
@@ -60,7 +61,9 @@ impl AstRule for SuperfluousWhileTrue {
         {
             return None;
         }
-        let fix = Fix::safe_edit(node.edit_delete(context.source_file()));
+        let edits = delete_stmt_part(node, context.source_text());
+        let mut iter = edits.into_iter();
+        let fix = Fix::safe_edits(iter.next().expect("edits should be nonempty"), iter);
         some_vec!(context.create_diagnostic(Self {}, node).with_fix(fix))
     }
 

--- a/crates/fortitude_linter/src/whitespace.rs
+++ b/crates/fortitude_linter/src/whitespace.rs
@@ -1,0 +1,71 @@
+// Adapted from ruff
+// Copyright 2024 Charles Marsh
+// SPDX-License-Identifier: MIT
+
+use ruff_source_file::LineRanges;
+use ruff_text_size::{TextRange, TextSize};
+
+/// Extract the leading indentation from a line.
+pub fn indentation_at_offset(offset: TextSize, source: &str) -> Option<&str> {
+    let line_start = source.line_start(offset);
+    let indentation = &source[TextRange::new(line_start, offset)];
+
+    indentation
+        .chars()
+        .all(is_fortran_whitespace)
+        .then_some(indentation)
+}
+
+/// Return `true` if the node starting the given [`TextSize`] has leading content.
+pub fn has_leading_content(offset: TextSize, source: &str) -> bool {
+    let line_start = source.line_start(offset);
+    let leading = &source[TextRange::new(line_start, offset)];
+    leading.chars().any(|char| !is_fortran_whitespace(char))
+}
+
+/// Return `true` if the node ending at the given [`TextSize`] has trailing
+/// content.
+pub fn has_trailing_content(offset: TextSize, source: &str) -> bool {
+    let line_end = source.line_end(offset);
+    let trailing = &source[TextRange::new(offset, line_end)];
+    trailing.chars().any(|char| !is_fortran_whitespace(char))
+}
+
+/// Returns `true` for Fortran whitespace characters.
+pub const fn is_fortran_whitespace(c: char) -> bool {
+    matches!(c, ' ' | '\t')
+}
+
+/// Extract the leading indentation from a line.
+pub fn leading_indentation(line: &str) -> &str {
+    line.find(|char: char| !is_fortran_whitespace(char))
+        .map_or(line, |index| &line[..index])
+}
+
+pub trait FortranWhitespace {
+    /// Like `str::trim()`, but only removes whitespace characters that Fortran considers
+    /// to be whitespace.
+    fn trim_whitespace(&self) -> &Self;
+
+    /// Like `str::trim_start()`, but only removes whitespace characters that Fortran considers
+    /// to be whitespace.
+    fn trim_whitespace_start(&self) -> &Self;
+
+    /// Like `str::trim_end()`, but only removes whitespace characters that Fortran considers
+    /// to be whitespace.
+    fn trim_whitespace_end(&self) -> &Self;
+}
+
+impl FortranWhitespace for str {
+    fn trim_whitespace(&self) -> &Self {
+        self.trim_matches(is_fortran_whitespace)
+    }
+
+    fn trim_whitespace_start(&self) -> &Self {
+        self.trim_start_matches(is_fortran_whitespace)
+    }
+
+    fn trim_whitespace_end(&self) -> &Self {
+        self.trim_end_matches(is_fortran_whitespace)
+    }
+}


### PR DESCRIPTION
Closes #659 

Adds a new function `delete_stmt_part` for deleting a node that's part of a statement and handling line continuations (and surrounding whitespace) correctly, and uses it in `superfluous-while-true`

I decided not to make this part of `FortitudeNode::edit_delete` to avoid fun with comments.

This also doesn't handle trailing line continuations because I was struggling to come up with an example where we want to delete the first node that isn't handled by `remove_from_comma_sep_stmt`.

Also as a drive-by, simplifies a couple of other methods, because I realised ruff has a trait `LineRanges` for `str` that lets us get the offset of the start of a line just from the `str`