### PR TITLE
Update diff format to match ruff's new style

### DIFF
--- a/crates/fortitude_linter/src/diagnostics/message/diff.rs
+++ b/crates/fortitude_linter/src/diagnostics/message/diff.rs
@@ -10,7 +10,7 @@ use colored::{Color, ColoredString, Colorize, Styles};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use similar::{ChangeTag, TextDiff};
 
-use crate::diagnostics::{Applicability, Fix};
+use crate::diagnostics::Fix;
 use ruff_source_file::{OneIndexed, SourceFile};
 
 use crate::Diagnostic;
@@ -57,22 +57,14 @@ impl Display for Diff<'_> {
 
         let diff = TextDiff::from_lines(self.source_code.source_text(), &output);
 
-        let message = match self.fix.applicability() {
-            // TODO(zanieb): Adjust this messaging once it's user-facing
-            Applicability::Safe => "Safe fix",
-            Applicability::Unsafe => "Unsafe fix",
-            Applicability::DisplayOnly => "Display-only fix",
-        };
-        writeln!(f, "ℹ {}", message.blue())?;
+        let grouped_ops = diff.grouped_ops(3);
 
-        let (largest_old, largest_new) = diff
-            .ops()
-            .last()
-            .map(|op| (op.old_range().start, op.new_range().start))
-            .unwrap_or_default();
+        // Find the new line number with the largest number of digits to align all of the line
+        // number separators.
+        let last_op = grouped_ops.last().and_then(|group| group.last());
+        let largest_new = last_op.map(|op| op.new_range().end).unwrap_or_default();
 
-        let digit_with =
-            calculate_print_width(OneIndexed::from_zero_indexed(largest_new.max(largest_old)));
+        let digit_with = OneIndexed::new(largest_new).unwrap_or_default().digits();
 
         for (idx, group) in diff.grouped_ops(3).iter().enumerate() {
             if idx > 0 {
@@ -80,37 +72,34 @@ impl Display for Diff<'_> {
             }
             for op in group {
                 for change in diff.iter_inline_changes(op) {
-                    let sign = match change.tag() {
-                        ChangeTag::Delete => "-",
-                        ChangeTag::Insert => "+",
-                        ChangeTag::Equal => " ",
+                    let (sign, index) = match change.tag() {
+                        ChangeTag::Delete => ("-", None),
+                        ChangeTag::Insert => ("+", change.new_index()),
+                        ChangeTag::Equal => ("|", change.new_index()),
                     };
 
                     let line_style = LineStyle::from(change.tag());
 
-                    let old_index = change.old_index().map(OneIndexed::from_zero_indexed);
-                    let new_index = change.new_index().map(OneIndexed::from_zero_indexed);
+                    let line = Line {
+                        index: index.map(OneIndexed::from_zero_indexed),
+                        width: digit_with,
+                    };
 
-                    write!(
-                        f,
-                        "{} {} |{}",
-                        Line {
-                            index: old_index,
-                            width: digit_with
-                        },
-                        Line {
-                            index: new_index,
-                            width: digit_with
-                        },
-                        line_style.apply_to(sign).bold()
-                    )?;
+                    write!(f, "{line} {sign}", sign = line_style.apply_to(sign).bold())?;
 
+                    let mut needs_separator = true;
                     for (emphasized, value) in change.iter_strings_lossy() {
+                        if needs_separator && !value.trim_end_matches(['\n', '\r']).is_empty() {
+                            f.write_str(" ")?;
+                            needs_separator = false;
+                        }
+
                         let value = value.show_nonprinting();
+                        let styled = line_style.apply_to(&value);
                         if emphasized {
-                            write!(f, "{}", line_style.apply_to(&value).underline().on_black())?;
+                            write!(f, "{}", styled.underline().on_black())?;
                         } else {
-                            write!(f, "{}", line_style.apply_to(&value))?;
+                            write!(f, "{styled}",)?;
                         }
                     }
                     if change.missing_newline() {

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__implicit-external-procedures_C003.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__implicit-external-procedures_C003.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/correctness/mod.rs
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -12,13 +12,12 @@ snapshot_kind: text
   |
   = help: Add `(external)` to 'implicit none'
 
-ℹ Unsafe fix
-1 1 | module a
-2   |-  implicit none
-  2 |+  implicit none (type, external)
-3 3 | end module a
-4 4 | 
-5 5 | module b
+1 | module a
+  -   implicit none
+2 +   implicit none (type, external)
+3 | end module a
+4 |
+5 | module b
 
 ./resources/test/fixtures/correctness/C003.f90:6:3: C003 [*] 'implicit none' missing 'external'
   |
@@ -29,12 +28,11 @@ snapshot_kind: text
   |
   = help: Add `(external)` to 'implicit none'
 
-ℹ Unsafe fix
-3 3 | end module a
-4 4 | 
-5 5 | module b
-6   |-  implicit none (type)
-  6 |+  implicit none (type, external)
-7 7 | end module b
-8 8 | 
-9 9 | module c
+3 | end module a
+4 |
+5 | module b
+  -   implicit none (type)
+6 +   implicit none (type, external)
+7 | end module b
+8 |
+9 | module c

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__implicit-typing_C001.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__implicit-typing_C001.f90.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/correctness/C001.f90:1:1: C001 [*] module uses implicit typing
   |
@@ -11,12 +12,11 @@ expression: diagnostics
   |
   = help: Insert `implicit none`
 
-ℹ Unsafe fix
-1 1 | module my_module
-  2 |+implicit none
-2 3 |   parameter(N = 1)
-3 4 | end module my_module
-4 5 | 
+1 | module my_module
+2 + implicit none
+3 |   parameter(N = 1)
+4 | end module my_module
+5 |
 
 ./resources/test/fixtures/correctness/C001.f90:5:1: C001 [*] module uses implicit typing
   |
@@ -30,14 +30,13 @@ expression: diagnostics
   |
   = help: Insert `implicit none`
 
-ℹ Unsafe fix
-4 4 | 
-5 5 | module safe_fix
-6 6 |   use, intrinsic :: iso_fortran_env, only: int32
-  7 |+  implicit none
-7 8 |   integer(int32) :: foo
-8 9 | contains
-9 10 |   integer function double(x)
+4  |
+5  | module safe_fix
+6  |   use, intrinsic :: iso_fortran_env, only: int32
+7  +   implicit none
+8  |   integer(int32) :: foo
+9  | contains
+10 |   integer function double(x)
 
 ./resources/test/fixtures/correctness/C001.f90:15:1: C001 [*] program uses implicit typing
    |
@@ -51,14 +50,13 @@ expression: diagnostics
    |
    = help: Insert `implicit none`
 
-ℹ Unsafe fix
-16 16 |   use, intrinsic :: iso_fortran_env, only: int32
-17 17 |   ! Fix should be applied after next line
-18 18 |   use safe_fix
-   19 |+  implicit none
-19 20 |   ! Fix should be applied before this line
-20 21 |   write(*,*) 42
-21 22 | end program my_program
+16 |   use, intrinsic :: iso_fortran_env, only: int32
+17 |   ! Fix should be applied after next line
+18 |   use safe_fix
+19 +   implicit none
+20 |   ! Fix should be applied before this line
+21 |   write(*,*) 42
+22 | end program my_program
 
 ./resources/test/fixtures/correctness/C001.f90:23:1: C001 [*] subroutine uses implicit typing
    |
@@ -71,14 +69,13 @@ expression: diagnostics
    |
    = help: Insert `implicit none`
 
-ℹ Unsafe fix
-21 21 | end program my_program
-22 22 | 
-23 23 | subroutine external_sub(x)
-   24 |+implicit none
-24 25 |   print*, x
-25 26 | end subroutine external_sub
-26 27 | 
+21 | end program my_program
+22 |
+23 | subroutine external_sub(x)
+24 + implicit none
+25 |   print*, x
+26 | end subroutine external_sub
+27 |
 
 ./resources/test/fixtures/correctness/C001.f90:27:1: C001 [*] module uses implicit typing
    |
@@ -92,15 +89,14 @@ expression: diagnostics
    |
    = help: Change to `implicit none (type, external)`
 
-ℹ Unsafe fix
-25 25 | end subroutine external_sub
-26 26 | 
-27 27 | module my_module_external
-28    |-  implicit none (external)
-   28 |+  implicit none (type, external)
-29 29 |   parameter(N = 1)
-30 30 | end module my_module_external
-31 31 | 
+25 | end subroutine external_sub
+26 |
+27 | module my_module_external
+   -   implicit none (external)
+28 +   implicit none (type, external)
+29 |   parameter(N = 1)
+30 | end module my_module_external
+31 |
 
 ./resources/test/fixtures/correctness/C001.f90:32:1: C001 [*] function uses implicit typing
    |
@@ -114,11 +110,10 @@ expression: diagnostics
    |
    = help: Change to `implicit none`
 
-ℹ Unsafe fix
-30 30 | end module my_module_external
-31 31 | 
-32 32 | real function external_func() result(x)
-33    |-  implicit real (a-z)
-   33 |+  implicit none
-34 34 |   x = 3.14
-35 35 | end function external_func
+30 | end module my_module_external
+31 |
+32 | real function external_func() result(x)
+   -   implicit real (a-z)
+33 +   implicit none
+34 |   x = 3.14
+35 | end function external_func

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__interface-implicit-typing_C002.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__interface-implicit-typing_C002.f90.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/correctness/C002.f90:4:5: C002 [*] interface 'function' uses implicit typing
   |
@@ -13,14 +14,13 @@ expression: diagnostics
   |
   = help: Insert `implicit none`
 
-ℹ Unsafe fix
-2 2 |   implicit none
-3 3 |   interface
-4 4 |     integer function myfunc(x)
-  5 |+    implicit none
-5 6 |       integer, intent(in) :: x
-6 7 |     end function myfunc
-7 8 | 
+2 |   implicit none
+3 |   interface
+4 |     integer function myfunc(x)
+5 +     implicit none
+6 |       integer, intent(in) :: x
+7 |     end function myfunc
+8 |
 
 ./resources/test/fixtures/correctness/C002.f90:8:5: C002 [*] interface 'subroutine' uses implicit typing
    |
@@ -34,15 +34,14 @@ expression: diagnostics
    |
    = help: Change to `implicit none (type, external)`
 
-ℹ Unsafe fix
-6  6  |     end function myfunc
-7  7  | 
-8  8  |     subroutine mysub(x)
-9     |-      implicit none (external)
-   9  |+      implicit none (type, external)
-10 10 |       integer, intent(in) :: x
-11 11 |     end subroutine mysub
-12 12 |   end interface
+6  |     end function myfunc
+7  |
+8  |     subroutine mysub(x)
+   -       implicit none (external)
+9  +       implicit none (type, external)
+10 |       integer, intent(in) :: x
+11 |     end subroutine mysub
+12 |   end interface
 
 ./resources/test/fixtures/correctness/C002.f90:18:5: C002 [*] interface 'function' uses implicit typing
    |
@@ -55,15 +54,14 @@ expression: diagnostics
    |
    = help: Change to `implicit none`
 
-ℹ Unsafe fix
-16 16 |   implicit none
-17 17 |   interface
-18 18 |     real function myfunc2(x)
-19    |-      implicit real (a,z)
-   19 |+      implicit none
-20 20 |     end function myfunc2
-21 21 | 
-22 22 |     subroutine mysub2(x)
+16 |   implicit none
+17 |   interface
+18 |     real function myfunc2(x)
+   -       implicit real (a,z)
+19 +       implicit none
+20 |     end function myfunc2
+21 |
+22 |     subroutine mysub2(x)
 
 ./resources/test/fixtures/correctness/C002.f90:22:5: C002 [*] interface 'subroutine' uses implicit typing
    |
@@ -77,11 +75,10 @@ expression: diagnostics
    |
    = help: Insert `implicit none`
 
-ℹ Unsafe fix
-20 20 |     end function myfunc2
-21 21 | 
-22 22 |     subroutine mysub2(x)
-   23 |+    implicit none
-23 24 |       integer, intent(inout) :: x
-24 25 |     end subroutine mysub2
-25 26 |   end interface
+20 |     end function myfunc2
+21 |
+22 |     subroutine mysub2(x)
+23 +     implicit none
+24 |       integer, intent(inout) :: x
+25 |     end subroutine mysub2
+26 |   end interface

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__misleading-inline-if-continuation_C152.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__misleading-inline-if-continuation_C152.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/correctness/mod.rs
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -13,18 +13,17 @@ snapshot_kind: text
    |
    = help: Convert to `if(...) then` block
 
-ℹ Safe fix
-22 22 |       "Hello world!"; end if
-23 23 | 
-24 24 |   ! Raise an error if the body is on a new line.
-25    |-  if (condition) &
-26    |-      print *, "Hello"
-   25 |+  if (condition) then
-   26 |+    print *, "Hello"
-   27 |+  end if
-27 28 |       print *, "World!"
-28 29 | 
-29 30 |   ! Misleading semicolons: the second statement in the body should be placed
+22 |       "Hello world!"; end if
+23 |
+24 |   ! Raise an error if the body is on a new line.
+   -   if (condition) &
+   -       print *, "Hello"
+25 +   if (condition) then
+26 +     print *, "Hello"
+27 +   end if
+28 |       print *, "World!"
+29 |
+30 |   ! Misleading semicolons: the second statement in the body should be placed
 
 ./resources/test/fixtures/correctness/C152.f90:31:3: C152 [*] Line continuation in inline if-statement is misleading
    |
@@ -38,18 +37,17 @@ snapshot_kind: text
    |
    = help: Convert to `if(...) then` block
 
-ℹ Safe fix
-28 28 | 
-29 29 |   ! Misleading semicolons: the second statement in the body should be placed
-30 30 |   ! after the `end if` in the fix.
-31    |-  if (condition) &
-32    |-      print *, "Hello"; print *, "World!"
-   31 |+  if (condition) then
-   32 |+    print *, "Hello"
-   33 |+  end if; print *, "World!"
-33 34 | 
-34 35 |   ! Permit body split across multiple lines.
-35 36 |   if (condition) print *, &
+28 |
+29 |   ! Misleading semicolons: the second statement in the body should be placed
+30 |   ! after the `end if` in the fix.
+   -   if (condition) &
+   -       print *, "Hello"; print *, "World!"
+31 +   if (condition) then
+32 +     print *, "Hello"
+33 +   end if; print *, "World!"
+34 |
+35 |   ! Permit body split across multiple lines.
+36 |   if (condition) print *, &
 
 ./resources/test/fixtures/correctness/C152.f90:47:3: C152 [*] Line continuation in inline if-statement is misleading
    |
@@ -63,18 +61,17 @@ snapshot_kind: text
    |
    = help: Convert to `if(...) then` block
 
-ℹ Safe fix
-45 45 | 
-46 46 |   ! ... but not if the body starts on a new line
-47 47 |   if (condition &
-48    |-      .and. i > 0) &
-49    |-        print *, "Hello world!"
-   48 |+      .and. i > 0) then
-   49 |+    print *, "Hello world!"
-   50 |+  end if
-50 51 | 
-51 52 |   ! Some cases might result in weird indentation.
-52 53 |   do i = 1, 3; if (i == 2) &
+45 |
+46 |   ! ... but not if the body starts on a new line
+47 |   if (condition &
+   -       .and. i > 0) &
+   -         print *, "Hello world!"
+48 +       .and. i > 0) then
+49 +     print *, "Hello world!"
+50 +   end if
+51 |
+52 |   ! Some cases might result in weird indentation.
+53 |   do i = 1, 3; if (i == 2) &
 
 ./resources/test/fixtures/correctness/C152.f90:52:16: C152 [*] Line continuation in inline if-statement is misleading
    |
@@ -88,15 +85,14 @@ snapshot_kind: text
    |
    = help: Convert to `if(...) then` block
 
-ℹ Safe fix
-49 49 |         print *, "Hello world!"
-50 50 | 
-51 51 |   ! Some cases might result in weird indentation.
-52    |-  do i = 1, 3; if (i == 2) &
-53    |-    print *, "foo"; end do
-   52 |+  do i = 1, 3; if (i == 2) then
-   53 |+    print *, "foo"
-   54 |+  end if; end do
-54 55 | 
-55 56 |   ! We don't handle misleading semicolons here.
-56 57 |   if (condition) print *, "foo"; print *, "bar"; &
+49 |         print *, "Hello world!"
+50 |
+51 |   ! Some cases might result in weird indentation.
+   -   do i = 1, 3; if (i == 2) &
+   -     print *, "foo"; end do
+52 +   do i = 1, 3; if (i == 2) then
+53 +     print *, "foo"
+54 +   end if; end do
+55 |
+56 |   ! We don't handle misleading semicolons here.
+57 |   if (condition) print *, "foo"; print *, "bar"; &

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__misleading-inline-if-semicolon_C151.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__misleading-inline-if-semicolon_C151.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/correctness/mod.rs
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,16 +14,15 @@ snapshot_kind: text
   |
   = help: Replace with newline, or convert to `if(...) then` statement
 
-ℹ Safe fix
-3 3 |   logical, parameter :: condition = .false.
-4 4 |   integer :: i
-5 5 | 
-6   |-  if (condition) print *, "Hello"; print *, "World!"
-  6 |+  if (condition) print *, "Hello"
-  7 |+  print *, "World!"
-7 8 | 
-8 9 |   if (condition) print * , &
-9 10 |     "Hello"; print *, "World!"
+3  |   logical, parameter :: condition = .false.
+4  |   integer :: i
+5  |
+   -   if (condition) print *, "Hello"; print *, "World!"
+6  +   if (condition) print *, "Hello"
+7  +   print *, "World!"
+8  |
+9  |   if (condition) print * , &
+10 |     "Hello"; print *, "World!"
 
 ./resources/test/fixtures/correctness/C151.f90:9:12: C151 [*] Semicolon following inline if-statement is misleading
    |
@@ -35,16 +34,15 @@ snapshot_kind: text
    |
    = help: Replace with newline, or convert to `if(...) then` statement
 
-ℹ Safe fix
-6  6  |   if (condition) print *, "Hello"; print *, "World!"
-7  7  | 
-8  8  |   if (condition) print * , &
-9     |-    "Hello"; print *, "World!"
-   9  |+    "Hello"
-   10 |+  print *, "World!"
-10 11 | 
-11 12 |   ! The following is bad practice, but shouldn't trigger
-12 13 |   if (condition) then
+6  |   if (condition) print *, "Hello"; print *, "World!"
+7  |
+8  |   if (condition) print * , &
+   -     "Hello"; print *, "World!"
+9  +     "Hello"
+10 +   print *, "World!"
+11 |
+12 |   ! The following is bad practice, but shouldn't trigger
+13 |   if (condition) then
 
 ./resources/test/fixtures/correctness/C151.f90:35:32: C151 [*] Semicolon following inline if-statement is misleading
    |
@@ -57,16 +55,15 @@ snapshot_kind: text
    |
    = help: Replace with newline, or convert to `if(...) then` statement
 
-ℹ Safe fix
-32 32 |   ! For multiple inline if statements, each should be moved to its own line.
-33 33 |   ! To confirm that the fixes work when combined, see the test
-34 34 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
-35    |-  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
-   35 |+  if (condition) print *, "foo"
-   36 |+  if(.true.) print *, "bar"; if(.false.) print *, "baz";
-36 37 | 
-37 38 |   ! The indentation will get a little weird in some cases:
-38 39 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
+32 |   ! For multiple inline if statements, each should be moved to its own line.
+33 |   ! To confirm that the fixes work when combined, see the test
+34 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+   -   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+35 +   if (condition) print *, "foo"
+36 +   if(.true.) print *, "bar"; if(.false.) print *, "baz";
+37 |
+38 |   ! The indentation will get a little weird in some cases:
+39 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
 
 ./resources/test/fixtures/correctness/C151.f90:35:59: C151 [*] Semicolon following inline if-statement is misleading
    |
@@ -79,16 +76,15 @@ snapshot_kind: text
    |
    = help: Replace with newline, or convert to `if(...) then` statement
 
-ℹ Safe fix
-32 32 |   ! For multiple inline if statements, each should be moved to its own line.
-33 33 |   ! To confirm that the fixes work when combined, see the test
-34 34 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
-35    |-  if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
-   35 |+  if (condition) print *, "foo"; if(.true.) print *, "bar"
-   36 |+  if(.false.) print *, "baz";
-36 37 | 
-37 38 |   ! The indentation will get a little weird in some cases:
-38 39 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
+32 |   ! For multiple inline if statements, each should be moved to its own line.
+33 |   ! To confirm that the fixes work when combined, see the test
+34 |   ! `c151_fix_multiple_inline_if` in `rules/correctness/mod.rs`
+   -   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+35 +   if (condition) print *, "foo"; if(.true.) print *, "bar"
+36 +   if(.false.) print *, "baz";
+37 |
+38 |   ! The indentation will get a little weird in some cases:
+39 |   do i = 1, 3; if (i == 2) print *, "foo"; end do
 
 ./resources/test/fixtures/correctness/C151.f90:38:42: C151 [*] Semicolon following inline if-statement is misleading
    |
@@ -99,11 +95,10 @@ snapshot_kind: text
    |
    = help: Replace with newline, or convert to `if(...) then` statement
 
-ℹ Safe fix
-35 35 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
-36 36 | 
-37 37 |   ! The indentation will get a little weird in some cases:
-38    |-  do i = 1, 3; if (i == 2) print *, "foo"; end do
-   38 |+  do i = 1, 3; if (i == 2) print *, "foo"
-   39 |+  end do
-39 40 | end program p
+35 |   if (condition) print *, "foo"; if(.true.) print *, "bar"; if(.false.) print *, "baz";
+36 |
+37 |   ! The indentation will get a little weird in some cases:
+   -   do i = 1, 3; if (i == 2) print *, "foo"; end do
+38 +   do i = 1, 3; if (i == 2) print *, "foo"
+39 +   end do
+40 | end program p

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-default-pointer-initalisation_C101.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-default-pointer-initalisation_C101.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/correctness/mod.rs
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,15 +14,14 @@ snapshot_kind: text
    |
    = help: Associate to a known value, such as 'null()'
 
-ℹ Unsafe fix
-13 13 | 
-14 14 |         integer :: i1, i2, i3
-15 15 | 
-16    |-        real(kind=real64), pointer :: pReal1
-   16 |+        real(kind=real64), pointer :: pReal1 => null()
-17 17 | 
-18 18 |         integer, pointer :: pInt1 => null()
-19 19 | 
+13 |
+14 |         integer :: i1, i2, i3
+15 |
+   -         real(kind=real64), pointer :: pReal1
+16 +         real(kind=real64), pointer :: pReal1 => null()
+17 |
+18 |         integer, pointer :: pInt1 => null()
+19 |
 
 ./resources/test/fixtures/correctness/C101.f90:20:29: C101 [*] pointer component 'pI1' does not have a default initialiser
    |
@@ -35,15 +34,14 @@ snapshot_kind: text
    |
    = help: Associate to a known value, such as 'null()'
 
-ℹ Unsafe fix
-17 17 | 
-18 18 |         integer, pointer :: pInt1 => null()
-19 19 | 
-20    |-        integer, pointer :: pI1, pI2
-   20 |+        integer, pointer :: pI1 => null(), pI2
-21 21 | 
-22 22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
-23 23 | 
+17 |
+18 |         integer, pointer :: pInt1 => null()
+19 |
+   -         integer, pointer :: pI1, pI2
+20 +         integer, pointer :: pI1 => null(), pI2
+21 |
+22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
+23 |
 
 ./resources/test/fixtures/correctness/C101.f90:20:34: C101 [*] pointer component 'pI2' does not have a default initialiser
    |
@@ -56,15 +54,14 @@ snapshot_kind: text
    |
    = help: Associate to a known value, such as 'null()'
 
-ℹ Unsafe fix
-17 17 | 
-18 18 |         integer, pointer :: pInt1 => null()
-19 19 | 
-20    |-        integer, pointer :: pI1, pI2
-   20 |+        integer, pointer :: pI1, pI2 => null()
-21 21 | 
-22 22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
-23 23 | 
+17 |
+18 |         integer, pointer :: pInt1 => null()
+19 |
+   -         integer, pointer :: pI1, pI2
+20 +         integer, pointer :: pI1, pI2 => null()
+21 |
+22 |         integer(kind=int32), pointer :: pI3 => null(), pI4
+23 |
 
 ./resources/test/fixtures/correctness/C101.f90:22:56: C101 [*] pointer component 'pI4' does not have a default initialiser
    |
@@ -77,12 +74,11 @@ snapshot_kind: text
    |
    = help: Associate to a known value, such as 'null()'
 
-ℹ Unsafe fix
-19 19 | 
-20 20 |         integer, pointer :: pI1, pI2
-21 21 | 
-22    |-        integer(kind=int32), pointer :: pI3 => null(), pI4
-   22 |+        integer(kind=int32), pointer :: pI3 => null(), pI4 => null()
-23 23 | 
-24 24 |         type(other), pointer :: pVal4 => null()
-25 25 |     end type mytype
+19 |
+20 |         integer, pointer :: pI1, pI2
+21 |
+   -         integer(kind=int32), pointer :: pI3 => null(), pI4
+22 +         integer(kind=int32), pointer :: pI3 => null(), pI4 => null()
+23 |
+24 |         type(other), pointer :: pVal4 => null()
+25 |     end type mytype

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-end-label_C143.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-end-label_C143.f90.snap
@@ -13,15 +13,14 @@ snapshot_kind: text
    |
    = help: Add label 'label1'
 
-ℹ Safe fix
-6  6  |   type(team_type) :: parent
-7  7  | 
-8  8  |   label1: associate(x => 1 + 1)
-9     |-  end associate
-   9  |+  end associate label1
-10 10 | 
-11 11 |   label2: block
-12 12 |   end block
+6  |   type(team_type) :: parent
+7  |
+8  |   label1: associate(x => 1 + 1)
+   -   end associate
+9  +   end associate label1
+10 |
+11 |   label2: block
+12 |   end block
 
 ./resources/test/fixtures/correctness/C143.f90:15:3: C143 [*] 'end critical' statement in named 'critical' block missing label
    |
@@ -33,15 +32,14 @@ snapshot_kind: text
    |
    = help: Add label 'label3'
 
-ℹ Safe fix
-12 12 |   end block
-13 13 | 
-14 14 |   label3: critical
-15    |-  end critical
-   15 |+  end critical label3
-16 16 | 
-17 17 |   form team(1, parent)
-18 18 |   label4: change team(parent)
+12 |   end block
+13 |
+14 |   label3: critical
+   -   end critical
+15 +   end critical label3
+16 |
+17 |   form team(1, parent)
+18 |   label4: change team(parent)
 
 ./resources/test/fixtures/correctness/C143.f90:19:3: C143 [*] 'end team' statement in named 'change team' block missing label
    |
@@ -54,15 +52,14 @@ snapshot_kind: text
    |
    = help: Add label 'label4'
 
-ℹ Safe fix
-16 16 | 
-17 17 |   form team(1, parent)
-18 18 |   label4: change team(parent)
-19    |-  end team
-   19 |+  end team label4
-20 20 | 
-21 21 |   label5: do i = 1, 10
-22 22 |   end do
+16 |
+17 |   form team(1, parent)
+18 |   label4: change team(parent)
+   -   end team
+19 +   end team label4
+20 |
+21 |   label5: do i = 1, 10
+22 |   end do
 
 ./resources/test/fixtures/correctness/C143.f90:22:3: C143 [*] 'end do' statement in named 'do' block missing label
    |
@@ -74,15 +71,14 @@ snapshot_kind: text
    |
    = help: Add label 'label5'
 
-ℹ Safe fix
-19 19 |   end team
-20 20 | 
-21 21 |   label5: do i = 1, 10
-22    |-  end do
-   22 |+  end do label5
-23 23 | 
-24 24 |   label6: forall(i=1:3)
-25 25 |   end forall
+19 |   end team
+20 |
+21 |   label5: do i = 1, 10
+   -   end do
+22 +   end do label5
+23 |
+24 |   label6: forall(i=1:3)
+25 |   end forall
 
 ./resources/test/fixtures/correctness/C143.f90:25:3: C143 [*] 'end forall' statement in named 'forall' block missing label
    |
@@ -94,15 +90,14 @@ snapshot_kind: text
    |
    = help: Add label 'label6'
 
-ℹ Safe fix
-22 22 |   end do
-23 23 | 
-24 24 |   label6: forall(i=1:3)
-25    |-  end forall
-   25 |+  end forall label6
-26 26 | 
-27 27 |   label7: if (.true.) then
-28 28 |   end if
+22 |   end do
+23 |
+24 |   label6: forall(i=1:3)
+   -   end forall
+25 +   end forall label6
+26 |
+27 |   label7: if (.true.) then
+28 |   end if
 
 ./resources/test/fixtures/correctness/C143.f90:28:3: C143 [*] 'end if' statement in named 'if' block missing label
    |
@@ -114,15 +109,14 @@ snapshot_kind: text
    |
    = help: Add label 'label7'
 
-ℹ Safe fix
-25 25 |   end forall
-26 26 | 
-27 27 |   label7: if (.true.) then
-28    |-  end if
-   28 |+  end if label7
-29 29 | 
-30 30 |   label8: select case(i)
-31 31 |   end select
+25 |   end forall
+26 |
+27 |   label7: if (.true.) then
+   -   end if
+28 +   end if label7
+29 |
+30 |   label8: select case(i)
+31 |   end select
 
 ./resources/test/fixtures/correctness/C143.f90:31:3: C143 [*] 'end select' statement in named 'select case' block missing label
    |
@@ -134,15 +128,14 @@ snapshot_kind: text
    |
    = help: Add label 'label8'
 
-ℹ Safe fix
-28 28 |   end if
-29 29 | 
-30 30 |   label8: select case(i)
-31    |-  end select
-   31 |+  end select label8
-32 32 | 
-33 33 |   label9: select rank(i)
-34 34 |   end select
+28 |   end if
+29 |
+30 |   label8: select case(i)
+   -   end select
+31 +   end select label8
+32 |
+33 |   label9: select rank(i)
+34 |   end select
 
 ./resources/test/fixtures/correctness/C143.f90:34:3: C143 [*] 'end select' statement in named 'select rank' block missing label
    |
@@ -154,15 +147,14 @@ snapshot_kind: text
    |
    = help: Add label 'label9'
 
-ℹ Safe fix
-31 31 |   end select
-32 32 | 
-33 33 |   label9: select rank(i)
-34    |-  end select
-   34 |+  end select label9
-35 35 | 
-36 36 |   label10: select type(i)
-37 37 |   end select
+31 |   end select
+32 |
+33 |   label9: select rank(i)
+   -   end select
+34 +   end select label9
+35 |
+36 |   label10: select type(i)
+37 |   end select
 
 ./resources/test/fixtures/correctness/C143.f90:37:3: C143 [*] 'end select' statement in named 'select type' block missing label
    |
@@ -174,15 +166,14 @@ snapshot_kind: text
    |
    = help: Add label 'label10'
 
-ℹ Safe fix
-34 34 |   end select
-35 35 | 
-36 36 |   label10: select type(i)
-37    |-  end select
-   37 |+  end select label10
-38 38 | 
-39 39 |   label11: where(i > 0)
-40 40 |   end where
+34 |   end select
+35 |
+36 |   label10: select type(i)
+   -   end select
+37 +   end select label10
+38 |
+39 |   label11: where(i > 0)
+40 |   end where
 
 ./resources/test/fixtures/correctness/C143.f90:40:3: C143 [*] 'end where' statement in named 'where' block missing label
    |
@@ -194,12 +185,11 @@ snapshot_kind: text
    |
    = help: Add label 'label11'
 
-ℹ Safe fix
-37 37 |   end select
-38 38 | 
-39 39 |   label11: where(i > 0)
-40    |-  end where
-   40 |+  end where label11
-41 41 |   
-42 42 |   label_yes1: associate(x => 1 + 1)
-43 43 |   end associate label_yes1
+37 |   end select
+38 |
+39 |   label11: where(i > 0)
+   -   end where
+40 +   end where label11
+41 |   
+42 |   label_yes1: associate(x => 1 + 1)
+43 |   end associate label_yes1

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-exit-or-cycle-label_C141.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-exit-or-cycle-label_C141.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/correctness/mod.rs
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,15 +14,14 @@ snapshot_kind: text
   |
   = help: Add label 'label1'
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   label1: do
-3 3 |     if (.true.) then
-4   |-      EXIT
-  4 |+      EXIT label1
-5 5 |     end if
-6 6 |   end do label1
-7 7 | 
+1 | program test
+2 |   label1: do
+3 |     if (.true.) then
+  -       EXIT
+4 +       EXIT label1
+5 |     end if
+6 |   end do label1
+7 |
 
 ./resources/test/fixtures/correctness/C141.f90:9:17: C141 [*] 'exit' statement in named 'do' loop missing label 'label2'
    |
@@ -33,15 +32,14 @@ snapshot_kind: text
    |
    = help: Add label 'label2'
 
-ℹ Unsafe fix
-6  6  |   end do label1
-7  7  | 
-8  8  |   label2: do
-9     |-    if (.true.) exit
-   9  |+    if (.true.) exit label2
-10 10 |   end do label2
-11 11 | 
-12 12 |   label3: do
+6  |   end do label1
+7  |
+8  |   label2: do
+   -     if (.true.) exit
+9  +     if (.true.) exit label2
+10 |   end do label2
+11 |
+12 |   label3: do
 
 ./resources/test/fixtures/correctness/C141.f90:28:19: C141 [*] 'cycle' statement in named 'do' loop missing label 'inner'
    |
@@ -54,12 +52,11 @@ snapshot_kind: text
    |
    = help: Add label 'inner'
 
-ℹ Unsafe fix
-25 25 | 
-26 26 |   label6: do i = 1, 2
-27 27 |     inner: do j = 1, 2
-28    |-      if (.true.) CYCLE ! named inner loop: warns on inner loop
-   28 |+      if (.true.) CYCLE inner ! named inner loop: warns on inner loop
-29 29 |     end do inner
-30 30 |   end do label6
-31 31 |
+25 |
+26 |   label6: do i = 1, 2
+27 |     inner: do j = 1, 2
+   -       if (.true.) CYCLE ! named inner loop: warns on inner loop
+28 +       if (.true.) CYCLE inner ! named inner loop: warns on inner loop
+29 |     end do inner
+30 |   end do label6
+31 |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-intrinsic_C122.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-intrinsic_C122.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/correctness/mod.rs
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -13,13 +13,12 @@ snapshot_kind: text
   |
   = help: Add 'intrinsic'
 
-ℹ Unsafe fix
-1 1 | module my_module
-2   |-    use iso_fortran_env
-  2 |+    use, intrinsic :: iso_fortran_env
-3 3 |     use my_other_module
-4 4 |     use :: iso_fortran_env, only: real32
-5 5 |     use, intrinsic :: iso_c_binding
+1 | module my_module
+  -     use iso_fortran_env
+2 +     use, intrinsic :: iso_fortran_env
+3 |     use my_other_module
+4 |     use :: iso_fortran_env, only: real32
+5 |     use, intrinsic :: iso_c_binding
 
 ./resources/test/fixtures/correctness/C122.f90:4:5: C122 [*] 'use' for intrinsic module missing 'intrinsic' modifier
   |
@@ -32,12 +31,11 @@ snapshot_kind: text
   |
   = help: Add 'intrinsic'
 
-ℹ Unsafe fix
-1 1 | module my_module
-2 2 |     use iso_fortran_env
-3 3 |     use my_other_module
-4   |-    use :: iso_fortran_env, only: real32
-  4 |+    use, intrinsic :: iso_fortran_env, only: real32
-5 5 |     use, intrinsic :: iso_c_binding
-6 6 |     use, non_intrinsic :: iso_c_binding
-7 7 |     use :: my_other_module
+1 | module my_module
+2 |     use iso_fortran_env
+3 |     use my_other_module
+  -     use :: iso_fortran_env, only: real32
+4 +     use, intrinsic :: iso_fortran_env, only: real32
+5 |     use, intrinsic :: iso_c_binding
+6 |     use, non_intrinsic :: iso_c_binding
+7 |     use :: my_other_module

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__split-escaped-quote_C171.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__split-escaped-quote_C171.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/correctness/mod.rs
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -16,16 +16,15 @@ snapshot_kind: text
   |
   = help: remove escaped quote
 
-ℹ Safe fix
-1 1 | program test
-2 2 |   implicit none (type, external)
-3   |-  print*, "this looks like implicit "&
-4   |-       &"concatenation but isn't"
-  3 |+  print*, "this looks like implicit &
-  4 |+       &concatenation but isn't"
-5 5 |   print*, "this looks like implicit "&  
-6 6 |        "concatenation but isn't"
-7 7 |   print*, 'this looks like implicit '&
+1 | program test
+2 |   implicit none (type, external)
+  -   print*, "this looks like implicit "&
+  -        &"concatenation but isn't"
+3 +   print*, "this looks like implicit &
+4 +        &concatenation but isn't"
+5 |   print*, "this looks like implicit "&  
+6 |        "concatenation but isn't"
+7 |   print*, 'this looks like implicit '&
 
 ./resources/test/fixtures/correctness/C171.f90:5:37: C171 [*] line continuation in split escaped quote looks like implicit concatenation
   |
@@ -40,17 +39,16 @@ snapshot_kind: text
   |
   = help: remove escaped quote
 
-ℹ Safe fix
-2 2 |   implicit none (type, external)
-3 3 |   print*, "this looks like implicit "&
-4 4 |        &"concatenation but isn't"
-5   |-  print*, "this looks like implicit "&  
-6   |-       "concatenation but isn't"
-  5 |+  print*, "this looks like implicit &  
-  6 |+       concatenation but isn't"
-7 7 |   print*, 'this looks like implicit '&
-8 8 |        &'concatenation but isn''t'
-9 9 |   print*, 'this looks like implicit '&
+2 |   implicit none (type, external)
+3 |   print*, "this looks like implicit "&
+4 |        &"concatenation but isn't"
+  -   print*, "this looks like implicit "&  
+  -        "concatenation but isn't"
+5 +   print*, "this looks like implicit &  
+6 +        concatenation but isn't"
+7 |   print*, 'this looks like implicit '&
+8 |        &'concatenation but isn''t'
+9 |   print*, 'this looks like implicit '&
 
 ./resources/test/fixtures/correctness/C171.f90:7:37: C171 [*] line continuation in split escaped quote looks like implicit concatenation
    |
@@ -65,17 +63,16 @@ snapshot_kind: text
    |
    = help: remove escaped quote
 
-ℹ Safe fix
-4 4 |        &"concatenation but isn't"
-5 5 |   print*, "this looks like implicit "&  
-6 6 |        "concatenation but isn't"
-7   |-  print*, 'this looks like implicit '&
-8   |-       &'concatenation but isn''t'
-  7 |+  print*, 'this looks like implicit &
-  8 |+       &concatenation but isn''t'
-9 9 |   print*, 'this looks like implicit '&
-10 10 |        'concatenation but isn''t'
-11 11 |   print*, "this explicit concatenation "&
+4  |        &"concatenation but isn't"
+5  |   print*, "this looks like implicit "&  
+6  |        "concatenation but isn't"
+   -   print*, 'this looks like implicit '&
+   -        &'concatenation but isn''t'
+7  +   print*, 'this looks like implicit &
+8  +        &concatenation but isn''t'
+9  |   print*, 'this looks like implicit '&
+10 |        'concatenation but isn''t'
+11 |   print*, "this explicit concatenation "&
 
 ./resources/test/fixtures/correctness/C171.f90:9:37: C171 [*] line continuation in split escaped quote looks like implicit concatenation
    |
@@ -90,14 +87,13 @@ snapshot_kind: text
    |
    = help: remove escaped quote
 
-ℹ Safe fix
-6  6  |        "concatenation but isn't"
-7  7  |   print*, 'this looks like implicit '&
-8  8  |        &'concatenation but isn''t'
-9     |-  print*, 'this looks like implicit '&
-10    |-       'concatenation but isn''t'
-   9  |+  print*, 'this looks like implicit &
-   10 |+       concatenation but isn''t'
-11 11 |   print*, "this explicit concatenation "&
-12 12 |        // "is intended"
-13 13 |   print*, 'this explicit concatenation '&
+6  |        "concatenation but isn't"
+7  |   print*, 'this looks like implicit '&
+8  |        &'concatenation but isn''t'
+   -   print*, 'this looks like implicit '&
+   -        'concatenation but isn''t'
+9  +   print*, 'this looks like implicit &
+10 +        concatenation but isn''t'
+11 |   print*, "this explicit concatenation "&
+12 |        // "is intended"
+13 |   print*, 'this explicit concatenation '&

--- a/crates/fortitude_linter/src/rules/fortitude/snapshots/fortitude_linter__rules__fortitude__tests__disabled-allow-comment_FORT005.f90.snap
+++ b/crates/fortitude_linter/src/rules/fortitude/snapshots/fortitude_linter__rules__fortitude__tests__disabled-allow-comment_FORT005.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/fortitude/mod.rs
+source: crates/fortitude_linter/src/rules/fortitude/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -12,8 +12,7 @@ snapshot_kind: text
   |
   = help: Remove disabled allow comment
 
-ℹ Safe fix
-1   |-! allow(unnamed-end-statement)
-2 1 | program foo
-3 2 |   implicit none
-4 3 | end program foo
+  - ! allow(unnamed-end-statement)
+1 | program foo
+2 |   implicit none
+3 | end program foo

--- a/crates/fortitude_linter/src/rules/fortitude/snapshots/fortitude_linter__rules__fortitude__tests__duplicated-allow-comment_FORT004.f90.snap
+++ b/crates/fortitude_linter/src/rules/fortitude/snapshots/fortitude_linter__rules__fortitude__tests__duplicated-allow-comment_FORT004.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/fortitude/mod.rs
+source: crates/fortitude_linter/src/rules/fortitude/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -12,8 +12,7 @@ snapshot_kind: text
   |
   = help: Remove duplicated allow comment
 
-ℹ Safe fix
-1   |-! allow(implicit-typing, implicit-typing)
-  1 |+! allow(implicit-typing)
-2 2 | program foo
-3 3 | end program foo
+  - ! allow(implicit-typing, implicit-typing)
+1 + ! allow(implicit-typing)
+2 | program foo
+3 | end program foo

--- a/crates/fortitude_linter/src/rules/fortitude/snapshots/fortitude_linter__rules__fortitude__tests__invalid-rule-code-or-name_FORT001.f90.snap
+++ b/crates/fortitude_linter/src/rules/fortitude/snapshots/fortitude_linter__rules__fortitude__tests__invalid-rule-code-or-name_FORT001.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/fortitude/mod.rs
+source: crates/fortitude_linter/src/rules/fortitude/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -11,11 +11,10 @@ snapshot_kind: text
 3 | end program test
   |
 
-ℹ Safe fix
-1   |-! allow(badbad, notgood, implicit-typing)
-  1 |+! allow(badbad, implicit-typing)
-2 2 | program test
-3 3 | end program test
+  - ! allow(badbad, notgood, implicit-typing)
+1 + ! allow(badbad, implicit-typing)
+2 | program test
+3 | end program test
 
 ./resources/test/fixtures/fortitude/FORT001.f90:1:9: FORT001 [*] Unknown rule or code `badbad` in allow comment
   |
@@ -25,8 +24,7 @@ snapshot_kind: text
 3 | end program test
   |
 
-ℹ Safe fix
-1   |-! allow(badbad, notgood, implicit-typing)
-  1 |+! allow(notgood, implicit-typing)
-2 2 | program test
-3 3 | end program test
+  - ! allow(badbad, notgood, implicit-typing)
+1 + ! allow(notgood, implicit-typing)
+2 | program test
+3 | end program test

--- a/crates/fortitude_linter/src/rules/fortitude/snapshots/fortitude_linter__rules__fortitude__tests__redirected-allow-comment_FORT003.f90.snap
+++ b/crates/fortitude_linter/src/rules/fortitude/snapshots/fortitude_linter__rules__fortitude__tests__redirected-allow-comment_FORT003.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/fortitude/mod.rs
+source: crates/fortitude_linter/src/rules/fortitude/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -12,8 +12,7 @@ snapshot_kind: text
   |
   = help: Replace with `C001` or `implicit-typing`
 
-ℹ Safe fix
-1   |-! allow(T001)
-  1 |+! allow(implicit-typing)
-2 2 | program foo
-3 3 | end program foo
+  - ! allow(T001)
+1 + ! allow(implicit-typing)
+2 | program foo
+3 | end program foo

--- a/crates/fortitude_linter/src/rules/fortitude/snapshots/fortitude_linter__rules__fortitude__tests__unused-allow-comment_FORT002.f90.snap
+++ b/crates/fortitude_linter/src/rules/fortitude/snapshots/fortitude_linter__rules__fortitude__tests__unused-allow-comment_FORT002.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/fortitude/mod.rs
+source: crates/fortitude_linter/src/rules/fortitude/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -12,8 +12,7 @@ snapshot_kind: text
   |
   = help: Remove unused allow comment
 
-ℹ Safe fix
-1   |-! allow(implicit-typing)
-2 1 | program foo
-3 2 |   implicit none
-4 3 | end program foo
+  - ! allow(implicit-typing)
+1 | program foo
+2 |   implicit none
+3 | end program foo

--- a/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__deprecated-relational-operator_MOD021.f90.snap
+++ b/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__deprecated-relational-operator_MOD021.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/modernisation/mod.rs
+source: crates/fortitude_linter/src/rules/modernisation/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -13,13 +13,12 @@ snapshot_kind: text
   |
   = help: Use '>'
 
-ℹ Safe fix
-1 1 | program test
-2   |-  if (0 .gt. 1) error stop
-  2 |+  if (0 > 1) error stop
-3 3 |   if (1 .le. 0) error stop
-4 4 |   if (a.eq.b.and.a.ne.b) error stop
-5 5 |   if (1 == 2) error stop  ! OK
+1 | program test
+  -   if (0 .gt. 1) error stop
+2 +   if (0 > 1) error stop
+3 |   if (1 .le. 0) error stop
+4 |   if (a.eq.b.and.a.ne.b) error stop
+5 |   if (1 == 2) error stop  ! OK
 
 ./resources/test/fixtures/modernisation/MOD021.f90:3:9: MOD021 [*] deprecated relational operator '.le.', prefer '<=' instead
   |
@@ -32,14 +31,13 @@ snapshot_kind: text
   |
   = help: Use '<='
 
-ℹ Safe fix
-1 1 | program test
-2 2 |   if (0 .gt. 1) error stop
-3   |-  if (1 .le. 0) error stop
-  3 |+  if (1 <= 0) error stop
-4 4 |   if (a.eq.b.and.a.ne.b) error stop
-5 5 |   if (1 == 2) error stop  ! OK
-6 6 |   if (2 /= 2) error stop  ! OK
+1 | program test
+2 |   if (0 .gt. 1) error stop
+  -   if (1 .le. 0) error stop
+3 +   if (1 <= 0) error stop
+4 |   if (a.eq.b.and.a.ne.b) error stop
+5 |   if (1 == 2) error stop  ! OK
+6 |   if (2 /= 2) error stop  ! OK
 
 ./resources/test/fixtures/modernisation/MOD021.f90:4:8: MOD021 [*] deprecated relational operator '.eq.', prefer '==' instead
   |
@@ -52,15 +50,14 @@ snapshot_kind: text
   |
   = help: Use '=='
 
-ℹ Safe fix
-1 1 | program test
-2 2 |   if (0 .gt. 1) error stop
-3 3 |   if (1 .le. 0) error stop
-4   |-  if (a.eq.b.and.a.ne.b) error stop
-  4 |+  if (a==b.and.a.ne.b) error stop
-5 5 |   if (1 == 2) error stop  ! OK
-6 6 |   if (2 /= 2) error stop  ! OK
-7 7 | end program test
+1 | program test
+2 |   if (0 .gt. 1) error stop
+3 |   if (1 .le. 0) error stop
+  -   if (a.eq.b.and.a.ne.b) error stop
+4 +   if (a==b.and.a.ne.b) error stop
+5 |   if (1 == 2) error stop  ! OK
+6 |   if (2 /= 2) error stop  ! OK
+7 | end program test
 
 ./resources/test/fixtures/modernisation/MOD021.f90:4:19: MOD021 [*] deprecated relational operator '.ne.', prefer '/=' instead
   |
@@ -73,12 +70,11 @@ snapshot_kind: text
   |
   = help: Use '/='
 
-ℹ Safe fix
-1 1 | program test
-2 2 |   if (0 .gt. 1) error stop
-3 3 |   if (1 .le. 0) error stop
-4   |-  if (a.eq.b.and.a.ne.b) error stop
-  4 |+  if (a.eq.b.and.a/=b) error stop
-5 5 |   if (1 == 2) error stop  ! OK
-6 6 |   if (2 /= 2) error stop  ! OK
-7 7 | end program test
+1 | program test
+2 |   if (0 .gt. 1) error stop
+3 |   if (1 .le. 0) error stop
+  -   if (a.eq.b.and.a.ne.b) error stop
+4 +   if (a.eq.b.and.a/=b) error stop
+5 |   if (1 == 2) error stop  ! OK
+6 |   if (2 /= 2) error stop  ! OK
+7 | end program test

--- a/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__old-style-array-literal_MOD011.f90.snap
+++ b/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__old-style-array-literal_MOD011.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/modernisation/mod.rs
+source: crates/fortitude_linter/src/rules/modernisation/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -13,13 +13,12 @@ snapshot_kind: text
   |
   = help: Change `(/.../)` to `[...]`
 
-ℹ Safe fix
-1 1 | program test
-2   |-  integer :: a(3) = (/1, 2, 3/)
-  2 |+  integer :: a(3) = [1, 2, 3]
-3 3 |   integer :: b(3) = (/ &
-4 4 |        1, &
-5 5 |        2, &
+1 | program test
+  -   integer :: a(3) = (/1, 2, 3/)
+2 +   integer :: a(3) = [1, 2, 3]
+3 |   integer :: b(3) = (/ &
+4 |        1, &
+5 |        2, &
 
 ./resources/test/fixtures/modernisation/MOD011.f90:3:21: MOD011 [*] Array literal uses old-style syntax: prefer `[...]`
   |
@@ -37,19 +36,18 @@ snapshot_kind: text
   |
   = help: Change `(/.../)` to `[...]`
 
-ℹ Safe fix
-1 1 | program test
-2 2 |   integer :: a(3) = (/1, 2, 3/)
-3   |-  integer :: b(3) = (/ &
-  3 |+  integer :: b(3) = [ &
-4 4 |        1, &
-5 5 |        2, &
-6 6 |        3 &
-7   |-       /)
-  7 |+       ]
-8 8 |   if (.true.) a = (/4, 5, 6/)
-9 9 |   b(1:3) = (/ &
-10 10 |        4, &
+1  | program test
+2  |   integer :: a(3) = (/1, 2, 3/)
+   -   integer :: b(3) = (/ &
+3  +   integer :: b(3) = [ &
+4  |        1, &
+5  |        2, &
+6  |        3 &
+   -        /)
+7  +        ]
+8  |   if (.true.) a = (/4, 5, 6/)
+9  |   b(1:3) = (/ &
+10 |        4, &
 
 ./resources/test/fixtures/modernisation/MOD011.f90:8:19: MOD011 [*] Array literal uses old-style syntax: prefer `[...]`
    |
@@ -62,15 +60,14 @@ snapshot_kind: text
    |
    = help: Change `(/.../)` to `[...]`
 
-ℹ Safe fix
-5 5 |        2, &
-6 6 |        3 &
-7 7 |        /)
-8   |-  if (.true.) a = (/4, 5, 6/)
-  8 |+  if (.true.) a = [4, 5, 6]
-9 9 |   b(1:3) = (/ &
-10 10 |        4, &
-11 11 |        5, &
+5  |        2, &
+6  |        3 &
+7  |        /)
+   -   if (.true.) a = (/4, 5, 6/)
+8  +   if (.true.) a = [4, 5, 6]
+9  |   b(1:3) = (/ &
+10 |        4, &
+11 |        5, &
 
 ./resources/test/fixtures/modernisation/MOD011.f90:9:12: MOD011 [*] Array literal uses old-style syntax: prefer `[...]`
    |
@@ -87,15 +84,14 @@ snapshot_kind: text
    |
    = help: Change `(/.../)` to `[...]`
 
-ℹ Safe fix
-6  6  |        3 &
-7  7  |        /)
-8  8  |   if (.true.) a = (/4, 5, 6/)
-9     |-  b(1:3) = (/ &
-   9  |+  b(1:3) = [ &
-10 10 |        4, &
-11 11 |        5, &
-12 12 |        6 &
-13    |-       /)
-   13 |+       ]
-14 14 | end program test
+6  |        3 &
+7  |        /)
+8  |   if (.true.) a = (/4, 5, 6/)
+   -   b(1:3) = (/ &
+9  +   b(1:3) = [ &
+10 |        4, &
+11 |        5, &
+12 |        6 &
+   -        /)
+13 +        ]
+14 | end program test

--- a/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__out-of-line-attribute_MOD041.f90.snap
+++ b/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__out-of-line-attribute_MOD041.f90.snap
@@ -13,16 +13,15 @@ snapshot_kind: text
   |
   = help: Add 'dimension' to 'y' declaration on line 4
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none
-3 3 |   integer :: X
-4   |-  real :: y
-5   |-  dimension y(2)
-  4 |+  real, dimension(2) :: y
-6 5 |   parameter(x = 1, Y=[2, 3])
-7 6 | 
-8 7 |   block
+1 | program test
+2 |   implicit none
+3 |   integer :: X
+  -   real :: y
+  -   dimension y(2)
+4 +   real, dimension(2) :: y
+5 |   parameter(x = 1, Y=[2, 3])
+6 |
+7 |   block
 
 ./resources/test/fixtures/modernisation/MOD041.f90:6:13: MOD041 [*] Out of line 'parameter' attribute for variable 'x'
   |
@@ -35,18 +34,17 @@ snapshot_kind: text
   |
   = help: Add 'parameter' to 'x' declaration on line 3
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none
-3   |-  integer :: X
-  3 |+  integer, parameter :: X = 1
-4 4 |   real :: y
-5 5 |   dimension y(2)
-6   |-  parameter(x = 1, Y=[2, 3])
-  6 |+  parameter( Y=[2, 3])
-7 7 | 
-8 8 |   block
-9 9 |     integer :: x, y
+1 | program test
+2 |   implicit none
+  -   integer :: X
+3 +   integer, parameter :: X = 1
+4 |   real :: y
+5 |   dimension y(2)
+  -   parameter(x = 1, Y=[2, 3])
+6 +   parameter( Y=[2, 3])
+7 |
+8 |   block
+9 |     integer :: x, y
 
 ./resources/test/fixtures/modernisation/MOD041.f90:6:20: MOD041 [*] Out of line 'parameter' attribute for variable 'Y'
   |
@@ -59,18 +57,17 @@ snapshot_kind: text
   |
   = help: Add 'parameter' to 'Y' declaration on line 4
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none
-3 3 |   integer :: X
-4   |-  real :: y
-  4 |+  real, parameter :: y = [2, 3]
-5 5 |   dimension y(2)
-6   |-  parameter(x = 1, Y=[2, 3])
-  6 |+  parameter(x = 1)
-7 7 | 
-8 8 |   block
-9 9 |     integer :: x, y
+1 | program test
+2 |   implicit none
+3 |   integer :: X
+  -   real :: y
+4 +   real, parameter :: y = [2, 3]
+5 |   dimension y(2)
+  -   parameter(x = 1, Y=[2, 3])
+6 +   parameter(x = 1)
+7 |
+8 |   block
+9 |     integer :: x, y
 
 ./resources/test/fixtures/modernisation/MOD041.f90:10:17: MOD041 [*] Out of line 'allocatable' attribute for variable 'x'
    |
@@ -83,17 +80,16 @@ snapshot_kind: text
    |
    = help: Add 'allocatable' to 'x' declaration on line 9
 
-ℹ Unsafe fix
-6  6  |   parameter(x = 1, Y=[2, 3])
-7  7  | 
-8  8  |   block
-9     |-    integer :: x, y
-10    |-    allocatable x
-   9  |+    integer ::  y
-   10 |+    integer, allocatable :: x
-11 11 |     allocatable y(:)
-12 12 |   end block
-13 13 | 
+6  |   parameter(x = 1, Y=[2, 3])
+7  |
+8  |   block
+   -     integer :: x, y
+   -     allocatable x
+9  +     integer ::  y
+10 +     integer, allocatable :: x
+11 |     allocatable y(:)
+12 |   end block
+13 |
 
 ./resources/test/fixtures/modernisation/MOD041.f90:11:17: MOD041 [*] Out of line 'allocatable' attribute for variable 'y'
    |
@@ -105,18 +101,17 @@ snapshot_kind: text
    |
    = help: Add 'allocatable' to 'y' declaration on line 9
 
-ℹ Unsafe fix
-6  6  |   parameter(x = 1, Y=[2, 3])
-7  7  | 
-8  8  |   block
-9     |-    integer :: x, y
-   9  |+    integer :: x
-   10 |+    integer, allocatable :: y(:)
-10 11 |     allocatable x
-11    |-    allocatable y(:)
-12 12 |   end block
-13 13 | 
-14 14 |   block
+6  |   parameter(x = 1, Y=[2, 3])
+7  |
+8  |   block
+   -     integer :: x, y
+9  +     integer :: x
+10 +     integer, allocatable :: y(:)
+11 |     allocatable x
+   -     allocatable y(:)
+12 |   end block
+13 |
+14 |   block
 
 ./resources/test/fixtures/modernisation/MOD041.f90:16:15: MOD041 [*] Out of line 'parameter' attribute for variable 'a'
    |
@@ -128,18 +123,17 @@ snapshot_kind: text
    |
    = help: Add 'parameter' to 'a' declaration on line 15
 
-ℹ Unsafe fix
-12 12 |   end block
-13 13 | 
-14 14 |   block
-15    |-    integer :: a, b, c
-16    |-    parameter(a=1, b=2)
-   15 |+    integer ::  b, c
-   16 |+    integer, parameter :: a = 1
-   17 |+    parameter( b=2)
-17 18 |   end block
-18 19 | 
-19 20 |   block
+12 |   end block
+13 |
+14 |   block
+   -     integer :: a, b, c
+   -     parameter(a=1, b=2)
+15 +     integer ::  b, c
+16 +     integer, parameter :: a = 1
+17 +     parameter( b=2)
+18 |   end block
+19 |
+20 |   block
 
 ./resources/test/fixtures/modernisation/MOD041.f90:16:20: MOD041 [*] Out of line 'parameter' attribute for variable 'b'
    |
@@ -151,18 +145,17 @@ snapshot_kind: text
    |
    = help: Add 'parameter' to 'b' declaration on line 15
 
-ℹ Unsafe fix
-12 12 |   end block
-13 13 | 
-14 14 |   block
-15    |-    integer :: a, b, c
-16    |-    parameter(a=1, b=2)
-   15 |+    integer :: a,  c
-   16 |+    integer, parameter :: b = 2
-   17 |+    parameter(a=1)
-17 18 |   end block
-18 19 | 
-19 20 |   block
+12 |   end block
+13 |
+14 |   block
+   -     integer :: a, b, c
+   -     parameter(a=1, b=2)
+15 +     integer :: a,  c
+16 +     integer, parameter :: b = 2
+17 +     parameter(a=1)
+18 |   end block
+19 |
+20 |   block
 
 ./resources/test/fixtures/modernisation/MOD041.f90:21:17: MOD041 [*] Out of line 'allocatable' attribute for variable 'x'
    |
@@ -174,16 +167,15 @@ snapshot_kind: text
    |
    = help: Add 'allocatable' to 'x' declaration on line 20
 
-ℹ Unsafe fix
-17 17 |   end block
-18 18 | 
-19 19 |   block
-20    |-    integer :: x
-21    |-    allocatable x (:, :)
-   20 |+    integer, allocatable :: x(:, :)
-22 21 |   end block
-23 22 | 
-24 23 |   block
+17 |   end block
+18 |
+19 |   block
+   -     integer :: x
+   -     allocatable x (:, :)
+20 +     integer, allocatable :: x(:, :)
+21 |   end block
+22 |
+23 |   block
 
 ./resources/test/fixtures/modernisation/MOD041.f90:26:17: MOD041 [*] Out of line 'allocatable' attribute for variable 'x'
    |
@@ -196,16 +188,15 @@ snapshot_kind: text
    |
    = help: Add 'allocatable' to 'x' declaration on line 25
 
-ℹ Unsafe fix
-22 22 |   end block
-23 23 | 
-24 24 |   block
-25    |-    integer :: x
-26    |-    allocatable x
-   25 |+    integer, allocatable :: x
-27 26 |     dimension x(:, :)
-28 27 |   end block
-29 28 | end program test
+22 |   end block
+23 |
+24 |   block
+   -     integer :: x
+   -     allocatable x
+25 +     integer, allocatable :: x
+26 |     dimension x(:, :)
+27 |   end block
+28 | end program test
 
 ./resources/test/fixtures/modernisation/MOD041.f90:27:15: MOD041 [*] Out of line 'dimension' attribute for variable 'x'
    |
@@ -218,13 +209,12 @@ snapshot_kind: text
    |
    = help: Add 'dimension' to 'x' declaration on line 25
 
-ℹ Unsafe fix
-22 22 |   end block
-23 23 | 
-24 24 |   block
-25    |-    integer :: x
-   25 |+    integer, dimension(:, :) :: x
-26 26 |     allocatable x
-27    |-    dimension x(:, :)
-28 27 |   end block
-29 28 | end program test
+22 |   end block
+23 |
+24 |   block
+   -     integer :: x
+25 +     integer, dimension(:, :) :: x
+26 |     allocatable x
+   -     dimension x(:, :)
+27 |   end block
+28 | end program test

--- a/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__superfluous-save_MOD051.f90.snap
+++ b/crates/fortitude_linter/src/rules/modernisation/snapshots/fortitude_linter__rules__modernisation__tests__superfluous-save_MOD051.f90.snap
@@ -13,12 +13,11 @@ snapshot_kind: text
   |
   = help: Remove `save`
 
-ℹ Safe fix
-1 1 | module test
-2   |-  save
-3 2 | 
-4 3 |   integer :: a
-5 4 | 
+1 | module test
+  -   save
+2 |
+3 |   integer :: a
+4 |
 
 ./resources/test/fixtures/modernisation/MOD051.f90:13:12: MOD051 [*] save attribute is superfluous at the module level
    |
@@ -29,10 +28,9 @@ snapshot_kind: text
    |
    = help: Remove `save`
 
-ℹ Safe fix
-10 10 | end module test
-11 11 | 
-12 12 | module test
-13    |-  integer, save :: a
-   13 |+  integer :: a
-14 14 | end module test
+10 | end module test
+11 |
+12 | module test
+   -   integer, save :: a
+13 +   integer :: a
+14 | end module test

--- a/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__arithmetic-if_OB081.f90.snap
+++ b/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__arithmetic-if_OB081.f90.snap
@@ -13,30 +13,29 @@ snapshot_kind: text
   |
   = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-3  3  |     integer :: x(1), k, i
-4  4  | 
-5  5  |     ! Permutations on three blocks
-6     |-    if (k) 1, 2, 3
-7     |-1   continue
-   6  |+    if (k < 0) then
-8  7  |     print*, "<"
-9  8  |     i = 0
-10    |-    goto 4
-11    |-2   continue
-   9  |+    else if (k == 0) then
-12 10 |     print*, "=="
-13 11 |     i = 1
-14    |-    goto 4
-15    |-3   continue
-   12 |+    else
-16 13 |     print*, ">"
-17 14 |     i = 2
-18    |-4   continue
-   15 |+    end if
-19 16 | 
-20 17 |     if (k) 13, 12, 11
-21 18 | 11  continue
+3  |     integer :: x(1), k, i
+4  |
+5  |     ! Permutations on three blocks
+   -     if (k) 1, 2, 3
+   - 1   continue
+6  +     if (k < 0) then
+7  |     print*, "<"
+8  |     i = 0
+   -     goto 4
+   - 2   continue
+9  +     else if (k == 0) then
+10 |     print*, "=="
+11 |     i = 1
+   -     goto 4
+   - 3   continue
+12 +     else
+13 |     print*, ">"
+14 |     i = 2
+   - 4   continue
+15 +     end if
+16 |
+17 |     if (k) 13, 12, 11
+18 | 11  continue
 
 ./resources/test/fixtures/obsolescent/OB081.f90:20:5: OB081 [*] Obsolete arithmetic `if`
    |
@@ -49,30 +48,29 @@ snapshot_kind: text
    |
    = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-17 17 |     i = 2
-18 18 | 4   continue
-19 19 | 
-20    |-    if (k) 13, 12, 11
-21    |-11  continue
-   20 |+    if (k > 0) then
-22 21 |     print*, ">"
-23 22 |     i = 0
-24    |-    goto 14
-25    |-12  continue
-   23 |+    else if (k == 0) then
-26 24 |     print*, "=="
-27 25 |     i = 1
-28    |-    goto 14
-29    |-13  continue
-   26 |+    else
-30 27 |     print*, "<"
-31 28 |     i = 2
-32    |-14  continue
-   29 |+    end if
-33 30 | 
-34 31 |     if (k) 23, 21, 22
-35 32 | 21  continue
+17 |     i = 2
+18 | 4   continue
+19 |
+   -     if (k) 13, 12, 11
+   - 11  continue
+20 +     if (k > 0) then
+21 |     print*, ">"
+22 |     i = 0
+   -     goto 14
+   - 12  continue
+23 +     else if (k == 0) then
+24 |     print*, "=="
+25 |     i = 1
+   -     goto 14
+   - 13  continue
+26 +     else
+27 |     print*, "<"
+28 |     i = 2
+   - 14  continue
+29 +     end if
+30 |
+31 |     if (k) 23, 21, 22
+32 | 21  continue
 
 ./resources/test/fixtures/obsolescent/OB081.f90:34:5: OB081 [*] Obsolete arithmetic `if`
    |
@@ -85,30 +83,29 @@ snapshot_kind: text
    |
    = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-31 31 |     i = 2
-32 32 | 14  continue
-33 33 | 
-34    |-    if (k) 23, 21, 22
-35    |-21  continue
-   34 |+    if (k == 0) then
-36 35 |     print*, "=="
-37 36 |     i = 0
-38    |-    goto 24
-39    |-22  continue
-   37 |+    else if (k > 0) then
-40 38 |     print*, ">"
-41 39 |     i = 1
-42    |-    goto 24
-43    |-23  continue
-   40 |+    else
-44 41 |     print*, "<"
-45 42 |     i = 2
-46    |-24  continue
-   43 |+    end if
-47 44 | 
-48 45 |     ! Permutations on two blocks
-49 46 |     if (k) 31, 31, 32
+31 |     i = 2
+32 | 14  continue
+33 |
+   -     if (k) 23, 21, 22
+   - 21  continue
+34 +     if (k == 0) then
+35 |     print*, "=="
+36 |     i = 0
+   -     goto 24
+   - 22  continue
+37 +     else if (k > 0) then
+38 |     print*, ">"
+39 |     i = 1
+   -     goto 24
+   - 23  continue
+40 +     else
+41 |     print*, "<"
+42 |     i = 2
+   - 24  continue
+43 +     end if
+44 |
+45 |     ! Permutations on two blocks
+46 |     if (k) 31, 31, 32
 
 ./resources/test/fixtures/obsolescent/OB081.f90:49:5: OB081 [*] Obsolete arithmetic `if`
    |
@@ -120,25 +117,24 @@ snapshot_kind: text
    |
    = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-46 46 | 24  continue
-47 47 | 
-48 48 |     ! Permutations on two blocks
-49    |-    if (k) 31, 31, 32
-50    |-31  continue
-   49 |+    if (k <= 0) then
-51 50 |     print*, "<="
-52 51 |     i = 0
-53    |-    goto 34
-54    |-32  continue
-   52 |+    else
-55 53 |     print*, ">"
-56 54 |     i = 2
-57    |-34  continue
-   55 |+    end if
-58 56 | 
-59 57 |     if (k) 41, 42, 42
-60 58 | 41  continue
+46 | 24  continue
+47 |
+48 |     ! Permutations on two blocks
+   -     if (k) 31, 31, 32
+   - 31  continue
+49 +     if (k <= 0) then
+50 |     print*, "<="
+51 |     i = 0
+   -     goto 34
+   - 32  continue
+52 +     else
+53 |     print*, ">"
+54 |     i = 2
+   - 34  continue
+55 +     end if
+56 |
+57 |     if (k) 41, 42, 42
+58 | 41  continue
 
 ./resources/test/fixtures/obsolescent/OB081.f90:59:5: OB081 [*] Obsolete arithmetic `if`
    |
@@ -151,25 +147,24 @@ snapshot_kind: text
    |
    = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-56 56 |     i = 2
-57 57 | 34  continue
-58 58 | 
-59    |-    if (k) 41, 42, 42
-60    |-41  continue
-   59 |+    if (k < 0) then
-61 60 |     print*, "<"
-62 61 |     i = 0
-63    |-    goto 44
-64    |-42  continue
-   62 |+    else
-65 63 |     print*, ">="
-66 64 |     i = 2
-67    |-44  continue
-   65 |+    end if
-68 66 | 
-69 67 |     if (k) 51, 52, 54
-70 68 | 51  continue
+56 |     i = 2
+57 | 34  continue
+58 |
+   -     if (k) 41, 42, 42
+   - 41  continue
+59 +     if (k < 0) then
+60 |     print*, "<"
+61 |     i = 0
+   -     goto 44
+   - 42  continue
+62 +     else
+63 |     print*, ">="
+64 |     i = 2
+   - 44  continue
+65 +     end if
+66 |
+67 |     if (k) 51, 52, 54
+68 | 51  continue
 
 ./resources/test/fixtures/obsolescent/OB081.f90:69:5: OB081 [*] Obsolete arithmetic `if`
    |
@@ -182,25 +177,24 @@ snapshot_kind: text
    |
    = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-66 66 |     i = 2
-67 67 | 44  continue
-68 68 | 
-69    |-    if (k) 51, 52, 54
-70    |-51  continue
-   69 |+    if (k < 0) then
-71 70 |     print*, "<"
-72 71 |     i = 0
-73    |-    goto 54
-74    |-52  continue
-   72 |+    else if (k == 0) then
-75 73 |     print*, "=="
-76 74 |     i = 2
-77    |-54  continue
-   75 |+    end if
-78 76 | 
-79 77 |     ! Single block
-80 78 |     if (k) 62, 61, 62
+66 |     i = 2
+67 | 44  continue
+68 |
+   -     if (k) 51, 52, 54
+   - 51  continue
+69 +     if (k < 0) then
+70 |     print*, "<"
+71 |     i = 0
+   -     goto 54
+   - 52  continue
+72 +     else if (k == 0) then
+73 |     print*, "=="
+74 |     i = 2
+   - 54  continue
+75 +     end if
+76 |
+77 |     ! Single block
+78 |     if (k) 62, 61, 62
 
 ./resources/test/fixtures/obsolescent/OB081.f90:80:5: OB081 [*] Obsolete arithmetic `if`
    |
@@ -212,19 +206,18 @@ snapshot_kind: text
    |
    = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-77 77 | 54  continue
-78 78 | 
-79 79 |     ! Single block
-80    |-    if (k) 62, 61, 62
-81    |-61  print*, "=="
-82    |-62  continue
-   80 |+    if (k == 0) then
-   81 |+    print*, "=="
-   82 |+    end if
-83 83 | 
-84 84 |     if (k) 71, 72, 71
-85 85 | 71  continue
+77 | 54  continue
+78 |
+79 |     ! Single block
+   -     if (k) 62, 61, 62
+   - 61  print*, "=="
+   - 62  continue
+80 +     if (k == 0) then
+81 +     print*, "=="
+82 +     end if
+83 |
+84 |     if (k) 71, 72, 71
+85 | 71  continue
 
 ./resources/test/fixtures/obsolescent/OB081.f90:84:5: OB081 [*] Obsolete arithmetic `if`
    |
@@ -237,19 +230,18 @@ snapshot_kind: text
    |
    = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-81 81 | 61  print*, "=="
-82 82 | 62  continue
-83 83 | 
-84    |-    if (k) 71, 72, 71
-85    |-71  continue
-   84 |+    if (k /= 0) then
-86 85 |     print*, "/="
-87    |-72  continue
-   86 |+    end if
-88 87 | 
-89 88 | 85  do 110 k=1,9
-90 89 | 87     if(i-1) 100,90,100
+81 | 61  print*, "=="
+82 | 62  continue
+83 |
+   -     if (k) 71, 72, 71
+   - 71  continue
+84 +     if (k /= 0) then
+85 |     print*, "/="
+   - 72  continue
+86 +     end if
+87 |
+88 | 85  do 110 k=1,9
+89 | 87     if(i-1) 100,90,100
 
 ./resources/test/fixtures/obsolescent/OB081.f90:90:8: OB081 [*] Obsolete arithmetic `if`
    |
@@ -261,20 +253,19 @@ snapshot_kind: text
    |
    = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-87 87 | 72  continue
-88 88 | 
-89 89 | 85  do 110 k=1,9
-90    |-87     if(i-1) 100,90,100
-91    |-90     print*, "=="
-   90 |+87     if (i-1 == 0) then
-   91 |+       print*, "=="
-92 92 |        goto 110
-93    |-100    continue
-   93 |+       end if
-94 94 | 110 continue
-95 95 | 
-96 96 |    ! This should become:
+87 | 72  continue
+88 |
+89 | 85  do 110 k=1,9
+   - 87     if(i-1) 100,90,100
+   - 90     print*, "=="
+90 + 87     if (i-1 == 0) then
+91 +        print*, "=="
+92 |        goto 110
+   - 100    continue
+93 +        end if
+94 | 110 continue
+95 |
+96 |    ! This should become:
 
 ./resources/test/fixtures/obsolescent/OB081.f90:110:5: OB081 [*] Obsolete arithmetic `if`
     |
@@ -287,27 +278,26 @@ snapshot_kind: text
     |
     = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-107 107 |   ! These should be fixable, but we have to not consume the returns
-108 108 |   subroutine blocks_end_in_control_flows(M)
-109 109 |     integer, intent(in) :: M
-110     |-    if (k) 1, 2, 3
-111     |-1   continue
-    110 |+    if (k < 0) then
-112 111 |     print*, "<"
-113 112 |     i = 0
-114 113 |     return
-115     |-2   continue
-    114 |+    end if
-    115 |+    if (k == 0) then
-116 116 |     print*, "=="
-117 117 |     i = 1
-118 118 |     return
-119     |-3   continue
-    119 |+    end if
-120 120 |     print*, ">"
-121 121 |     i = 2
-122 122 |     continue
+107 |   ! These should be fixable, but we have to not consume the returns
+108 |   subroutine blocks_end_in_control_flows(M)
+109 |     integer, intent(in) :: M
+    -     if (k) 1, 2, 3
+    - 1   continue
+110 +     if (k < 0) then
+111 |     print*, "<"
+112 |     i = 0
+113 |     return
+    - 2   continue
+114 +     end if
+115 +     if (k == 0) then
+116 |     print*, "=="
+117 |     i = 1
+118 |     return
+    - 3   continue
+119 +     end if
+120 |     print*, ">"
+121 |     i = 2
+122 |     continue
 
 ./resources/test/fixtures/obsolescent/OB081.f90:128:5: OB081 [*] Obsolete arithmetic `if`
     |
@@ -320,22 +310,21 @@ snapshot_kind: text
     |
     = help: Use `if` statement or `if` construct
 
-ℹ Unsafe fix
-125 125 |   subroutine bar(n)
-126 126 |     integer, intent(inout) :: n
-127 127 |     ! TEST LESS THAN TWO POINTS
-128     |-    if(n-1)  90,90,80
-129     |-80  continue
-    128 |+    if (n-1 > 0) then
-130 129 |     ! infinite loop, but never mind that
-131 130 | 30  n = 1
-132 131 |     goto 30
-133     |-90  return
-    132 |+    end if
-    133 |+    return
-134 134 |   end subroutine bar
-135 135 | 
-136 136 |   subroutine unfixable_versions(x)
+125 |   subroutine bar(n)
+126 |     integer, intent(inout) :: n
+127 |     ! TEST LESS THAN TWO POINTS
+    -     if(n-1)  90,90,80
+    - 80  continue
+128 +     if (n-1 > 0) then
+129 |     ! infinite loop, but never mind that
+130 | 30  n = 1
+131 |     goto 30
+    - 90  return
+132 +     end if
+133 +     return
+134 |   end subroutine bar
+135 |
+136 |   subroutine unfixable_versions(x)
 
 ./resources/test/fixtures/obsolescent/OB081.f90:141:5: OB081 Obsolete arithmetic `if`
     |

--- a/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__bad-do-termination_labelled_do.f90.snap
+++ b/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__bad-do-termination_labelled_do.f90.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
    |
    = help: Add `end do` statement
 
-ℹ Safe fix
-21 21 | 
-22 22 |     ! Doesn't end in `continue` or `end do`
-23 23 |     do 30 i = 1,10
-24    |-30  foo(i) = 3 * i
-   24 |+    foo(i) = 3 * i
-   25 |+ 30 end do
-25 26 | 
-26 27 |     ! Doesn't end in `continue` or `end do`
-27 28 |     ! and has arithmetic `if` so we need to keep label
+21 |
+22 |     ! Doesn't end in `continue` or `end do`
+23 |     do 30 i = 1,10
+   - 30  foo(i) = 3 * i
+24 +     foo(i) = 3 * i
+25 +  30 end do
+26 |
+27 |     ! Doesn't end in `continue` or `end do`
+28 |     ! and has arithmetic `if` so we need to keep label
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:31:5: OB093 [*] `do` termination is not `end do` or `continue`
    |
@@ -36,16 +35,15 @@ snapshot_kind: text
    |
    = help: Add `end do` statement
 
-ℹ Safe fix
-28 28 |     do 40 i = 1,10
-29 29 |     if (i - 5) 39, 39, 40
-30 30 | 39  continue
-31    |-40  foo(i) = 3 * i
-   31 |+    foo(i) = 3 * i
-   32 |+ 40 end do
-32 33 | 
-33 34 |     ! Shared termination
-34 35 |     do 100 i = 1,10
+28 |     do 40 i = 1,10
+29 |     if (i - 5) 39, 39, 40
+30 | 39  continue
+   - 40  foo(i) = 3 * i
+31 +     foo(i) = 3 * i
+32 +  40 end do
+33 |
+34 |     ! Shared termination
+35 |     do 100 i = 1,10
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:45:9: OB093 `do` termination is not `end do` or `continue`
    |

--- a/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__deprecated-character-syntax_OB061.f90.snap
+++ b/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__deprecated-character-syntax_OB061.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/obsolescent/mod.rs
+source: crates/fortitude_linter/src/rules/obsolescent/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -13,15 +13,14 @@ snapshot_kind: text
    |
    = help: Replace with 'character(len=*)'
 
-ℹ Safe fix
-10 10 |     use, intrinsic :: iso_c_binding, only: c_char
-11 11 | 
-12 12 |     ! assumed size
-13    |-    character * ( * ), intent(in) :: a
-   13 |+    character(len=*), intent(in) :: a
-14 14 |     character*(*), intent(in) :: b, c*9
-15 15 |     character*(:), allocatable :: d
-16 16 | 
+10 |     use, intrinsic :: iso_c_binding, only: c_char
+11 |
+12 |     ! assumed size
+   -     character * ( * ), intent(in) :: a
+13 +     character(len=*), intent(in) :: a
+14 |     character*(*), intent(in) :: b, c*9
+15 |     character*(:), allocatable :: d
+16 |
 
 ./resources/test/fixtures/obsolescent/OB061.f90:14:5: OB061 [*] 'character*(*)' uses deprecated syntax
    |
@@ -33,15 +32,14 @@ snapshot_kind: text
    |
    = help: Replace with 'character(len=*)'
 
-ℹ Safe fix
-11 11 | 
-12 12 |     ! assumed size
-13 13 |     character * ( * ), intent(in) :: a
-14    |-    character*(*), intent(in) :: b, c*9
-   14 |+    character(len=*), intent(in) :: b, c*9
-15 15 |     character*(:), allocatable :: d
-16 16 | 
-17 17 |     ! sized with a number literal
+11 |
+12 |     ! assumed size
+13 |     character * ( * ), intent(in) :: a
+   -     character*(*), intent(in) :: b, c*9
+14 +     character(len=*), intent(in) :: b, c*9
+15 |     character*(:), allocatable :: d
+16 |
+17 |     ! sized with a number literal
 
 ./resources/test/fixtures/obsolescent/OB061.f90:15:5: OB061 [*] 'character*(:)' uses deprecated syntax
    |
@@ -54,15 +52,14 @@ snapshot_kind: text
    |
    = help: Replace with 'character(len=:)'
 
-ℹ Safe fix
-12 12 |     ! assumed size
-13 13 |     character * ( * ), intent(in) :: a
-14 14 |     character*(*), intent(in) :: b, c*9
-15    |-    character*(:), allocatable :: d
-   15 |+    character(len=:), allocatable :: d
-16 16 | 
-17 17 |     ! sized with a number literal
-18 18 |     character*5 e, f
+12 |     ! assumed size
+13 |     character * ( * ), intent(in) :: a
+14 |     character*(*), intent(in) :: b, c*9
+   -     character*(:), allocatable :: d
+15 +     character(len=:), allocatable :: d
+16 |
+17 |     ! sized with a number literal
+18 |     character*5 e, f
 
 ./resources/test/fixtures/obsolescent/OB061.f90:18:5: OB061 [*] 'character*5' uses deprecated syntax
    |
@@ -74,15 +71,14 @@ snapshot_kind: text
    |
    = help: Replace with 'character(len=5)'
 
-ℹ Safe fix
-15 15 |     character*(:), allocatable :: d
-16 16 | 
-17 17 |     ! sized with a number literal
-18    |-    character*5 e, f
-   18 |+    character(len=5) e, f
-19 19 |     CHARACTer  *  10 g
-20 20 |     chAracTer* 3 h, i*7
-21 21 | 
+15 |     character*(:), allocatable :: d
+16 |
+17 |     ! sized with a number literal
+   -     character*5 e, f
+18 +     character(len=5) e, f
+19 |     CHARACTer  *  10 g
+20 |     chAracTer* 3 h, i*7
+21 |
 
 ./resources/test/fixtures/obsolescent/OB061.f90:19:5: OB061 [*] 'CHARACTer  *  10' uses deprecated syntax
    |
@@ -94,15 +90,14 @@ snapshot_kind: text
    |
    = help: Replace with 'CHARACTer(len=10)'
 
-ℹ Safe fix
-16 16 | 
-17 17 |     ! sized with a number literal
-18 18 |     character*5 e, f
-19    |-    CHARACTer  *  10 g
-   19 |+    CHARACTer(len=10) g
-20 20 |     chAracTer* 3 h, i*7
-21 21 | 
-22 22 |     ! sized with an integer expression
+16 |
+17 |     ! sized with a number literal
+18 |     character*5 e, f
+   -     CHARACTer  *  10 g
+19 +     CHARACTer(len=10) g
+20 |     chAracTer* 3 h, i*7
+21 |
+22 |     ! sized with an integer expression
 
 ./resources/test/fixtures/obsolescent/OB061.f90:20:5: OB061 [*] 'chAracTer* 3' uses deprecated syntax
    |
@@ -115,15 +110,14 @@ snapshot_kind: text
    |
    = help: Replace with 'chAracTer(len=3)'
 
-ℹ Safe fix
-17 17 |     ! sized with a number literal
-18 18 |     character*5 e, f
-19 19 |     CHARACTer  *  10 g
-20    |-    chAracTer* 3 h, i*7
-   20 |+    chAracTer(len=3) h, i*7
-21 21 | 
-22 22 |     ! sized with an integer expression
-23 23 |     character*(MAX_LEN), intent(in) :: j
+17 |     ! sized with a number literal
+18 |     character*5 e, f
+19 |     CHARACTer  *  10 g
+   -     chAracTer* 3 h, i*7
+20 +     chAracTer(len=3) h, i*7
+21 |
+22 |     ! sized with an integer expression
+23 |     character*(MAX_LEN), intent(in) :: j
 
 ./resources/test/fixtures/obsolescent/OB061.f90:23:5: OB061 [*] 'character*(MAX_LEN)' uses deprecated syntax
    |
@@ -134,15 +128,14 @@ snapshot_kind: text
    |
    = help: Replace with 'character(len=MAX_LEN)'
 
-ℹ Safe fix
-20 20 |     chAracTer* 3 h, i*7
-21 21 | 
-22 22 |     ! sized with an integer expression
-23    |-    character*(MAX_LEN), intent(in) :: j
-   23 |+    character(len=MAX_LEN), intent(in) :: j
-24 24 |     character * (2* (MAX_LEN) ) k
-25 25 | 
-26 26 |     ! these are ok
+20 |     chAracTer* 3 h, i*7
+21 |
+22 |     ! sized with an integer expression
+   -     character*(MAX_LEN), intent(in) :: j
+23 +     character(len=MAX_LEN), intent(in) :: j
+24 |     character * (2* (MAX_LEN) ) k
+25 |
+26 |     ! these are ok
 
 ./resources/test/fixtures/obsolescent/OB061.f90:24:5: OB061 [*] 'character * (2* (MAX_LEN) )' uses deprecated syntax
    |
@@ -155,12 +148,11 @@ snapshot_kind: text
    |
    = help: Replace with 'character(len=2* (MAX_LEN))'
 
-ℹ Safe fix
-21 21 | 
-22 22 |     ! sized with an integer expression
-23 23 |     character*(MAX_LEN), intent(in) :: j
-24    |-    character * (2* (MAX_LEN) ) k
-   24 |+    character(len=2* (MAX_LEN)) k
-25 25 | 
-26 26 |     ! these are ok
-27 27 |     character(*, c_char) :: l
+21 |
+22 |     ! sized with an integer expression
+23 |     character*(MAX_LEN), intent(in) :: j
+   -     character * (2* (MAX_LEN) ) k
+24 +     character(len=2* (MAX_LEN)) k
+25 |
+26 |     ! these are ok
+27 |     character(*, c_char) :: l

--- a/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__goto-end-do_labelled_do.f90.snap
+++ b/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__goto-end-do_labelled_do.f90.snap
@@ -14,15 +14,14 @@ snapshot_kind: text
    |
    = help: Use `cycle` instead of `goto` to `end do`
 
-ℹ Safe fix
-8  8  | 
-9  9  |     ! Has a goto which means we can't remove label on `end do`
-10 10 |     do 20 i = 1, 10
-11    |-        if (i > 5) goto 20
-   11 |+        if (i > 5) cycle
-12 12 |         foo(i) = 2 * i
-13 13 | 20  end do
-14 14 | 
+8  |
+9  |     ! Has a goto which means we can't remove label on `end do`
+10 |     do 20 i = 1, 10
+   -         if (i > 5) goto 20
+11 +         if (i > 5) cycle
+12 |         foo(i) = 2 * i
+13 | 20  end do
+14 |
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:18:20: OB094 [*] `goto` points to `end do`
    |
@@ -35,15 +34,14 @@ snapshot_kind: text
    |
    = help: Use `cycle` instead of `goto` to `end do`
 
-ℹ Safe fix
-15 15 |     ! Has a goto which means we can't remove label on `end do`
-16 16 |     ! We still have to replace `continue` with `end do`
-17 17 |     do 25 i = 1, 10
-18    |-        if (i > 5) goto 25
-   18 |+        if (i > 5) cycle
-19 19 |         foo(i) = 2 * i
-20 20 | 25  continue
-21 21 | 
+15 |     ! Has a goto which means we can't remove label on `end do`
+16 |     ! We still have to replace `continue` with `end do`
+17 |     do 25 i = 1, 10
+   -         if (i > 5) goto 25
+18 +         if (i > 5) cycle
+19 |         foo(i) = 2 * i
+20 | 25  continue
+21 |
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:60:20: OB094 [*] `goto` points to `end do`
    |
@@ -56,15 +54,14 @@ snapshot_kind: text
    |
    = help: Use `cycle` instead of `goto` to `end do`
 
-ℹ Safe fix
-57 57 | 
-58 58 |     ! This only has a `goto` that could be a `cycle`
-59 59 |     do i = 1, 10
-60    |-        if (i > 5) goto 91
-   60 |+        if (i > 5) cycle
-61 61 |         foo(i) = 2 * i
-62 62 | 91  end do
-63 63 | 
+57 |
+58 |     ! This only has a `goto` that could be a `cycle`
+59 |     do i = 1, 10
+   -         if (i > 5) goto 91
+60 +         if (i > 5) cycle
+61 |         foo(i) = 2 * i
+62 | 91  end do
+63 |
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:79:24: OB094 `goto` points to `end do`
    |

--- a/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__labelled-do-loop_labelled_do.f90.snap
+++ b/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__labelled-do-loop_labelled_do.f90.snap
@@ -13,18 +13,17 @@ snapshot_kind: text
   |
   = help: Remove `do` label
 
-ℹ Unsafe fix
-2 2 |     integer :: i, j, k, l, m, foo(10), A(10, 10), B(10, 10, 10)
-3 3 | 
-4 4 |     ! No gotos, so we can autofix
-5   |-    do 10 i = 1, 10
-  5 |+    do i = 1, 10
-6 6 |         foo(i) = i
-7   |-10  continue
-  7 |+    end do
-8 8 | 
-9 9 |     ! Has a goto which means we can't remove label on `end do`
-10 10 |     do 20 i = 1, 10
+2  |     integer :: i, j, k, l, m, foo(10), A(10, 10), B(10, 10, 10)
+3  |
+4  |     ! No gotos, so we can autofix
+   -     do 10 i = 1, 10
+5  +     do i = 1, 10
+6  |         foo(i) = i
+   - 10  continue
+7  +     end do
+8  |
+9  |     ! Has a goto which means we can't remove label on `end do`
+10 |     do 20 i = 1, 10
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:10:8: OB091 [*] Obsolescent labelled `do` loop
    |
@@ -36,15 +35,14 @@ snapshot_kind: text
    |
    = help: Remove `do` label
 
-ℹ Unsafe fix
-7  7  | 10  continue
-8  8  | 
-9  9  |     ! Has a goto which means we can't remove label on `end do`
-10    |-    do 20 i = 1, 10
-   10 |+    do i = 1, 10
-11 11 |         if (i > 5) goto 20
-12 12 |         foo(i) = 2 * i
-13 13 | 20  end do
+7  | 10  continue
+8  |
+9  |     ! Has a goto which means we can't remove label on `end do`
+   -     do 20 i = 1, 10
+10 +     do i = 1, 10
+11 |         if (i > 5) goto 20
+12 |         foo(i) = 2 * i
+13 | 20  end do
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:17:8: OB091 [*] Obsolescent labelled `do` loop
    |
@@ -57,19 +55,18 @@ snapshot_kind: text
    |
    = help: Remove `do` label
 
-ℹ Unsafe fix
-14 14 | 
-15 15 |     ! Has a goto which means we can't remove label on `end do`
-16 16 |     ! We still have to replace `continue` with `end do`
-17    |-    do 25 i = 1, 10
-   17 |+    do i = 1, 10
-18 18 |         if (i > 5) goto 25
-19 19 |         foo(i) = 2 * i
-20    |-25  continue
-   20 |+25  end do
-21 21 | 
-22 22 |     ! Doesn't end in `continue` or `end do`
-23 23 |     do 30 i = 1,10
+14 |
+15 |     ! Has a goto which means we can't remove label on `end do`
+16 |     ! We still have to replace `continue` with `end do`
+   -     do 25 i = 1, 10
+17 +     do i = 1, 10
+18 |         if (i > 5) goto 25
+19 |         foo(i) = 2 * i
+   - 25  continue
+20 + 25  end do
+21 |
+22 |     ! Doesn't end in `continue` or `end do`
+23 |     do 30 i = 1,10
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:23:8: OB091 [*] Obsolescent labelled `do` loop
    |
@@ -80,18 +77,17 @@ snapshot_kind: text
    |
    = help: Remove `do` label
 
-ℹ Unsafe fix
-20 20 | 25  continue
-21 21 | 
-22 22 |     ! Doesn't end in `continue` or `end do`
-23    |-    do 30 i = 1,10
-24    |-30  foo(i) = 3 * i
-   23 |+    do i = 1,10
-   24 |+    foo(i) = 3 * i
-   25 |+    end do
-25 26 | 
-26 27 |     ! Doesn't end in `continue` or `end do`
-27 28 |     ! and has arithmetic `if` so we need to keep label
+20 | 25  continue
+21 |
+22 |     ! Doesn't end in `continue` or `end do`
+   -     do 30 i = 1,10
+   - 30  foo(i) = 3 * i
+23 +     do i = 1,10
+24 +     foo(i) = 3 * i
+25 +     end do
+26 |
+27 |     ! Doesn't end in `continue` or `end do`
+28 |     ! and has arithmetic `if` so we need to keep label
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:28:8: OB091 [*] Obsolescent labelled `do` loop
    |
@@ -104,20 +100,19 @@ snapshot_kind: text
    |
    = help: Remove `do` label
 
-ℹ Unsafe fix
-25 25 | 
-26 26 |     ! Doesn't end in `continue` or `end do`
-27 27 |     ! and has arithmetic `if` so we need to keep label
-28    |-    do 40 i = 1,10
-   28 |+    do i = 1,10
-29 29 |     if (i - 5) 39, 39, 40
-30 30 | 39  continue
-31    |-40  foo(i) = 3 * i
-   31 |+    foo(i) = 3 * i
-   32 |+ 40 end do
-32 33 | 
-33 34 |     ! Shared termination
-34 35 |     do 100 i = 1,10
+25 |
+26 |     ! Doesn't end in `continue` or `end do`
+27 |     ! and has arithmetic `if` so we need to keep label
+   -     do 40 i = 1,10
+28 +     do i = 1,10
+29 |     if (i - 5) 39, 39, 40
+30 | 39  continue
+   - 40  foo(i) = 3 * i
+31 +     foo(i) = 3 * i
+32 +  40 end do
+33 |
+34 |     ! Shared termination
+35 |     do 100 i = 1,10
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:34:8: OB091 Obsolescent labelled `do` loop
    |
@@ -204,20 +199,19 @@ snapshot_kind: text
    |
    = help: Remove `do` label
 
-ℹ Unsafe fix
-44 44 |       do 300, j = 1,10
-45 45 |     300 A(j, i) = i * j
-46 46 | 
-47    |-    double_loop: do 400, i=1,10
-   47 |+    double_loop: do i=1,10
-48 48 |       inner: do 500, j=1,10
-49 49 |         A(i, j) = i + j
-50 50 | 500   enddo inner
-51    |-400 enddo double_loop
-   51 |+    enddo double_loop
-52 52 | 
-53 53 |     ! This is obviously fine
-54 54 |     do i = 1, 10
+44 |       do 300, j = 1,10
+45 |     300 A(j, i) = i * j
+46 |
+   -     double_loop: do 400, i=1,10
+47 +     double_loop: do i=1,10
+48 |       inner: do 500, j=1,10
+49 |         A(i, j) = i + j
+50 | 500   enddo inner
+   - 400 enddo double_loop
+51 +     enddo double_loop
+52 |
+53 |     ! This is obviously fine
+54 |     do i = 1, 10
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:48:17: OB091 [*] Obsolescent labelled `do` loop
    |
@@ -229,18 +223,17 @@ snapshot_kind: text
    |
    = help: Remove `do` label
 
-ℹ Unsafe fix
-45 45 |     300 A(j, i) = i * j
-46 46 | 
-47 47 |     double_loop: do 400, i=1,10
-48    |-      inner: do 500, j=1,10
-   48 |+      inner: do j=1,10
-49 49 |         A(i, j) = i + j
-50    |-500   enddo inner
-   50 |+      enddo inner
-51 51 | 400 enddo double_loop
-52 52 | 
-53 53 |     ! This is obviously fine
+45 |     300 A(j, i) = i * j
+46 |
+47 |     double_loop: do 400, i=1,10
+   -       inner: do 500, j=1,10
+48 +       inner: do j=1,10
+49 |         A(i, j) = i + j
+   - 500   enddo inner
+50 +       enddo inner
+51 | 400 enddo double_loop
+52 |
+53 |     ! This is obviously fine
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:77:8: OB091 [*] Obsolescent labelled `do` loop
    |
@@ -252,15 +245,14 @@ snapshot_kind: text
    |
    = help: Remove `do` label
 
-ℹ Unsafe fix
-74 74 |     end do
-75 75 | 
-76 76 |     ! This can't be fixed because the `goto` targets the outer loop
-77    |-    do 110, i = 1,10
-   77 |+    do i = 1,10
-78 78 |       do 120, j = 1,10
-79 79 |         if (i + j > 5) goto 110
-80 80 |         A(i, j) = i + j
+74 |     end do
+75 |
+76 |     ! This can't be fixed because the `goto` targets the outer loop
+   -     do 110, i = 1,10
+77 +     do i = 1,10
+78 |       do 120, j = 1,10
+79 |         if (i + j > 5) goto 110
+80 |         A(i, j) = i + j
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:78:10: OB091 [*] Obsolescent labelled `do` loop
    |
@@ -273,16 +265,15 @@ snapshot_kind: text
    |
    = help: Remove `do` label
 
-ℹ Unsafe fix
-75 75 | 
-76 76 |     ! This can't be fixed because the `goto` targets the outer loop
-77 77 |     do 110, i = 1,10
-78    |-      do 120, j = 1,10
-   78 |+      do j = 1,10
-79 79 |         if (i + j > 5) goto 110
-80 80 |         A(i, j) = i + j
-81    |-120    end do
-   81 |+       end do
-82 82 | 110 end do
-83 83 | 
-84 84 | end program test
+75 |
+76 |     ! This can't be fixed because the `goto` targets the outer loop
+77 |     do 110, i = 1,10
+   -       do 120, j = 1,10
+78 +       do j = 1,10
+79 |         if (i + j > 5) goto 110
+80 |         A(i, j) = i + j
+   - 120    end do
+81 +        end do
+82 | 110 end do
+83 |
+84 | end program test

--- a/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__pause-statement_OB051.f90.snap
+++ b/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__pause-statement_OB051.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/obsolescent/mod.rs
+source: crates/fortitude_linter/src/rules/obsolescent/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,11 +14,10 @@ snapshot_kind: text
   |
   = help: Use 'read(*, *)' instead
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none
-3 3 |   print*,"hello"
-4   |-  pause
-  4 |+  read(*, *)
-5 5 |   print*,"bye"
-6 6 | end program
+1 | program test
+2 |   implicit none
+3 |   print*,"hello"
+  -   pause
+4 +   read(*, *)
+5 |   print*,"bye"
+6 | end program

--- a/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__shared-do-termination_labelled_do.f90.snap
+++ b/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__shared-do-termination_labelled_do.f90.snap
@@ -13,17 +13,16 @@ snapshot_kind: text
    |
    = help: Add `end do` statement
 
-ℹ Safe fix
-35 35 |       do 100 j = 1,10
-36 36 |         do 200 k = 1,10
-37 37 |           do 200 l = 1,10
-38    |-            do 200 m = 1,10
-   38 |+            do m = 1,10
-39 39 |             A(i,j) = A(i,j) + B(k,l,m)
-   40 |+            end do
-40 41 | 200 Continue
-41 42 | 100 End Do
-42 43 | 
+35 |       do 100 j = 1,10
+36 |         do 200 k = 1,10
+37 |           do 200 l = 1,10
+   -             do 200 m = 1,10
+38 +             do m = 1,10
+39 |             A(i,j) = A(i,j) + B(k,l,m)
+40 +             end do
+41 | 200 Continue
+42 | 100 End Do
+43 |
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:41:1: OB092 [*] Shared `do` loop termination
    |
@@ -36,21 +35,20 @@ snapshot_kind: text
    |
    = help: Add `end do` statement
 
-ℹ Safe fix
-32 32 | 
-33 33 |     ! Shared termination
-34 34 |     do 100 i = 1,10
-35    |-      do 100 j = 1,10
-   35 |+      do j = 1,10
-36 36 |         do 200 k = 1,10
-37 37 |           do 200 l = 1,10
-38 38 |             do 200 m = 1,10
-39 39 |             A(i,j) = A(i,j) + B(k,l,m)
-40 40 | 200 Continue
-   41 |+      end do
-41 42 | 100 End Do
-42 43 | 
-43 44 |     do 300, i = 1, 10
+32 |
+33 |     ! Shared termination
+34 |     do 100 i = 1,10
+   -       do 100 j = 1,10
+35 +       do j = 1,10
+36 |         do 200 k = 1,10
+37 |           do 200 l = 1,10
+38 |             do 200 m = 1,10
+39 |             A(i,j) = A(i,j) + B(k,l,m)
+40 | 200 Continue
+41 +       end do
+42 | 100 End Do
+43 |
+44 |     do 300, i = 1, 10
 
 ./resources/test/fixtures/obsolescent/labelled_do.f90:45:5: OB092 [*] Shared `do` loop termination
    |
@@ -63,16 +61,15 @@ snapshot_kind: text
    |
    = help: Add `end do` statement
 
-ℹ Safe fix
-41 41 | 100 End Do
-42 42 | 
-43 43 |     do 300, i = 1, 10
-44    |-      do 300, j = 1,10
-45    |-    300 A(j, i) = i * j
-   44 |+      do j = 1,10
-   45 |+        A(j, i) = i * j
-   46 |+      end do
-   47 |+ 300 end do
-46 48 | 
-47 49 |     double_loop: do 400, i=1,10
-48 50 |       inner: do 500, j=1,10
+41 | 100 End Do
+42 |
+43 |     do 300, i = 1, 10
+   -       do 300, j = 1,10
+   -     300 A(j, i) = i * j
+44 +       do j = 1,10
+45 +         A(j, i) = i * j
+46 +       end do
+47 +  300 end do
+48 |
+49 |     double_loop: do 400, i=1,10
+50 |       inner: do 500, j=1,10

--- a/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__specific-name_OB031.f90.snap
+++ b/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__specific-name_OB031.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/obsolescent/mod.rs
+source: crates/fortitude_linter/src/rules/obsolescent/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -12,15 +12,14 @@ snapshot_kind: text
   |
   = help: Use 'SIN'
 
-ℹ Unsafe fix
-3 3 |     real(kind=dp) :: x, y
-4 4 | 
-5 5 |     y = ASIN(x)
-6   |-    y = DSIN(x)
-  6 |+    y = SIN(x)
-7 7 | end subroutine test
-8 8 | 
-9 9 | subroutine test1()
+3 |     real(kind=dp) :: x, y
+4 |
+5 |     y = ASIN(x)
+  -     y = DSIN(x)
+6 +     y = SIN(x)
+7 | end subroutine test
+8 |
+9 | subroutine test1()
 
 ./resources/test/fixtures/obsolescent/OB031.f90:13:19: OB031 [*] deprecated type-specific function 'DSIN'
    |
@@ -32,15 +31,14 @@ snapshot_kind: text
    |
    = help: Use 'SIN'
 
-ℹ Unsafe fix
-10 10 |     use, intrinsic :: iso_fortran_env, dp => real64
-11 11 |     real(kind=dp) :: x, y
-12 12 | 
-13    |-    y = ASIN(x) + DSIN(x)
-   13 |+    y = ASIN(x) + SIN(x)
-14 14 | end subroutine test1
-15 15 | 
-16 16 | subroutine test2()
+10 |     use, intrinsic :: iso_fortran_env, dp => real64
+11 |     real(kind=dp) :: x, y
+12 |
+   -     y = ASIN(x) + DSIN(x)
+13 +     y = ASIN(x) + SIN(x)
+14 | end subroutine test1
+15 |
+16 | subroutine test2()
 
 ./resources/test/fixtures/obsolescent/OB031.f90:20:9: OB031 [*] deprecated type-specific function 'dsin'
    |
@@ -52,13 +50,12 @@ snapshot_kind: text
    |
    = help: Use 'sin'
 
-ℹ Unsafe fix
-17 17 |     use, intrinsic :: iso_fortran_env, dp => real64
-18 18 |     real(kind=dp) :: x, y
-19 19 | 
-20    |-    y = dsin(x) + dcos(x)
-   20 |+    y = sin(x) + dcos(x)
-21 21 | end subroutine test2
+17 |     use, intrinsic :: iso_fortran_env, dp => real64
+18 |     real(kind=dp) :: x, y
+19 |
+   -     y = dsin(x) + dcos(x)
+20 +     y = sin(x) + dcos(x)
+21 | end subroutine test2
 
 ./resources/test/fixtures/obsolescent/OB031.f90:20:19: OB031 [*] deprecated type-specific function 'dcos'
    |
@@ -70,10 +67,9 @@ snapshot_kind: text
    |
    = help: Use 'cos'
 
-ℹ Unsafe fix
-17 17 |     use, intrinsic :: iso_fortran_env, dp => real64
-18 18 |     real(kind=dp) :: x, y
-19 19 | 
-20    |-    y = dsin(x) + dcos(x)
-   20 |+    y = dsin(x) + cos(x)
-21 21 | end subroutine test2
+17 |     use, intrinsic :: iso_fortran_env, dp => real64
+18 |     real(kind=dp) :: x, y
+19 |
+   -     y = dsin(x) + dcos(x)
+20 +     y = dsin(x) + cos(x)
+21 | end subroutine test2

--- a/crates/fortitude_linter/src/rules/portability/snapshots/fortitude_linter__rules__portability__tests__invalid-tab_PORT031.f90.snap
+++ b/crates/fortitude_linter/src/rules/portability/snapshots/fortitude_linter__rules__portability__tests__invalid-tab_PORT031.f90.snap
@@ -14,15 +14,14 @@ snapshot_kind: text
   |
   = help: Replace with spaces
 
-ℹ Unsafe fix
-1 1 | ! If you touch this file, be careful your editor doesn't auto-correct
-2 2 | ! the horrible whitespace!
-3 3 | program invalid_tab
-4   |-	implicit none
-  4 |+    implicit none
-5 5 |     print*, "Don't flag this:	"
-6 6 |     ! Or this:|	|
-7 7 |     if	(.true.)	then
+1 | ! If you touch this file, be careful your editor doesn't auto-correct
+2 | ! the horrible whitespace!
+3 | program invalid_tab
+  - 	implicit none
+4 +     implicit none
+5 |     print*, "Don't flag this:	"
+6 |     ! Or this:|	|
+7 |     if	(.true.)	then
 
 ./resources/test/fixtures/portability/PORT031.f90:7:7: PORT031 [*] Invalid tab character
   |
@@ -35,15 +34,14 @@ snapshot_kind: text
   |
   = help: Replace with spaces
 
-ℹ Unsafe fix
-4 4 | 	implicit none
-5 5 |     print*, "Don't flag this:	"
-6 6 |     ! Or this:|	|
-7   |-    if	(.true.)	then
-  7 |+    if    (.true.)	then
-8 8 |     	print*, "Mixed tab/space"
-9 9 |     else
-10 10 | 		print*, "Two tabs"
+4  | 	implicit none
+5  |     print*, "Don't flag this:	"
+6  |     ! Or this:|	|
+   -     if	(.true.)	then
+7  +     if    (.true.)	then
+8  |     	print*, "Mixed tab/space"
+9  |     else
+10 | 		print*, "Two tabs"
 
 ./resources/test/fixtures/portability/PORT031.f90:7:16: PORT031 [*] Invalid tab character
   |
@@ -56,15 +54,14 @@ snapshot_kind: text
   |
   = help: Replace with spaces
 
-ℹ Unsafe fix
-4 4 | 	implicit none
-5 5 |     print*, "Don't flag this:	"
-6 6 |     ! Or this:|	|
-7   |-    if	(.true.)	then
-  7 |+    if	(.true.)    then
-8 8 |     	print*, "Mixed tab/space"
-9 9 |     else
-10 10 | 		print*, "Two tabs"
+4  | 	implicit none
+5  |     print*, "Don't flag this:	"
+6  |     ! Or this:|	|
+   -     if	(.true.)	then
+7  +     if	(.true.)    then
+8  |     	print*, "Mixed tab/space"
+9  |     else
+10 | 		print*, "Two tabs"
 
 ./resources/test/fixtures/portability/PORT031.f90:8:5: PORT031 [*] Invalid tab character
    |
@@ -77,15 +74,14 @@ snapshot_kind: text
    |
    = help: Replace with spaces
 
-ℹ Unsafe fix
-5 5 |     print*, "Don't flag this:	"
-6 6 |     ! Or this:|	|
-7 7 |     if	(.true.)	then
-8   |-    	print*, "Mixed tab/space"
-  8 |+        print*, "Mixed tab/space"
-9 9 |     else
-10 10 | 		print*, "Two tabs"
-11 11 |     end if
+5  |     print*, "Don't flag this:	"
+6  |     ! Or this:|	|
+7  |     if	(.true.)	then
+   -     	print*, "Mixed tab/space"
+8  +         print*, "Mixed tab/space"
+9  |     else
+10 | 		print*, "Two tabs"
+11 |     end if
 
 ./resources/test/fixtures/portability/PORT031.f90:10:1: PORT031 [*] Invalid tab character
    |
@@ -98,14 +94,13 @@ snapshot_kind: text
    |
    = help: Replace with spaces
 
-ℹ Unsafe fix
-7  7  |     if	(.true.)	then
-8  8  |     	print*, "Mixed tab/space"
-9  9  |     else
-10    |-		print*, "Two tabs"
-   10 |+    	print*, "Two tabs"
-11 11 |     end if
-12 12 | end program invalid_tab
+7  |     if	(.true.)	then
+8  |     	print*, "Mixed tab/space"
+9  |     else
+   - 		print*, "Two tabs"
+10 +     	print*, "Two tabs"
+11 |     end if
+12 | end program invalid_tab
 
 ./resources/test/fixtures/portability/PORT031.f90:10:2: PORT031 [*] Invalid tab character
    |
@@ -118,11 +113,10 @@ snapshot_kind: text
    |
    = help: Replace with spaces
 
-ℹ Unsafe fix
-7  7  |     if	(.true.)	then
-8  8  |     	print*, "Mixed tab/space"
-9  9  |     else
-10    |-		print*, "Two tabs"
-   10 |+	    print*, "Two tabs"
-11 11 |     end if
-12 12 | end program invalid_tab
+7  |     if	(.true.)	then
+8  |     	print*, "Mixed tab/space"
+9  |     else
+   - 		print*, "Two tabs"
+10 + 	    print*, "Two tabs"
+11 |     end if
+12 | end program invalid_tab

--- a/crates/fortitude_linter/src/rules/portability/snapshots/fortitude_linter__rules__portability__tests__star-kind_PORT021.f90.snap
+++ b/crates/fortitude_linter/src/rules/portability/snapshots/fortitude_linter__rules__portability__tests__star-kind_PORT021.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/portability/mod.rs
+source: crates/fortitude_linter/src/rules/portability/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -12,12 +12,11 @@ snapshot_kind: text
   |
   = help: Replace with 'integer(8)'
 
-ℹ Unsafe fix
-1   |-integer*8 function add_if(x, y, z)
-  1 |+integer(8) function add_if(x, y, z)
-2 2 |   integer(kind=2), intent(in) :: x
-3 3 |   integer *4, intent(in) :: y
-4 4 |   logical*   4, intent(in) :: z
+  - integer*8 function add_if(x, y, z)
+1 + integer(8) function add_if(x, y, z)
+2 |   integer(kind=2), intent(in) :: x
+3 |   integer *4, intent(in) :: y
+4 |   logical*   4, intent(in) :: z
 
 ./resources/test/fixtures/portability/PORT021.f90:3:11: PORT021 [*] 'integer*4' uses non-standard syntax
   |
@@ -30,14 +29,13 @@ snapshot_kind: text
   |
   = help: Replace with 'integer(4)'
 
-ℹ Unsafe fix
-1 1 | integer*8 function add_if(x, y, z)
-2 2 |   integer(kind=2), intent(in) :: x
-3   |-  integer *4, intent(in) :: y
-  3 |+  integer(4), intent(in) :: y
-4 4 |   logical*   4, intent(in) :: z
-5 5 |   real    * &
-6 6 |        8 :: t
+1 | integer*8 function add_if(x, y, z)
+2 |   integer(kind=2), intent(in) :: x
+  -   integer *4, intent(in) :: y
+3 +   integer(4), intent(in) :: y
+4 |   logical*   4, intent(in) :: z
+5 |   real    * &
+6 |        8 :: t
 
 ./resources/test/fixtures/portability/PORT021.f90:4:10: PORT021 [*] 'logical*4' uses non-standard syntax
   |
@@ -50,15 +48,14 @@ snapshot_kind: text
   |
   = help: Replace with 'logical(4)'
 
-ℹ Unsafe fix
-1 1 | integer*8 function add_if(x, y, z)
-2 2 |   integer(kind=2), intent(in) :: x
-3 3 |   integer *4, intent(in) :: y
-4   |-  logical*   4, intent(in) :: z
-  4 |+  logical(4), intent(in) :: z
-5 5 |   real    * &
-6 6 |        8 :: t
-7 7 | 
+1 | integer*8 function add_if(x, y, z)
+2 |   integer(kind=2), intent(in) :: x
+3 |   integer *4, intent(in) :: y
+  -   logical*   4, intent(in) :: z
+4 +   logical(4), intent(in) :: z
+5 |   real    * &
+6 |        8 :: t
+7 |
 
 ./resources/test/fixtures/portability/PORT021.f90:5:11: PORT021 [*] 'real*8' uses non-standard syntax
   |
@@ -73,16 +70,15 @@ snapshot_kind: text
   |
   = help: Replace with 'real(8)'
 
-ℹ Unsafe fix
-2 2 |   integer(kind=2), intent(in) :: x
-3 3 |   integer *4, intent(in) :: y
-4 4 |   logical*   4, intent(in) :: z
-5   |-  real    * &
-6   |-       8 :: t
-  5 |+  real(8) :: t
-7 6 | 
-8 7 |   if (x == 2) then
-9 8 |     add_if = x + y
+2 |   integer(kind=2), intent(in) :: x
+3 |   integer *4, intent(in) :: y
+4 |   logical*   4, intent(in) :: z
+  -   real    * &
+  -        8 :: t
+5 +   real(8) :: t
+6 |
+7 |   if (x == 2) then
+8 |     add_if = x + y
 
 ./resources/test/fixtures/portability/PORT021.f90:16:8: PORT021 [*] 'real*4' uses non-standard syntax
    |
@@ -94,15 +90,14 @@ snapshot_kind: text
    |
    = help: Replace with 'real(4)'
 
-ℹ Unsafe fix
-13 13 | end function add_if
-14 14 | 
-15 15 | subroutine complex_mul(x, real)
-16    |-  real * 4, intent(in) :: x
-   16 |+  real(4), intent(in) :: x
-17 17 |   complex  *  8, intent(inout) :: real
-18 18 |   ! This would be a false positive with purely regexp based linting
-19 19 |   real = real * 8
+13 | end function add_if
+14 |
+15 | subroutine complex_mul(x, real)
+   -   real * 4, intent(in) :: x
+16 +   real(4), intent(in) :: x
+17 |   complex  *  8, intent(inout) :: real
+18 |   ! This would be a false positive with purely regexp based linting
+19 |   real = real * 8
 
 ./resources/test/fixtures/portability/PORT021.f90:17:12: PORT021 [*] 'complex*8' uses non-standard syntax
    |
@@ -115,12 +110,11 @@ snapshot_kind: text
    |
    = help: Replace with 'complex(8)'
 
-ℹ Unsafe fix
-14 14 | 
-15 15 | subroutine complex_mul(x, real)
-16 16 |   real * 4, intent(in) :: x
-17    |-  complex  *  8, intent(inout) :: real
-   17 |+  complex(8), intent(inout) :: real
-18 18 |   ! This would be a false positive with purely regexp based linting
-19 19 |   real = real * 8
-20 20 | end subroutine complex_mul
+14 |
+15 | subroutine complex_mul(x, real)
+16 |   real * 4, intent(in) :: x
+   -   complex  *  8, intent(inout) :: real
+17 +   complex(8), intent(inout) :: real
+18 |   ! This would be a false positive with purely regexp based linting
+19 |   real = real * 8
+20 | end subroutine complex_mul

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__avoidable-escaped-quote_S242.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__avoidable-escaped-quote_S242.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,15 +14,14 @@ snapshot_kind: text
   |
   = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-2 2 |   use, intrinsic :: iso_c_binding, only: c_char
-3 3 |   implicit none (type, external)
-4 4 | 
-5   |-  print*, 'This isn''t necessary'
-  5 |+  print*, "This isn't necessary"
-6 6 |   print*, "This ""is not"" necessary"
-7 7 |   print*, 'This "isn''t" unnecessary'
-8 8 |   print*, "This ""isn't"" unnecessary"
+2 |   use, intrinsic :: iso_c_binding, only: c_char
+3 |   implicit none (type, external)
+4 |
+  -   print*, 'This isn''t necessary'
+5 +   print*, "This isn't necessary"
+6 |   print*, "This ""is not"" necessary"
+7 |   print*, 'This "isn''t" unnecessary'
+8 |   print*, "This ""isn't"" unnecessary"
 
 ./resources/test/fixtures/style/S242.f90:6:11: S242 [*] Avoidable escaped quotes
   |
@@ -34,15 +33,14 @@ snapshot_kind: text
   |
   = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-3 3 |   implicit none (type, external)
-4 4 | 
-5 5 |   print*, 'This isn''t necessary'
-6   |-  print*, "This ""is not"" necessary"
-  6 |+  print*, 'This "is not" necessary'
-7 7 |   print*, 'This "isn''t" unnecessary'
-8 8 |   print*, "This ""isn't"" unnecessary"
-9 9 |   print*, 4_"Does this ""break""?"
+3 |   implicit none (type, external)
+4 |
+5 |   print*, 'This isn''t necessary'
+  -   print*, "This ""is not"" necessary"
+6 +   print*, 'This "is not" necessary'
+7 |   print*, 'This "isn''t" unnecessary'
+8 |   print*, "This ""isn't"" unnecessary"
+9 |   print*, 4_"Does this ""break""?"
 
 ./resources/test/fixtures/style/S242.f90:9:13: S242 [*] Avoidable escaped quotes
    |
@@ -55,15 +53,14 @@ snapshot_kind: text
    |
    = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-6  6  |   print*, "This ""is not"" necessary"
-7  7  |   print*, 'This "isn''t" unnecessary'
-8  8  |   print*, "This ""isn't"" unnecessary"
-9     |-  print*, 4_"Does this ""break""?"
-   9  |+  print*, 4_'Does this "break"?'
-10 10 |   print*, c_char_'Does this ''break''?'
-11 11 |   print*, 'This &
-12 12 |        &isn''t &
+6  |   print*, "This ""is not"" necessary"
+7  |   print*, 'This "isn''t" unnecessary'
+8  |   print*, "This ""isn't"" unnecessary"
+   -   print*, 4_"Does this ""break""?"
+9  +   print*, 4_'Does this "break"?'
+10 |   print*, c_char_'Does this ''break''?'
+11 |   print*, 'This &
+12 |        &isn''t &
 
 ./resources/test/fixtures/style/S242.f90:10:18: S242 [*] Avoidable escaped quotes
    |
@@ -76,15 +73,14 @@ snapshot_kind: text
    |
    = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-7  7  |   print*, 'This "isn''t" unnecessary'
-8  8  |   print*, "This ""isn't"" unnecessary"
-9  9  |   print*, 4_"Does this ""break""?"
-10    |-  print*, c_char_'Does this ''break''?'
-   10 |+  print*, c_char_"Does this 'break'?"
-11 11 |   print*, 'This &
-12 12 |        &isn''t &
-13 13 |        &necessary'
+7  |   print*, 'This "isn''t" unnecessary'
+8  |   print*, "This ""isn't"" unnecessary"
+9  |   print*, 4_"Does this ""break""?"
+   -   print*, c_char_'Does this ''break''?'
+10 +   print*, c_char_"Does this 'break'?"
+11 |   print*, 'This &
+12 |        &isn''t &
+13 |        &necessary'
 
 ./resources/test/fixtures/style/S242.f90:11:11: S242 [*] Avoidable escaped quotes
    |
@@ -100,19 +96,18 @@ snapshot_kind: text
    |
    = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-8  8  |   print*, "This ""isn't"" unnecessary"
-9  9  |   print*, 4_"Does this ""break""?"
-10 10 |   print*, c_char_'Does this ''break''?'
-11    |-  print*, 'This &
-12    |-       &isn''t &
-13    |-       &necessary'
-   11 |+  print*, "This &
-   12 |+       &isn't &
-   13 |+       &necessary"
-14 14 |   print*, 'This &
-15 15 |        &""isn''t"" &
-16 16 |        &unnecessary'
+8  |   print*, "This ""isn't"" unnecessary"
+9  |   print*, 4_"Does this ""break""?"
+10 |   print*, c_char_'Does this ''break''?'
+   -   print*, 'This &
+   -        &isn''t &
+   -        &necessary'
+11 +   print*, "This &
+12 +        &isn't &
+13 +        &necessary"
+14 |   print*, 'This &
+15 |        &""isn''t"" &
+16 |        &unnecessary'
 
 ./resources/test/fixtures/style/S242.f90:21:11: S242 [*] Avoidable escaped quotes
    |
@@ -125,15 +120,14 @@ snapshot_kind: text
    |
    = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-18 18 |   ! Multiple quotes
-19 19 |   print*, ''                    ! empty
-20 20 |   print*, ""                    ! empty
-21    |-  print*, ''''                  ! '
-   21 |+  print*, "'"                  ! '
-22 22 |   print*, """"                  ! "
-23 23 |   print*, ''''''                ! ''
-24 24 |   print*, ''''''''              ! '''
+18 |   ! Multiple quotes
+19 |   print*, ''                    ! empty
+20 |   print*, ""                    ! empty
+   -   print*, ''''                  ! '
+21 +   print*, "'"                  ! '
+22 |   print*, """"                  ! "
+23 |   print*, ''''''                ! ''
+24 |   print*, ''''''''              ! '''
 
 ./resources/test/fixtures/style/S242.f90:22:11: S242 [*] Avoidable escaped quotes
    |
@@ -146,15 +140,14 @@ snapshot_kind: text
    |
    = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-19 19 |   print*, ''                    ! empty
-20 20 |   print*, ""                    ! empty
-21 21 |   print*, ''''                  ! '
-22    |-  print*, """"                  ! "
-   22 |+  print*, '"'                  ! "
-23 23 |   print*, ''''''                ! ''
-24 24 |   print*, ''''''''              ! '''
-25 25 |   print*, """"""                ! ""
+19 |   print*, ''                    ! empty
+20 |   print*, ""                    ! empty
+21 |   print*, ''''                  ! '
+   -   print*, """"                  ! "
+22 +   print*, '"'                  ! "
+23 |   print*, ''''''                ! ''
+24 |   print*, ''''''''              ! '''
+25 |   print*, """"""                ! ""
 
 ./resources/test/fixtures/style/S242.f90:23:11: S242 [*] Avoidable escaped quotes
    |
@@ -167,15 +160,14 @@ snapshot_kind: text
    |
    = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-20 20 |   print*, ""                    ! empty
-21 21 |   print*, ''''                  ! '
-22 22 |   print*, """"                  ! "
-23    |-  print*, ''''''                ! ''
-   23 |+  print*, "''"                ! ''
-24 24 |   print*, ''''''''              ! '''
-25 25 |   print*, """"""                ! ""
-26 26 |   print*, """"""""              ! """
+20 |   print*, ""                    ! empty
+21 |   print*, ''''                  ! '
+22 |   print*, """"                  ! "
+   -   print*, ''''''                ! ''
+23 +   print*, "''"                ! ''
+24 |   print*, ''''''''              ! '''
+25 |   print*, """"""                ! ""
+26 |   print*, """"""""              ! """
 
 ./resources/test/fixtures/style/S242.f90:24:11: S242 [*] Avoidable escaped quotes
    |
@@ -188,15 +180,14 @@ snapshot_kind: text
    |
    = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-21 21 |   print*, ''''                  ! '
-22 22 |   print*, """"                  ! "
-23 23 |   print*, ''''''                ! ''
-24    |-  print*, ''''''''              ! '''
-   24 |+  print*, "'''"              ! '''
-25 25 |   print*, """"""                ! ""
-26 26 |   print*, """"""""              ! """
-27 27 | 
+21 |   print*, ''''                  ! '
+22 |   print*, """"                  ! "
+23 |   print*, ''''''                ! ''
+   -   print*, ''''''''              ! '''
+24 +   print*, "'''"              ! '''
+25 |   print*, """"""                ! ""
+26 |   print*, """"""""              ! """
+27 |
 
 ./resources/test/fixtures/style/S242.f90:25:11: S242 [*] Avoidable escaped quotes
    |
@@ -208,15 +199,14 @@ snapshot_kind: text
    |
    = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-22 22 |   print*, """"                  ! "
-23 23 |   print*, ''''''                ! ''
-24 24 |   print*, ''''''''              ! '''
-25    |-  print*, """"""                ! ""
-   25 |+  print*, '""'                ! ""
-26 26 |   print*, """"""""              ! """
-27 27 | 
-28 28 | end program test
+22 |   print*, """"                  ! "
+23 |   print*, ''''''                ! ''
+24 |   print*, ''''''''              ! '''
+   -   print*, """"""                ! ""
+25 +   print*, '""'                ! ""
+26 |   print*, """"""""              ! """
+27 |
+28 | end program test
 
 ./resources/test/fixtures/style/S242.f90:26:11: S242 [*] Avoidable escaped quotes
    |
@@ -229,11 +219,10 @@ snapshot_kind: text
    |
    = help: Change outer quotes to avoid escaping inner quotes
 
-ℹ Safe fix
-23 23 |   print*, ''''''                ! ''
-24 24 |   print*, ''''''''              ! '''
-25 25 |   print*, """"""                ! ""
-26    |-  print*, """"""""              ! """
-   26 |+  print*, '"""'              ! """
-27 27 | 
-28 28 | end program test
+23 |   print*, ''''''                ! ''
+24 |   print*, ''''''''              ! '''
+25 |   print*, """"""                ! ""
+   -   print*, """"""""              ! """
+26 +   print*, '"""'              ! """
+27 |
+28 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__bad-array-declaration_S263.f90_always.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__bad-array-declaration_S263.f90_always.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
   |
   = help: Add `dimension` attribute to declaration
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3 3 |   real, dimension(2) :: x, y = [4, 2], z(3)
-4   |-  real :: a(1), b(2) = [4, 2], c(3, 4)
-  4 |+  real ::  b(2) = [4, 2], c(3, 4)
-  5 |+  real, dimension(1) :: a
-5 6 |   integer, dimension(2), parameter :: p = [1, 2]
-6 7 |   integer, parameter :: q(2) = [1, 2]
-7 8 | end program test
+1 | program test
+2 |   implicit none (external, type)
+3 |   real, dimension(2) :: x, y = [4, 2], z(3)
+  -   real :: a(1), b(2) = [4, 2], c(3, 4)
+4 +   real ::  b(2) = [4, 2], c(3, 4)
+5 +   real, dimension(1) :: a
+6 |   integer, dimension(2), parameter :: p = [1, 2]
+7 |   integer, parameter :: q(2) = [1, 2]
+8 | end program test
 
 ./resources/test/fixtures/style/S263.f90:4:17: S263 [*] Bad declaration of array
   |
@@ -36,16 +35,15 @@ snapshot_kind: text
   |
   = help: Add `dimension` attribute to declaration
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3 3 |   real, dimension(2) :: x, y = [4, 2], z(3)
-4   |-  real :: a(1), b(2) = [4, 2], c(3, 4)
-  4 |+  real :: a(1),  c(3, 4)
-  5 |+  real, dimension(2) :: b = [4, 2]
-5 6 |   integer, dimension(2), parameter :: p = [1, 2]
-6 7 |   integer, parameter :: q(2) = [1, 2]
-7 8 | end program test
+1 | program test
+2 |   implicit none (external, type)
+3 |   real, dimension(2) :: x, y = [4, 2], z(3)
+  -   real :: a(1), b(2) = [4, 2], c(3, 4)
+4 +   real :: a(1),  c(3, 4)
+5 +   real, dimension(2) :: b = [4, 2]
+6 |   integer, dimension(2), parameter :: p = [1, 2]
+7 |   integer, parameter :: q(2) = [1, 2]
+8 | end program test
 
 ./resources/test/fixtures/style/S263.f90:4:32: S263 [*] Bad declaration of array
   |
@@ -58,16 +56,15 @@ snapshot_kind: text
   |
   = help: Add `dimension` attribute to declaration
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3 3 |   real, dimension(2) :: x, y = [4, 2], z(3)
-4   |-  real :: a(1), b(2) = [4, 2], c(3, 4)
-  4 |+  real :: a(1), b(2) = [4, 2]
-  5 |+  real, dimension(3, 4) :: c
-5 6 |   integer, dimension(2), parameter :: p = [1, 2]
-6 7 |   integer, parameter :: q(2) = [1, 2]
-7 8 | end program test
+1 | program test
+2 |   implicit none (external, type)
+3 |   real, dimension(2) :: x, y = [4, 2], z(3)
+  -   real :: a(1), b(2) = [4, 2], c(3, 4)
+4 +   real :: a(1), b(2) = [4, 2]
+5 +   real, dimension(3, 4) :: c
+6 |   integer, dimension(2), parameter :: p = [1, 2]
+7 |   integer, parameter :: q(2) = [1, 2]
+8 | end program test
 
 ./resources/test/fixtures/style/S263.f90:6:25: S263 [*] Bad declaration of array
   |
@@ -79,10 +76,9 @@ snapshot_kind: text
   |
   = help: Add `dimension` attribute to declaration
 
-ℹ Unsafe fix
-3 3 |   real, dimension(2) :: x, y = [4, 2], z(3)
-4 4 |   real :: a(1), b(2) = [4, 2], c(3, 4)
-5 5 |   integer, dimension(2), parameter :: p = [1, 2]
-6   |-  integer, parameter :: q(2) = [1, 2]
-  6 |+  integer, parameter, dimension(2) :: q = [1, 2]
-7 7 | end program test
+3 |   real, dimension(2) :: x, y = [4, 2], z(3)
+4 |   real :: a(1), b(2) = [4, 2], c(3, 4)
+5 |   integer, dimension(2), parameter :: p = [1, 2]
+  -   integer, parameter :: q(2) = [1, 2]
+6 +   integer, parameter, dimension(2) :: q = [1, 2]
+7 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__bad-array-declaration_S263.f90_never.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__bad-array-declaration_S263.f90_never.snap
@@ -14,15 +14,14 @@ snapshot_kind: text
   |
   = help: Remove `dimension` attribute from declaration
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3   |-  real, dimension(2) :: x, y = [4, 2], z(3)
-  3 |+  real, dimension(2) ::  y = [4, 2], z(3)
-  4 |+  real :: x(2)
-4 5 |   real :: a(1), b(2) = [4, 2], c(3, 4)
-5 6 |   integer, dimension(2), parameter :: p = [1, 2]
-6 7 |   integer, parameter :: q(2) = [1, 2]
+1 | program test
+2 |   implicit none (external, type)
+  -   real, dimension(2) :: x, y = [4, 2], z(3)
+3 +   real, dimension(2) ::  y = [4, 2], z(3)
+4 +   real :: x(2)
+5 |   real :: a(1), b(2) = [4, 2], c(3, 4)
+6 |   integer, dimension(2), parameter :: p = [1, 2]
+7 |   integer, parameter :: q(2) = [1, 2]
 
 ./resources/test/fixtures/style/S263.f90:3:28: S263 [*] Bad declaration of array
   |
@@ -35,15 +34,14 @@ snapshot_kind: text
   |
   = help: Remove `dimension` attribute from declaration
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3   |-  real, dimension(2) :: x, y = [4, 2], z(3)
-  3 |+  real, dimension(2) :: x,  z(3)
-  4 |+  real :: y(2) = [4, 2]
-4 5 |   real :: a(1), b(2) = [4, 2], c(3, 4)
-5 6 |   integer, dimension(2), parameter :: p = [1, 2]
-6 7 |   integer, parameter :: q(2) = [1, 2]
+1 | program test
+2 |   implicit none (external, type)
+  -   real, dimension(2) :: x, y = [4, 2], z(3)
+3 +   real, dimension(2) :: x,  z(3)
+4 +   real :: y(2) = [4, 2]
+5 |   real :: a(1), b(2) = [4, 2], c(3, 4)
+6 |   integer, dimension(2), parameter :: p = [1, 2]
+7 |   integer, parameter :: q(2) = [1, 2]
 
 ./resources/test/fixtures/style/S263.f90:5:39: S263 [*] Bad declaration of array
   |
@@ -56,11 +54,10 @@ snapshot_kind: text
   |
   = help: Remove `dimension` attribute from declaration
 
-ℹ Unsafe fix
-2 2 |   implicit none (external, type)
-3 3 |   real, dimension(2) :: x, y = [4, 2], z(3)
-4 4 |   real :: a(1), b(2) = [4, 2], c(3, 4)
-5   |-  integer, dimension(2), parameter :: p = [1, 2]
-  5 |+  integer, parameter :: p(2) = [1, 2]
-6 6 |   integer, parameter :: q(2) = [1, 2]
-7 7 | end program test
+2 |   implicit none (external, type)
+3 |   real, dimension(2) :: x, y = [4, 2], z(3)
+4 |   real :: a(1), b(2) = [4, 2], c(3, 4)
+  -   integer, dimension(2), parameter :: p = [1, 2]
+5 +   integer, parameter :: p(2) = [1, 2]
+6 |   integer, parameter :: q(2) = [1, 2]
+7 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__bad-quote-string_S241.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__bad-quote-string_S241.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -13,15 +13,14 @@ snapshot_kind: text
   |
   = help: Replace single quotes with double quotes
 
-ℹ Safe fix
-2 2 |   implicit none (type, external)
-3 3 | 
-4 4 |   print *, "Hello, World!"
-5   |-  print *, 'Hello, World!'
-  5 |+  print *, "Hello, World!"
-6 6 |   print *, 'Hello, "World"!'
-7 7 |   print *, "Hello, ""World""!"
-8 8 |   print *, 'Hello, ''World''!'
+2 |   implicit none (type, external)
+3 |
+4 |   print *, "Hello, World!"
+  -   print *, 'Hello, World!'
+5 +   print *, "Hello, World!"
+6 |   print *, 'Hello, "World"!'
+7 |   print *, "Hello, ""World""!"
+8 |   print *, 'Hello, ''World''!'
 
 ./resources/test/fixtures/style/S241.f90:8:12: S241 String uses single quotes but double quotes preferred
    |
@@ -46,17 +45,16 @@ snapshot_kind: text
    |
    = help: Replace single quotes with double quotes
 
-ℹ Safe fix
-8  8  |   print *, 'Hello, ''World''!'
-9  9  |   print *, "Hello, &
-10 10 |             & World!"
-11    |-  print *, 'Hello, &
-12    |-            & World!'
-   11 |+  print *, "Hello, &
-   12 |+            & World!"
-13 13 |   print *, 'Hello, &
-14 14 |             & "World"!'
-15 15 |   print *, "Hello, &
+8  |   print *, 'Hello, ''World''!'
+9  |   print *, "Hello, &
+10 |             & World!"
+   -   print *, 'Hello, &
+   -             & World!'
+11 +   print *, "Hello, &
+12 +             & World!"
+13 |   print *, 'Hello, &
+14 |             & "World"!'
+15 |   print *, "Hello, &
 
 ./resources/test/fixtures/style/S241.f90:17:12: S241 String uses single quotes but double quotes preferred
    |

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__bad-quote-string_S241.f90_include_inout_goto.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__bad-quote-string_S241.f90_include_inout_goto.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,16 +14,15 @@ snapshot_kind: text
   |
   = help: Replace double quotes with single quotes
 
-ℹ Safe fix
-1 1 | program p
-2 2 |   implicit none (type, external)
-3 3 | 
-4   |-  print *, "Hello, World!"
-5 4 |   print *, 'Hello, World!'
-  5 |+  print *, 'Hello, World!'
-6 6 |   print *, 'Hello, "World"!'
-7 7 |   print *, "Hello, ""World""!"
-8 8 |   print *, 'Hello, ''World''!'
+1 | program p
+2 |   implicit none (type, external)
+3 |
+  -   print *, "Hello, World!"
+4 |   print *, 'Hello, World!'
+5 +   print *, 'Hello, World!'
+6 |   print *, 'Hello, "World"!'
+7 |   print *, "Hello, ""World""!"
+8 |   print *, 'Hello, ''World''!'
 
 ./resources/test/fixtures/style/S241.f90:7:12: S241 String uses double quotes but single quotes preferred
   |
@@ -48,20 +47,19 @@ snapshot_kind: text
    |
    = help: Replace double quotes with single quotes
 
-ℹ Safe fix
-6  6  |   print *, 'Hello, "World"!'
-7  7  |   print *, "Hello, ""World""!"
-8  8  |   print *, 'Hello, ''World''!'
-9     |-  print *, "Hello, &
-10    |-            & World!"
-11 9  |   print *, 'Hello, &
-12 10 |             & World!'
-13 11 |   print *, 'Hello, &
-   12 |+            & World!'
-   13 |+  print *, 'Hello, &
-14 14 |             & "World"!'
-15 15 |   print *, "Hello, &
-16 16 |             & ""World""!"
+6  |   print *, 'Hello, "World"!'
+7  |   print *, "Hello, ""World""!"
+8  |   print *, 'Hello, ''World''!'
+   -   print *, "Hello, &
+   -             & World!"
+9  |   print *, 'Hello, &
+10 |             & World!'
+11 |   print *, 'Hello, &
+12 +             & World!'
+13 +   print *, 'Hello, &
+14 |             & "World"!'
+15 |   print *, "Hello, &
+16 |             & ""World""!"
 
 ./resources/test/fixtures/style/S241.f90:15:12: S241 String uses double quotes but single quotes preferred
    |

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__bare-decimal_S291.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__bare-decimal_S291.f90.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S291.f90:7:21: S291 [*] trailing decimal point in `real` literal `6.`
   |
@@ -12,15 +13,14 @@ expression: diagnostics
   |
   = help: Prefer `6.0`
 
-ℹ Safe fix
-4 4 |     implicit none (type, external)
-5 5 | 
-6 6 |     real(dp) :: a = 6.0
-7   |-    real(dp) :: b = 6.
-  7 |+    real(dp) :: b = 6.0
-8 8 |     real(dp) :: c = .6
-9 9 |     real(dp) :: d = 12.45
-10 10 |     real(dp) :: e = .45
+4  |     implicit none (type, external)
+5  |
+6  |     real(dp) :: a = 6.0
+   -     real(dp) :: b = 6.
+7  +     real(dp) :: b = 6.0
+8  |     real(dp) :: c = .6
+9  |     real(dp) :: d = 12.45
+10 |     real(dp) :: e = .45
 
 ./resources/test/fixtures/style/S291.f90:8:21: S291 [*] leading decimal point in `real` literal `.6`
    |
@@ -33,15 +33,14 @@ expression: diagnostics
    |
    = help: Prefer `0.6`
 
-ℹ Safe fix
-5 5 | 
-6 6 |     real(dp) :: a = 6.0
-7 7 |     real(dp) :: b = 6.
-8   |-    real(dp) :: c = .6
-  8 |+    real(dp) :: c = 0.6
-9 9 |     real(dp) :: d = 12.45
-10 10 |     real(dp) :: e = .45
-11 11 |     real(dp) :: f = 45.
+5  |
+6  |     real(dp) :: a = 6.0
+7  |     real(dp) :: b = 6.
+   -     real(dp) :: c = .6
+8  +     real(dp) :: c = 0.6
+9  |     real(dp) :: d = 12.45
+10 |     real(dp) :: e = .45
+11 |     real(dp) :: f = 45.
 
 ./resources/test/fixtures/style/S291.f90:10:21: S291 [*] leading decimal point in `real` literal `.45`
    |
@@ -54,15 +53,14 @@ expression: diagnostics
    |
    = help: Prefer `0.45`
 
-ℹ Safe fix
-7  7  |     real(dp) :: b = 6.
-8  8  |     real(dp) :: c = .6
-9  9  |     real(dp) :: d = 12.45
-10    |-    real(dp) :: e = .45
-   10 |+    real(dp) :: e = 0.45
-11 11 |     real(dp) :: f = 45.
-12 12 |     real(dp) :: g = 1.0e+10
-13 13 |     real(dp) :: h = 3.e+10
+7  |     real(dp) :: b = 6.
+8  |     real(dp) :: c = .6
+9  |     real(dp) :: d = 12.45
+   -     real(dp) :: e = .45
+10 +     real(dp) :: e = 0.45
+11 |     real(dp) :: f = 45.
+12 |     real(dp) :: g = 1.0e+10
+13 |     real(dp) :: h = 3.e+10
 
 ./resources/test/fixtures/style/S291.f90:11:21: S291 [*] trailing decimal point in `real` literal `45.`
    |
@@ -75,15 +73,14 @@ expression: diagnostics
    |
    = help: Prefer `45.0`
 
-ℹ Safe fix
-8  8  |     real(dp) :: c = .6
-9  9  |     real(dp) :: d = 12.45
-10 10 |     real(dp) :: e = .45
-11    |-    real(dp) :: f = 45.
-   11 |+    real(dp) :: f = 45.0
-12 12 |     real(dp) :: g = 1.0e+10
-13 13 |     real(dp) :: h = 3.e+10
-14 14 |     real(dp) :: i = .5e10
+8  |     real(dp) :: c = .6
+9  |     real(dp) :: d = 12.45
+10 |     real(dp) :: e = .45
+   -     real(dp) :: f = 45.
+11 +     real(dp) :: f = 45.0
+12 |     real(dp) :: g = 1.0e+10
+13 |     real(dp) :: h = 3.e+10
+14 |     real(dp) :: i = .5e10
 
 ./resources/test/fixtures/style/S291.f90:13:21: S291 [*] trailing decimal point in `real` literal `3.e+10`
    |
@@ -96,15 +93,14 @@ expression: diagnostics
    |
    = help: Prefer `3.0e+10`
 
-ℹ Safe fix
-10 10 |     real(dp) :: e = .45
-11 11 |     real(dp) :: f = 45.
-12 12 |     real(dp) :: g = 1.0e+10
-13    |-    real(dp) :: h = 3.e+10
-   13 |+    real(dp) :: h = 3.0e+10
-14 14 |     real(dp) :: i = .5e10
-15 15 |     real(dp) :: j = 11.0d+10
-16 16 |     real(dp) :: k = 53.d+10
+10 |     real(dp) :: e = .45
+11 |     real(dp) :: f = 45.
+12 |     real(dp) :: g = 1.0e+10
+   -     real(dp) :: h = 3.e+10
+13 +     real(dp) :: h = 3.0e+10
+14 |     real(dp) :: i = .5e10
+15 |     real(dp) :: j = 11.0d+10
+16 |     real(dp) :: k = 53.d+10
 
 ./resources/test/fixtures/style/S291.f90:14:21: S291 [*] leading decimal point in `real` literal `.5e10`
    |
@@ -117,15 +113,14 @@ expression: diagnostics
    |
    = help: Prefer `0.5e10`
 
-ℹ Safe fix
-11 11 |     real(dp) :: f = 45.
-12 12 |     real(dp) :: g = 1.0e+10
-13 13 |     real(dp) :: h = 3.e+10
-14    |-    real(dp) :: i = .5e10
-   14 |+    real(dp) :: i = 0.5e10
-15 15 |     real(dp) :: j = 11.0d+10
-16 16 |     real(dp) :: k = 53.d+10
-17 17 |     real(dp) :: l = .75d10
+11 |     real(dp) :: f = 45.
+12 |     real(dp) :: g = 1.0e+10
+13 |     real(dp) :: h = 3.e+10
+   -     real(dp) :: i = .5e10
+14 +     real(dp) :: i = 0.5e10
+15 |     real(dp) :: j = 11.0d+10
+16 |     real(dp) :: k = 53.d+10
+17 |     real(dp) :: l = .75d10
 
 ./resources/test/fixtures/style/S291.f90:16:21: S291 [*] trailing decimal point in `real` literal `53.d+10`
    |
@@ -138,15 +133,14 @@ expression: diagnostics
    |
    = help: Prefer `53.0d+10`
 
-ℹ Safe fix
-13 13 |     real(dp) :: h = 3.e+10
-14 14 |     real(dp) :: i = .5e10
-15 15 |     real(dp) :: j = 11.0d+10
-16    |-    real(dp) :: k = 53.d+10
-   16 |+    real(dp) :: k = 53.0d+10
-17 17 |     real(dp) :: l = .75d10
-18 18 |     real(dp) :: m = .5_dp
-19 19 |     real(dp) :: n = 5._dp
+13 |     real(dp) :: h = 3.e+10
+14 |     real(dp) :: i = .5e10
+15 |     real(dp) :: j = 11.0d+10
+   -     real(dp) :: k = 53.d+10
+16 +     real(dp) :: k = 53.0d+10
+17 |     real(dp) :: l = .75d10
+18 |     real(dp) :: m = .5_dp
+19 |     real(dp) :: n = 5._dp
 
 ./resources/test/fixtures/style/S291.f90:17:21: S291 [*] leading decimal point in `real` literal `.75d10`
    |
@@ -159,15 +153,14 @@ expression: diagnostics
    |
    = help: Prefer `0.75d10`
 
-ℹ Safe fix
-14 14 |     real(dp) :: i = .5e10
-15 15 |     real(dp) :: j = 11.0d+10
-16 16 |     real(dp) :: k = 53.d+10
-17    |-    real(dp) :: l = .75d10
-   17 |+    real(dp) :: l = 0.75d10
-18 18 |     real(dp) :: m = .5_dp
-19 19 |     real(dp) :: n = 5._dp
-20 20 |     real(dp) :: o = 0.5_dp
+14 |     real(dp) :: i = .5e10
+15 |     real(dp) :: j = 11.0d+10
+16 |     real(dp) :: k = 53.d+10
+   -     real(dp) :: l = .75d10
+17 +     real(dp) :: l = 0.75d10
+18 |     real(dp) :: m = .5_dp
+19 |     real(dp) :: n = 5._dp
+20 |     real(dp) :: o = 0.5_dp
 
 ./resources/test/fixtures/style/S291.f90:18:21: S291 [*] leading decimal point in `real` literal `.5_dp`
    |
@@ -180,15 +173,14 @@ expression: diagnostics
    |
    = help: Prefer `0.5_dp`
 
-ℹ Safe fix
-15 15 |     real(dp) :: j = 11.0d+10
-16 16 |     real(dp) :: k = 53.d+10
-17 17 |     real(dp) :: l = .75d10
-18    |-    real(dp) :: m = .5_dp
-   18 |+    real(dp) :: m = 0.5_dp
-19 19 |     real(dp) :: n = 5._dp
-20 20 |     real(dp) :: o = 0.5_dp
-21 21 | 
+15 |     real(dp) :: j = 11.0d+10
+16 |     real(dp) :: k = 53.d+10
+17 |     real(dp) :: l = .75d10
+   -     real(dp) :: m = .5_dp
+18 +     real(dp) :: m = 0.5_dp
+19 |     real(dp) :: n = 5._dp
+20 |     real(dp) :: o = 0.5_dp
+21 |
 
 ./resources/test/fixtures/style/S291.f90:19:21: S291 [*] trailing decimal point in `real` literal `5._dp`
    |
@@ -200,12 +192,11 @@ expression: diagnostics
    |
    = help: Prefer `5.0_dp`
 
-ℹ Safe fix
-16 16 |     real(dp) :: k = 53.d+10
-17 17 |     real(dp) :: l = .75d10
-18 18 |     real(dp) :: m = .5_dp
-19    |-    real(dp) :: n = 5._dp
-   19 |+    real(dp) :: n = 5.0_dp
-20 20 |     real(dp) :: o = 0.5_dp
-21 21 | 
-22 22 | end program p
+16 |     real(dp) :: k = 53.d+10
+17 |     real(dp) :: l = .75d10
+18 |     real(dp) :: m = .5_dp
+   -     real(dp) :: n = 5._dp
+19 +     real(dp) :: n = 5.0_dp
+20 |     real(dp) :: o = 0.5_dp
+21 |
+22 | end program p

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__inconsistent-array-declaration_S261.f90_always.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__inconsistent-array-declaration_S261.f90_always.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3 3 |   ! y and z are inconsistent with decl
-4   |-  real, dimension(1) :: x, y(2), z(3, 4)
-  4 |+  real, dimension(1) :: x,  z(3, 4)
-  5 |+  real, dimension(2) :: y
-5 6 |   ! these are ok
-6 7 |   real :: a, b(5), c(6, 7)
-7 8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
+1 | program test
+2 |   implicit none (external, type)
+3 |   ! y and z are inconsistent with decl
+  -   real, dimension(1) :: x, y(2), z(3, 4)
+4 +   real, dimension(1) :: x,  z(3, 4)
+5 +   real, dimension(2) :: y
+6 |   ! these are ok
+7 |   real :: a, b(5), c(6, 7)
+8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
 
 ./resources/test/fixtures/style/S261.f90:4:34: S261 [*] Inconsistent specification of dimension
   |
@@ -36,16 +35,15 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3 3 |   ! y and z are inconsistent with decl
-4   |-  real, dimension(1) :: x, y(2), z(3, 4)
-  4 |+  real, dimension(1) :: x, y(2)
-  5 |+  real, dimension(3, 4) :: z
-5 6 |   ! these are ok
-6 7 |   real :: a, b(5), c(6, 7)
-7 8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
+1 | program test
+2 |   implicit none (external, type)
+3 |   ! y and z are inconsistent with decl
+  -   real, dimension(1) :: x, y(2), z(3, 4)
+4 +   real, dimension(1) :: x, y(2)
+5 +   real, dimension(3, 4) :: z
+6 |   ! these are ok
+7 |   real :: a, b(5), c(6, 7)
+8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
 
 ./resources/test/fixtures/style/S261.f90:7:38: S261 [*] Inconsistent specification of dimension
   |
@@ -57,11 +55,10 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-4 4 |   real, dimension(1) :: x, y(2), z(3, 4)
-5 5 |   ! these are ok
-6 6 |   real :: a, b(5), c(6, 7)
-7   |-  real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
-  7 |+  real, dimension(1) :: alpha = [0] ! more complicated
-  8 |+  real, dimension(2) :: beta = [1, 2]
-8 9 | end program test
+4 |   real, dimension(1) :: x, y(2), z(3, 4)
+5 |   ! these are ok
+6 |   real :: a, b(5), c(6, 7)
+  -   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
+7 +   real, dimension(1) :: alpha = [0] ! more complicated
+8 +   real, dimension(2) :: beta = [1, 2]
+9 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__inconsistent-array-declaration_S261.f90_keep.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__inconsistent-array-declaration_S261.f90_keep.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3 3 |   ! y and z are inconsistent with decl
-4   |-  real, dimension(1) :: x, y(2), z(3, 4)
-  4 |+  real, dimension(1) :: x,  z(3, 4)
-  5 |+  real :: y(2)
-5 6 |   ! these are ok
-6 7 |   real :: a, b(5), c(6, 7)
-7 8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
+1 | program test
+2 |   implicit none (external, type)
+3 |   ! y and z are inconsistent with decl
+  -   real, dimension(1) :: x, y(2), z(3, 4)
+4 +   real, dimension(1) :: x,  z(3, 4)
+5 +   real :: y(2)
+6 |   ! these are ok
+7 |   real :: a, b(5), c(6, 7)
+8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
 
 ./resources/test/fixtures/style/S261.f90:4:34: S261 [*] Inconsistent specification of dimension
   |
@@ -36,16 +35,15 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3 3 |   ! y and z are inconsistent with decl
-4   |-  real, dimension(1) :: x, y(2), z(3, 4)
-  4 |+  real, dimension(1) :: x, y(2)
-  5 |+  real :: z(3, 4)
-5 6 |   ! these are ok
-6 7 |   real :: a, b(5), c(6, 7)
-7 8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
+1 | program test
+2 |   implicit none (external, type)
+3 |   ! y and z are inconsistent with decl
+  -   real, dimension(1) :: x, y(2), z(3, 4)
+4 +   real, dimension(1) :: x, y(2)
+5 +   real :: z(3, 4)
+6 |   ! these are ok
+7 |   real :: a, b(5), c(6, 7)
+8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
 
 ./resources/test/fixtures/style/S261.f90:7:38: S261 [*] Inconsistent specification of dimension
   |
@@ -57,11 +55,10 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-4 4 |   real, dimension(1) :: x, y(2), z(3, 4)
-5 5 |   ! these are ok
-6 6 |   real :: a, b(5), c(6, 7)
-7   |-  real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
-  7 |+  real, dimension(1) :: alpha = [0] ! more complicated
-  8 |+  real :: beta(2) = [1, 2]
-8 9 | end program test
+4 |   real, dimension(1) :: x, y(2), z(3, 4)
+5 |   ! these are ok
+6 |   real :: a, b(5), c(6, 7)
+  -   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
+7 +   real, dimension(1) :: alpha = [0] ! more complicated
+8 +   real :: beta(2) = [1, 2]
+9 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__inconsistent-array-declaration_S261.f90_never.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__inconsistent-array-declaration_S261.f90_never.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3 3 |   ! y and z are inconsistent with decl
-4   |-  real, dimension(1) :: x, y(2), z(3, 4)
-  4 |+  real, dimension(1) :: x,  z(3, 4)
-  5 |+  real :: y(2)
-5 6 |   ! these are ok
-6 7 |   real :: a, b(5), c(6, 7)
-7 8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
+1 | program test
+2 |   implicit none (external, type)
+3 |   ! y and z are inconsistent with decl
+  -   real, dimension(1) :: x, y(2), z(3, 4)
+4 +   real, dimension(1) :: x,  z(3, 4)
+5 +   real :: y(2)
+6 |   ! these are ok
+7 |   real :: a, b(5), c(6, 7)
+8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
 
 ./resources/test/fixtures/style/S261.f90:4:34: S261 [*] Inconsistent specification of dimension
   |
@@ -36,16 +35,15 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-1 1 | program test
-2 2 |   implicit none (external, type)
-3 3 |   ! y and z are inconsistent with decl
-4   |-  real, dimension(1) :: x, y(2), z(3, 4)
-  4 |+  real, dimension(1) :: x, y(2)
-  5 |+  real :: z(3, 4)
-5 6 |   ! these are ok
-6 7 |   real :: a, b(5), c(6, 7)
-7 8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
+1 | program test
+2 |   implicit none (external, type)
+3 |   ! y and z are inconsistent with decl
+  -   real, dimension(1) :: x, y(2), z(3, 4)
+4 +   real, dimension(1) :: x, y(2)
+5 +   real :: z(3, 4)
+6 |   ! these are ok
+7 |   real :: a, b(5), c(6, 7)
+8 |   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
 
 ./resources/test/fixtures/style/S261.f90:7:38: S261 [*] Inconsistent specification of dimension
   |
@@ -57,11 +55,10 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-4 4 |   real, dimension(1) :: x, y(2), z(3, 4)
-5 5 |   ! these are ok
-6 6 |   real :: a, b(5), c(6, 7)
-7   |-  real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
-  7 |+  real, dimension(1) :: alpha = [0] ! more complicated
-  8 |+  real :: beta(2) = [1, 2]
-8 9 | end program test
+4 |   real, dimension(1) :: x, y(2), z(3, 4)
+5 |   ! these are ok
+6 |   real :: a, b(5), c(6, 7)
+  -   real, dimension(1) :: alpha = [0], beta(2) = [1, 2] ! more complicated
+7 +   real, dimension(1) :: alpha = [0] ! more complicated
+8 +   real :: beta(2) = [1, 2]
+9 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-keyword-case_S233.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-keyword-case_S233.f90.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S233.f90:1:1: S233 [*] Keyword 'MODULE' should be 'module'
   |
@@ -11,12 +12,11 @@ expression: diagnostics
   |
   = help: Change to 'module'
 
-ℹ Safe fix
-1   |-MODULE MY_MODULE
-  1 |+module MY_MODULE
-2 2 | IMPLICIT NONE
-3 3 | PRIVATE
-4 4 | PUBLIC :: TEST_TYPE, TEST_PROC
+  - MODULE MY_MODULE
+1 + module MY_MODULE
+2 | IMPLICIT NONE
+3 | PRIVATE
+4 | PUBLIC :: TEST_TYPE, TEST_PROC
 
 ./resources/test/fixtures/style/S233.f90:2:1: S233 [*] Keyword 'IMPLICIT' should be 'implicit'
   |
@@ -28,13 +28,12 @@ expression: diagnostics
   |
   = help: Change to 'implicit'
 
-ℹ Safe fix
-1 1 | MODULE MY_MODULE
-2   |-IMPLICIT NONE
-  2 |+implicit NONE
-3 3 | PRIVATE
-4 4 | PUBLIC :: TEST_TYPE, TEST_PROC
-5 5 | 
+1 | MODULE MY_MODULE
+  - IMPLICIT NONE
+2 + implicit NONE
+3 | PRIVATE
+4 | PUBLIC :: TEST_TYPE, TEST_PROC
+5 |
 
 ./resources/test/fixtures/style/S233.f90:2:10: S233 [*] Keyword 'NONE' should be 'none'
   |
@@ -46,13 +45,12 @@ expression: diagnostics
   |
   = help: Change to 'none'
 
-ℹ Safe fix
-1 1 | MODULE MY_MODULE
-2   |-IMPLICIT NONE
-  2 |+IMPLICIT none
-3 3 | PRIVATE
-4 4 | PUBLIC :: TEST_TYPE, TEST_PROC
-5 5 | 
+1 | MODULE MY_MODULE
+  - IMPLICIT NONE
+2 + IMPLICIT none
+3 | PRIVATE
+4 | PUBLIC :: TEST_TYPE, TEST_PROC
+5 |
 
 ./resources/test/fixtures/style/S233.f90:3:1: S233 [*] Keyword 'PRIVATE' should be 'private'
   |
@@ -64,14 +62,13 @@ expression: diagnostics
   |
   = help: Change to 'private'
 
-ℹ Safe fix
-1 1 | MODULE MY_MODULE
-2 2 | IMPLICIT NONE
-3   |-PRIVATE
-  3 |+private
-4 4 | PUBLIC :: TEST_TYPE, TEST_PROC
-5 5 | 
-6 6 | TYPE, ABSTRACT :: BASE_TYPE
+1 | MODULE MY_MODULE
+2 | IMPLICIT NONE
+  - PRIVATE
+3 + private
+4 | PUBLIC :: TEST_TYPE, TEST_PROC
+5 |
+6 | TYPE, ABSTRACT :: BASE_TYPE
 
 ./resources/test/fixtures/style/S233.f90:4:1: S233 [*] Keyword 'PUBLIC' should be 'public'
   |
@@ -84,15 +81,14 @@ expression: diagnostics
   |
   = help: Change to 'public'
 
-ℹ Safe fix
-1 1 | MODULE MY_MODULE
-2 2 | IMPLICIT NONE
-3 3 | PRIVATE
-4   |-PUBLIC :: TEST_TYPE, TEST_PROC
-  4 |+public :: TEST_TYPE, TEST_PROC
-5 5 | 
-6 6 | TYPE, ABSTRACT :: BASE_TYPE
-7 7 | CONTAINS
+1 | MODULE MY_MODULE
+2 | IMPLICIT NONE
+3 | PRIVATE
+  - PUBLIC :: TEST_TYPE, TEST_PROC
+4 + public :: TEST_TYPE, TEST_PROC
+5 |
+6 | TYPE, ABSTRACT :: BASE_TYPE
+7 | CONTAINS
 
 ./resources/test/fixtures/style/S233.f90:6:1: S233 [*] Keyword 'TYPE' should be 'type'
   |
@@ -105,15 +101,14 @@ expression: diagnostics
   |
   = help: Change to 'type'
 
-ℹ Safe fix
-3 3 | PRIVATE
-4 4 | PUBLIC :: TEST_TYPE, TEST_PROC
-5 5 | 
-6   |-TYPE, ABSTRACT :: BASE_TYPE
-  6 |+type, ABSTRACT :: BASE_TYPE
-7 7 | CONTAINS
-8 8 |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
-9 9 | END TYPE BASE_TYPE
+3 | PRIVATE
+4 | PUBLIC :: TEST_TYPE, TEST_PROC
+5 |
+  - TYPE, ABSTRACT :: BASE_TYPE
+6 + type, ABSTRACT :: BASE_TYPE
+7 | CONTAINS
+8 |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
+9 | END TYPE BASE_TYPE
 
 ./resources/test/fixtures/style/S233.f90:6:7: S233 [*] Keyword 'ABSTRACT' should be 'abstract'
   |
@@ -126,15 +121,14 @@ expression: diagnostics
   |
   = help: Change to 'abstract'
 
-ℹ Safe fix
-3 3 | PRIVATE
-4 4 | PUBLIC :: TEST_TYPE, TEST_PROC
-5 5 | 
-6   |-TYPE, ABSTRACT :: BASE_TYPE
-  6 |+TYPE, abstract :: BASE_TYPE
-7 7 | CONTAINS
-8 8 |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
-9 9 | END TYPE BASE_TYPE
+3 | PRIVATE
+4 | PUBLIC :: TEST_TYPE, TEST_PROC
+5 |
+  - TYPE, ABSTRACT :: BASE_TYPE
+6 + TYPE, abstract :: BASE_TYPE
+7 | CONTAINS
+8 |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
+9 | END TYPE BASE_TYPE
 
 ./resources/test/fixtures/style/S233.f90:7:1: S233 [*] Keyword 'CONTAINS' should be 'contains'
   |
@@ -146,15 +140,14 @@ expression: diagnostics
   |
   = help: Change to 'contains'
 
-ℹ Safe fix
-4 4 | PUBLIC :: TEST_TYPE, TEST_PROC
-5 5 | 
-6 6 | TYPE, ABSTRACT :: BASE_TYPE
-7   |-CONTAINS
-  7 |+contains
-8 8 |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
-9 9 | END TYPE BASE_TYPE
-10 10 | 
+4  | PUBLIC :: TEST_TYPE, TEST_PROC
+5  |
+6  | TYPE, ABSTRACT :: BASE_TYPE
+   - CONTAINS
+7  + contains
+8  |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
+9  | END TYPE BASE_TYPE
+10 |
 
 ./resources/test/fixtures/style/S233.f90:8:5: S233 [*] Keyword 'PROCEDURE' should be 'procedure'
   |
@@ -166,15 +159,14 @@ expression: diagnostics
   |
   = help: Change to 'procedure'
 
-ℹ Safe fix
-5 5 | 
-6 6 | TYPE, ABSTRACT :: BASE_TYPE
-7 7 | CONTAINS
-8   |-    PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
-  8 |+    procedure(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
-9 9 | END TYPE BASE_TYPE
-10 10 | 
-11 11 | ABSTRACT INTERFACE
+5  |
+6  | TYPE, ABSTRACT :: BASE_TYPE
+7  | CONTAINS
+   -     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
+8  +     procedure(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
+9  | END TYPE BASE_TYPE
+10 |
+11 | ABSTRACT INTERFACE
 
 ./resources/test/fixtures/style/S233.f90:8:31: S233 [*] Keyword 'DEFERRED' should be 'deferred'
   |
@@ -186,15 +178,14 @@ expression: diagnostics
   |
   = help: Change to 'deferred'
 
-ℹ Safe fix
-5 5 | 
-6 6 | TYPE, ABSTRACT :: BASE_TYPE
-7 7 | CONTAINS
-8   |-    PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
-  8 |+    PROCEDURE(DEFERRED_PROC), deferred :: DO_SOMETHING
-9 9 | END TYPE BASE_TYPE
-10 10 | 
-11 11 | ABSTRACT INTERFACE
+5  |
+6  | TYPE, ABSTRACT :: BASE_TYPE
+7  | CONTAINS
+   -     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
+8  +     PROCEDURE(DEFERRED_PROC), deferred :: DO_SOMETHING
+9  | END TYPE BASE_TYPE
+10 |
+11 | ABSTRACT INTERFACE
 
 ./resources/test/fixtures/style/S233.f90:9:1: S233 [*] Keyword 'END' should be 'end'
    |
@@ -207,15 +198,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-6  6  | TYPE, ABSTRACT :: BASE_TYPE
-7  7  | CONTAINS
-8  8  |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
-9     |-END TYPE BASE_TYPE
-   9  |+end TYPE BASE_TYPE
-10 10 | 
-11 11 | ABSTRACT INTERFACE
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
+6  | TYPE, ABSTRACT :: BASE_TYPE
+7  | CONTAINS
+8  |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
+   - END TYPE BASE_TYPE
+9  + end TYPE BASE_TYPE
+10 |
+11 | ABSTRACT INTERFACE
+12 |     SUBROUTINE DEFERRED_PROC(X)
 
 ./resources/test/fixtures/style/S233.f90:9:5: S233 [*] Keyword 'TYPE' should be 'type'
    |
@@ -228,15 +218,14 @@ expression: diagnostics
    |
    = help: Change to 'type'
 
-ℹ Safe fix
-6  6  | TYPE, ABSTRACT :: BASE_TYPE
-7  7  | CONTAINS
-8  8  |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
-9     |-END TYPE BASE_TYPE
-   9  |+END type BASE_TYPE
-10 10 | 
-11 11 | ABSTRACT INTERFACE
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
+6  | TYPE, ABSTRACT :: BASE_TYPE
+7  | CONTAINS
+8  |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
+   - END TYPE BASE_TYPE
+9  + END type BASE_TYPE
+10 |
+11 | ABSTRACT INTERFACE
+12 |     SUBROUTINE DEFERRED_PROC(X)
 
 ./resources/test/fixtures/style/S233.f90:11:1: S233 [*] Keyword 'ABSTRACT' should be 'abstract'
    |
@@ -249,15 +238,14 @@ expression: diagnostics
    |
    = help: Change to 'abstract'
 
-ℹ Safe fix
-8  8  |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
-9  9  | END TYPE BASE_TYPE
-10 10 | 
-11    |-ABSTRACT INTERFACE
-   11 |+abstract INTERFACE
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
-13 13 |         INTEGER, INTENT(INOUT) :: X
-14 14 |     END SUBROUTINE DEFERRED_PROC
+8  |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
+9  | END TYPE BASE_TYPE
+10 |
+   - ABSTRACT INTERFACE
+11 + abstract INTERFACE
+12 |     SUBROUTINE DEFERRED_PROC(X)
+13 |         INTEGER, INTENT(INOUT) :: X
+14 |     END SUBROUTINE DEFERRED_PROC
 
 ./resources/test/fixtures/style/S233.f90:11:10: S233 [*] Keyword 'INTERFACE' should be 'interface'
    |
@@ -270,15 +258,14 @@ expression: diagnostics
    |
    = help: Change to 'interface'
 
-ℹ Safe fix
-8  8  |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
-9  9  | END TYPE BASE_TYPE
-10 10 | 
-11    |-ABSTRACT INTERFACE
-   11 |+ABSTRACT interface
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
-13 13 |         INTEGER, INTENT(INOUT) :: X
-14 14 |     END SUBROUTINE DEFERRED_PROC
+8  |     PROCEDURE(DEFERRED_PROC), DEFERRED :: DO_SOMETHING
+9  | END TYPE BASE_TYPE
+10 |
+   - ABSTRACT INTERFACE
+11 + ABSTRACT interface
+12 |     SUBROUTINE DEFERRED_PROC(X)
+13 |         INTEGER, INTENT(INOUT) :: X
+14 |     END SUBROUTINE DEFERRED_PROC
 
 ./resources/test/fixtures/style/S233.f90:12:5: S233 [*] Keyword 'SUBROUTINE' should be 'subroutine'
    |
@@ -290,15 +277,14 @@ expression: diagnostics
    |
    = help: Change to 'subroutine'
 
-ℹ Safe fix
-9  9  | END TYPE BASE_TYPE
-10 10 | 
-11 11 | ABSTRACT INTERFACE
-12    |-    SUBROUTINE DEFERRED_PROC(X)
-   12 |+    subroutine DEFERRED_PROC(X)
-13 13 |         INTEGER, INTENT(INOUT) :: X
-14 14 |     END SUBROUTINE DEFERRED_PROC
-15 15 | END INTERFACE
+9  | END TYPE BASE_TYPE
+10 |
+11 | ABSTRACT INTERFACE
+   -     SUBROUTINE DEFERRED_PROC(X)
+12 +     subroutine DEFERRED_PROC(X)
+13 |         INTEGER, INTENT(INOUT) :: X
+14 |     END SUBROUTINE DEFERRED_PROC
+15 | END INTERFACE
 
 ./resources/test/fixtures/style/S233.f90:13:9: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -311,15 +297,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-10 10 | 
-11 11 | ABSTRACT INTERFACE
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
-13    |-        INTEGER, INTENT(INOUT) :: X
-   13 |+        integer, INTENT(INOUT) :: X
-14 14 |     END SUBROUTINE DEFERRED_PROC
-15 15 | END INTERFACE
-16 16 | 
+10 |
+11 | ABSTRACT INTERFACE
+12 |     SUBROUTINE DEFERRED_PROC(X)
+   -         INTEGER, INTENT(INOUT) :: X
+13 +         integer, INTENT(INOUT) :: X
+14 |     END SUBROUTINE DEFERRED_PROC
+15 | END INTERFACE
+16 |
 
 ./resources/test/fixtures/style/S233.f90:13:18: S233 [*] Keyword 'INTENT' should be 'intent'
    |
@@ -332,15 +317,14 @@ expression: diagnostics
    |
    = help: Change to 'intent'
 
-ℹ Safe fix
-10 10 | 
-11 11 | ABSTRACT INTERFACE
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
-13    |-        INTEGER, INTENT(INOUT) :: X
-   13 |+        INTEGER, intent(INOUT) :: X
-14 14 |     END SUBROUTINE DEFERRED_PROC
-15 15 | END INTERFACE
-16 16 | 
+10 |
+11 | ABSTRACT INTERFACE
+12 |     SUBROUTINE DEFERRED_PROC(X)
+   -         INTEGER, INTENT(INOUT) :: X
+13 +         INTEGER, intent(INOUT) :: X
+14 |     END SUBROUTINE DEFERRED_PROC
+15 | END INTERFACE
+16 |
 
 ./resources/test/fixtures/style/S233.f90:13:25: S233 [*] Keyword 'INOUT' should be 'inout'
    |
@@ -353,15 +337,14 @@ expression: diagnostics
    |
    = help: Change to 'inout'
 
-ℹ Safe fix
-10 10 | 
-11 11 | ABSTRACT INTERFACE
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
-13    |-        INTEGER, INTENT(INOUT) :: X
-   13 |+        INTEGER, INTENT(inout) :: X
-14 14 |     END SUBROUTINE DEFERRED_PROC
-15 15 | END INTERFACE
-16 16 | 
+10 |
+11 | ABSTRACT INTERFACE
+12 |     SUBROUTINE DEFERRED_PROC(X)
+   -         INTEGER, INTENT(INOUT) :: X
+13 +         INTEGER, INTENT(inout) :: X
+14 |     END SUBROUTINE DEFERRED_PROC
+15 | END INTERFACE
+16 |
 
 ./resources/test/fixtures/style/S233.f90:14:5: S233 [*] Keyword 'END' should be 'end'
    |
@@ -373,15 +356,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-11 11 | ABSTRACT INTERFACE
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
-13 13 |         INTEGER, INTENT(INOUT) :: X
-14    |-    END SUBROUTINE DEFERRED_PROC
-   14 |+    end SUBROUTINE DEFERRED_PROC
-15 15 | END INTERFACE
-16 16 | 
-17 17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
+11 | ABSTRACT INTERFACE
+12 |     SUBROUTINE DEFERRED_PROC(X)
+13 |         INTEGER, INTENT(INOUT) :: X
+   -     END SUBROUTINE DEFERRED_PROC
+14 +     end SUBROUTINE DEFERRED_PROC
+15 | END INTERFACE
+16 |
+17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
 
 ./resources/test/fixtures/style/S233.f90:14:9: S233 [*] Keyword 'SUBROUTINE' should be 'subroutine'
    |
@@ -393,15 +375,14 @@ expression: diagnostics
    |
    = help: Change to 'subroutine'
 
-ℹ Safe fix
-11 11 | ABSTRACT INTERFACE
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
-13 13 |         INTEGER, INTENT(INOUT) :: X
-14    |-    END SUBROUTINE DEFERRED_PROC
-   14 |+    END subroutine DEFERRED_PROC
-15 15 | END INTERFACE
-16 16 | 
-17 17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
+11 | ABSTRACT INTERFACE
+12 |     SUBROUTINE DEFERRED_PROC(X)
+13 |         INTEGER, INTENT(INOUT) :: X
+   -     END SUBROUTINE DEFERRED_PROC
+14 +     END subroutine DEFERRED_PROC
+15 | END INTERFACE
+16 |
+17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
 
 ./resources/test/fixtures/style/S233.f90:15:1: S233 [*] Keyword 'END' should be 'end'
    |
@@ -414,15 +395,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
-13 13 |         INTEGER, INTENT(INOUT) :: X
-14 14 |     END SUBROUTINE DEFERRED_PROC
-15    |-END INTERFACE
-   15 |+end INTERFACE
-16 16 | 
-17 17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
-18 18 |     INTEGER :: VALUE
+12 |     SUBROUTINE DEFERRED_PROC(X)
+13 |         INTEGER, INTENT(INOUT) :: X
+14 |     END SUBROUTINE DEFERRED_PROC
+   - END INTERFACE
+15 + end INTERFACE
+16 |
+17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
+18 |     INTEGER :: VALUE
 
 ./resources/test/fixtures/style/S233.f90:15:5: S233 [*] Keyword 'INTERFACE' should be 'interface'
    |
@@ -435,15 +415,14 @@ expression: diagnostics
    |
    = help: Change to 'interface'
 
-ℹ Safe fix
-12 12 |     SUBROUTINE DEFERRED_PROC(X)
-13 13 |         INTEGER, INTENT(INOUT) :: X
-14 14 |     END SUBROUTINE DEFERRED_PROC
-15    |-END INTERFACE
-   15 |+END interface
-16 16 | 
-17 17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
-18 18 |     INTEGER :: VALUE
+12 |     SUBROUTINE DEFERRED_PROC(X)
+13 |         INTEGER, INTENT(INOUT) :: X
+14 |     END SUBROUTINE DEFERRED_PROC
+   - END INTERFACE
+15 + END interface
+16 |
+17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
+18 |     INTEGER :: VALUE
 
 ./resources/test/fixtures/style/S233.f90:17:1: S233 [*] Keyword 'TYPE' should be 'type'
    |
@@ -456,15 +435,14 @@ expression: diagnostics
    |
    = help: Change to 'type'
 
-ℹ Safe fix
-14 14 |     END SUBROUTINE DEFERRED_PROC
-15 15 | END INTERFACE
-16 16 | 
-17    |-TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
-   17 |+type, EXTENDS(BASE_TYPE) :: TEST_TYPE
-18 18 |     INTEGER :: VALUE
-19 19 | CONTAINS
-20 20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
+14 |     END SUBROUTINE DEFERRED_PROC
+15 | END INTERFACE
+16 |
+   - TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
+17 + type, EXTENDS(BASE_TYPE) :: TEST_TYPE
+18 |     INTEGER :: VALUE
+19 | CONTAINS
+20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
 
 ./resources/test/fixtures/style/S233.f90:17:7: S233 [*] Keyword 'EXTENDS' should be 'extends'
    |
@@ -477,15 +455,14 @@ expression: diagnostics
    |
    = help: Change to 'extends'
 
-ℹ Safe fix
-14 14 |     END SUBROUTINE DEFERRED_PROC
-15 15 | END INTERFACE
-16 16 | 
-17    |-TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
-   17 |+TYPE, extends(BASE_TYPE) :: TEST_TYPE
-18 18 |     INTEGER :: VALUE
-19 19 | CONTAINS
-20 20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
+14 |     END SUBROUTINE DEFERRED_PROC
+15 | END INTERFACE
+16 |
+   - TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
+17 + TYPE, extends(BASE_TYPE) :: TEST_TYPE
+18 |     INTEGER :: VALUE
+19 | CONTAINS
+20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
 
 ./resources/test/fixtures/style/S233.f90:18:5: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -497,15 +474,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-15 15 | END INTERFACE
-16 16 | 
-17 17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
-18    |-    INTEGER :: VALUE
-   18 |+    integer :: VALUE
-19 19 | CONTAINS
-20 20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
-21 21 |     FINAL :: FINALIZE_TEST
+15 | END INTERFACE
+16 |
+17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
+   -     INTEGER :: VALUE
+18 +     integer :: VALUE
+19 | CONTAINS
+20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
+21 |     FINAL :: FINALIZE_TEST
 
 ./resources/test/fixtures/style/S233.f90:19:1: S233 [*] Keyword 'CONTAINS' should be 'contains'
    |
@@ -518,15 +494,14 @@ expression: diagnostics
    |
    = help: Change to 'contains'
 
-ℹ Safe fix
-16 16 | 
-17 17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
-18 18 |     INTEGER :: VALUE
-19    |-CONTAINS
-   19 |+contains
-20 20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
-21 21 |     FINAL :: FINALIZE_TEST
-22 22 | END TYPE TEST_TYPE
+16 |
+17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
+18 |     INTEGER :: VALUE
+   - CONTAINS
+19 + contains
+20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
+21 |     FINAL :: FINALIZE_TEST
+22 | END TYPE TEST_TYPE
 
 ./resources/test/fixtures/style/S233.f90:20:5: S233 [*] Keyword 'PROCEDURE' should be 'procedure'
    |
@@ -539,15 +514,14 @@ expression: diagnostics
    |
    = help: Change to 'procedure'
 
-ℹ Safe fix
-17 17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
-18 18 |     INTEGER :: VALUE
-19 19 | CONTAINS
-20    |-    PROCEDURE :: DO_SOMETHING => IMPL_PROC
-   20 |+    procedure :: DO_SOMETHING => IMPL_PROC
-21 21 |     FINAL :: FINALIZE_TEST
-22 22 | END TYPE TEST_TYPE
-23 23 | 
+17 | TYPE, EXTENDS(BASE_TYPE) :: TEST_TYPE
+18 |     INTEGER :: VALUE
+19 | CONTAINS
+   -     PROCEDURE :: DO_SOMETHING => IMPL_PROC
+20 +     procedure :: DO_SOMETHING => IMPL_PROC
+21 |     FINAL :: FINALIZE_TEST
+22 | END TYPE TEST_TYPE
+23 |
 
 ./resources/test/fixtures/style/S233.f90:21:5: S233 [*] Keyword 'FINAL' should be 'final'
    |
@@ -559,15 +533,14 @@ expression: diagnostics
    |
    = help: Change to 'final'
 
-ℹ Safe fix
-18 18 |     INTEGER :: VALUE
-19 19 | CONTAINS
-20 20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
-21    |-    FINAL :: FINALIZE_TEST
-   21 |+    final :: FINALIZE_TEST
-22 22 | END TYPE TEST_TYPE
-23 23 | 
-24 24 | INTERFACE TEST_PROC
+18 |     INTEGER :: VALUE
+19 | CONTAINS
+20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
+   -     FINAL :: FINALIZE_TEST
+21 +     final :: FINALIZE_TEST
+22 | END TYPE TEST_TYPE
+23 |
+24 | INTERFACE TEST_PROC
 
 ./resources/test/fixtures/style/S233.f90:22:1: S233 [*] Keyword 'END' should be 'end'
    |
@@ -580,15 +553,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-19 19 | CONTAINS
-20 20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
-21 21 |     FINAL :: FINALIZE_TEST
-22    |-END TYPE TEST_TYPE
-   22 |+end TYPE TEST_TYPE
-23 23 | 
-24 24 | INTERFACE TEST_PROC
-25 25 |     MODULE PROCEDURE IMPL_PROC
+19 | CONTAINS
+20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
+21 |     FINAL :: FINALIZE_TEST
+   - END TYPE TEST_TYPE
+22 + end TYPE TEST_TYPE
+23 |
+24 | INTERFACE TEST_PROC
+25 |     MODULE PROCEDURE IMPL_PROC
 
 ./resources/test/fixtures/style/S233.f90:22:5: S233 [*] Keyword 'TYPE' should be 'type'
    |
@@ -601,15 +573,14 @@ expression: diagnostics
    |
    = help: Change to 'type'
 
-ℹ Safe fix
-19 19 | CONTAINS
-20 20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
-21 21 |     FINAL :: FINALIZE_TEST
-22    |-END TYPE TEST_TYPE
-   22 |+END type TEST_TYPE
-23 23 | 
-24 24 | INTERFACE TEST_PROC
-25 25 |     MODULE PROCEDURE IMPL_PROC
+19 | CONTAINS
+20 |     PROCEDURE :: DO_SOMETHING => IMPL_PROC
+21 |     FINAL :: FINALIZE_TEST
+   - END TYPE TEST_TYPE
+22 + END type TEST_TYPE
+23 |
+24 | INTERFACE TEST_PROC
+25 |     MODULE PROCEDURE IMPL_PROC
 
 ./resources/test/fixtures/style/S233.f90:24:1: S233 [*] Keyword 'INTERFACE' should be 'interface'
    |
@@ -622,15 +593,14 @@ expression: diagnostics
    |
    = help: Change to 'interface'
 
-ℹ Safe fix
-21 21 |     FINAL :: FINALIZE_TEST
-22 22 | END TYPE TEST_TYPE
-23 23 | 
-24    |-INTERFACE TEST_PROC
-   24 |+interface TEST_PROC
-25 25 |     MODULE PROCEDURE IMPL_PROC
-26 26 | END INTERFACE
-27 27 | 
+21 |     FINAL :: FINALIZE_TEST
+22 | END TYPE TEST_TYPE
+23 |
+   - INTERFACE TEST_PROC
+24 + interface TEST_PROC
+25 |     MODULE PROCEDURE IMPL_PROC
+26 | END INTERFACE
+27 |
 
 ./resources/test/fixtures/style/S233.f90:25:5: S233 [*] Keyword 'MODULE' should be 'module'
    |
@@ -641,15 +611,14 @@ expression: diagnostics
    |
    = help: Change to 'module'
 
-ℹ Safe fix
-22 22 | END TYPE TEST_TYPE
-23 23 | 
-24 24 | INTERFACE TEST_PROC
-25    |-    MODULE PROCEDURE IMPL_PROC
-   25 |+    module PROCEDURE IMPL_PROC
-26 26 | END INTERFACE
-27 27 | 
-28 28 | CONTAINS
+22 | END TYPE TEST_TYPE
+23 |
+24 | INTERFACE TEST_PROC
+   -     MODULE PROCEDURE IMPL_PROC
+25 +     module PROCEDURE IMPL_PROC
+26 | END INTERFACE
+27 |
+28 | CONTAINS
 
 ./resources/test/fixtures/style/S233.f90:25:12: S233 [*] Keyword 'PROCEDURE' should be 'procedure'
    |
@@ -660,15 +629,14 @@ expression: diagnostics
    |
    = help: Change to 'procedure'
 
-ℹ Safe fix
-22 22 | END TYPE TEST_TYPE
-23 23 | 
-24 24 | INTERFACE TEST_PROC
-25    |-    MODULE PROCEDURE IMPL_PROC
-   25 |+    MODULE procedure IMPL_PROC
-26 26 | END INTERFACE
-27 27 | 
-28 28 | CONTAINS
+22 | END TYPE TEST_TYPE
+23 |
+24 | INTERFACE TEST_PROC
+   -     MODULE PROCEDURE IMPL_PROC
+25 +     MODULE procedure IMPL_PROC
+26 | END INTERFACE
+27 |
+28 | CONTAINS
 
 ./resources/test/fixtures/style/S233.f90:26:1: S233 [*] Keyword 'END' should be 'end'
    |
@@ -681,15 +649,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-23 23 | 
-24 24 | INTERFACE TEST_PROC
-25 25 |     MODULE PROCEDURE IMPL_PROC
-26    |-END INTERFACE
-   26 |+end INTERFACE
-27 27 | 
-28 28 | CONTAINS
-29 29 | 
+23 |
+24 | INTERFACE TEST_PROC
+25 |     MODULE PROCEDURE IMPL_PROC
+   - END INTERFACE
+26 + end INTERFACE
+27 |
+28 | CONTAINS
+29 |
 
 ./resources/test/fixtures/style/S233.f90:26:5: S233 [*] Keyword 'INTERFACE' should be 'interface'
    |
@@ -702,15 +669,14 @@ expression: diagnostics
    |
    = help: Change to 'interface'
 
-ℹ Safe fix
-23 23 | 
-24 24 | INTERFACE TEST_PROC
-25 25 |     MODULE PROCEDURE IMPL_PROC
-26    |-END INTERFACE
-   26 |+END interface
-27 27 | 
-28 28 | CONTAINS
-29 29 | 
+23 |
+24 | INTERFACE TEST_PROC
+25 |     MODULE PROCEDURE IMPL_PROC
+   - END INTERFACE
+26 + END interface
+27 |
+28 | CONTAINS
+29 |
 
 ./resources/test/fixtures/style/S233.f90:28:1: S233 [*] Keyword 'CONTAINS' should be 'contains'
    |
@@ -723,15 +689,14 @@ expression: diagnostics
    |
    = help: Change to 'contains'
 
-ℹ Safe fix
-25 25 |     MODULE PROCEDURE IMPL_PROC
-26 26 | END INTERFACE
-27 27 | 
-28    |-CONTAINS
-   28 |+contains
-29 29 | 
-30 30 | PURE SUBROUTINE IMPL_PROC(X)
-31 31 |     INTEGER, INTENT(INOUT) :: X
+25 |     MODULE PROCEDURE IMPL_PROC
+26 | END INTERFACE
+27 |
+   - CONTAINS
+28 + contains
+29 |
+30 | PURE SUBROUTINE IMPL_PROC(X)
+31 |     INTEGER, INTENT(INOUT) :: X
 
 ./resources/test/fixtures/style/S233.f90:30:1: S233 [*] Keyword 'PURE' should be 'pure'
    |
@@ -744,15 +709,14 @@ expression: diagnostics
    |
    = help: Change to 'pure'
 
-ℹ Safe fix
-27 27 | 
-28 28 | CONTAINS
-29 29 | 
-30    |-PURE SUBROUTINE IMPL_PROC(X)
-   30 |+pure SUBROUTINE IMPL_PROC(X)
-31 31 |     INTEGER, INTENT(INOUT) :: X
-32 32 |     X = X + 1
-33 33 | END SUBROUTINE IMPL_PROC
+27 |
+28 | CONTAINS
+29 |
+   - PURE SUBROUTINE IMPL_PROC(X)
+30 + pure SUBROUTINE IMPL_PROC(X)
+31 |     INTEGER, INTENT(INOUT) :: X
+32 |     X = X + 1
+33 | END SUBROUTINE IMPL_PROC
 
 ./resources/test/fixtures/style/S233.f90:30:6: S233 [*] Keyword 'SUBROUTINE' should be 'subroutine'
    |
@@ -765,15 +729,14 @@ expression: diagnostics
    |
    = help: Change to 'subroutine'
 
-ℹ Safe fix
-27 27 | 
-28 28 | CONTAINS
-29 29 | 
-30    |-PURE SUBROUTINE IMPL_PROC(X)
-   30 |+PURE subroutine IMPL_PROC(X)
-31 31 |     INTEGER, INTENT(INOUT) :: X
-32 32 |     X = X + 1
-33 33 | END SUBROUTINE IMPL_PROC
+27 |
+28 | CONTAINS
+29 |
+   - PURE SUBROUTINE IMPL_PROC(X)
+30 + PURE subroutine IMPL_PROC(X)
+31 |     INTEGER, INTENT(INOUT) :: X
+32 |     X = X + 1
+33 | END SUBROUTINE IMPL_PROC
 
 ./resources/test/fixtures/style/S233.f90:31:5: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -785,15 +748,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-28 28 | CONTAINS
-29 29 | 
-30 30 | PURE SUBROUTINE IMPL_PROC(X)
-31    |-    INTEGER, INTENT(INOUT) :: X
-   31 |+    integer, INTENT(INOUT) :: X
-32 32 |     X = X + 1
-33 33 | END SUBROUTINE IMPL_PROC
-34 34 | 
+28 | CONTAINS
+29 |
+30 | PURE SUBROUTINE IMPL_PROC(X)
+   -     INTEGER, INTENT(INOUT) :: X
+31 +     integer, INTENT(INOUT) :: X
+32 |     X = X + 1
+33 | END SUBROUTINE IMPL_PROC
+34 |
 
 ./resources/test/fixtures/style/S233.f90:31:14: S233 [*] Keyword 'INTENT' should be 'intent'
    |
@@ -805,15 +767,14 @@ expression: diagnostics
    |
    = help: Change to 'intent'
 
-ℹ Safe fix
-28 28 | CONTAINS
-29 29 | 
-30 30 | PURE SUBROUTINE IMPL_PROC(X)
-31    |-    INTEGER, INTENT(INOUT) :: X
-   31 |+    INTEGER, intent(INOUT) :: X
-32 32 |     X = X + 1
-33 33 | END SUBROUTINE IMPL_PROC
-34 34 | 
+28 | CONTAINS
+29 |
+30 | PURE SUBROUTINE IMPL_PROC(X)
+   -     INTEGER, INTENT(INOUT) :: X
+31 +     INTEGER, intent(INOUT) :: X
+32 |     X = X + 1
+33 | END SUBROUTINE IMPL_PROC
+34 |
 
 ./resources/test/fixtures/style/S233.f90:31:21: S233 [*] Keyword 'INOUT' should be 'inout'
    |
@@ -825,15 +786,14 @@ expression: diagnostics
    |
    = help: Change to 'inout'
 
-ℹ Safe fix
-28 28 | CONTAINS
-29 29 | 
-30 30 | PURE SUBROUTINE IMPL_PROC(X)
-31    |-    INTEGER, INTENT(INOUT) :: X
-   31 |+    INTEGER, INTENT(inout) :: X
-32 32 |     X = X + 1
-33 33 | END SUBROUTINE IMPL_PROC
-34 34 | 
+28 | CONTAINS
+29 |
+30 | PURE SUBROUTINE IMPL_PROC(X)
+   -     INTEGER, INTENT(INOUT) :: X
+31 +     INTEGER, INTENT(inout) :: X
+32 |     X = X + 1
+33 | END SUBROUTINE IMPL_PROC
+34 |
 
 ./resources/test/fixtures/style/S233.f90:33:1: S233 [*] Keyword 'END' should be 'end'
    |
@@ -846,15 +806,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-30 30 | PURE SUBROUTINE IMPL_PROC(X)
-31 31 |     INTEGER, INTENT(INOUT) :: X
-32 32 |     X = X + 1
-33    |-END SUBROUTINE IMPL_PROC
-   33 |+end SUBROUTINE IMPL_PROC
-34 34 | 
-35 35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
-36 36 |     INTEGER, INTENT(IN) :: Y
+30 | PURE SUBROUTINE IMPL_PROC(X)
+31 |     INTEGER, INTENT(INOUT) :: X
+32 |     X = X + 1
+   - END SUBROUTINE IMPL_PROC
+33 + end SUBROUTINE IMPL_PROC
+34 |
+35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
+36 |     INTEGER, INTENT(IN) :: Y
 
 ./resources/test/fixtures/style/S233.f90:33:5: S233 [*] Keyword 'SUBROUTINE' should be 'subroutine'
    |
@@ -867,15 +826,14 @@ expression: diagnostics
    |
    = help: Change to 'subroutine'
 
-ℹ Safe fix
-30 30 | PURE SUBROUTINE IMPL_PROC(X)
-31 31 |     INTEGER, INTENT(INOUT) :: X
-32 32 |     X = X + 1
-33    |-END SUBROUTINE IMPL_PROC
-   33 |+END subroutine IMPL_PROC
-34 34 | 
-35 35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
-36 36 |     INTEGER, INTENT(IN) :: Y
+30 | PURE SUBROUTINE IMPL_PROC(X)
+31 |     INTEGER, INTENT(INOUT) :: X
+32 |     X = X + 1
+   - END SUBROUTINE IMPL_PROC
+33 + END subroutine IMPL_PROC
+34 |
+35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
+36 |     INTEGER, INTENT(IN) :: Y
 
 ./resources/test/fixtures/style/S233.f90:35:1: S233 [*] Keyword 'ELEMENTAL' should be 'elemental'
    |
@@ -888,15 +846,14 @@ expression: diagnostics
    |
    = help: Change to 'elemental'
 
-ℹ Safe fix
-32 32 |     X = X + 1
-33 33 | END SUBROUTINE IMPL_PROC
-34 34 | 
-35    |-ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
-   35 |+elemental FUNCTION DOUBLE_VAL(Y) RESULT(RES)
-36 36 |     INTEGER, INTENT(IN) :: Y
-37 37 |     INTEGER :: RES
-38 38 |     RES = Y * 2
+32 |     X = X + 1
+33 | END SUBROUTINE IMPL_PROC
+34 |
+   - ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
+35 + elemental FUNCTION DOUBLE_VAL(Y) RESULT(RES)
+36 |     INTEGER, INTENT(IN) :: Y
+37 |     INTEGER :: RES
+38 |     RES = Y * 2
 
 ./resources/test/fixtures/style/S233.f90:35:11: S233 [*] Keyword 'FUNCTION' should be 'function'
    |
@@ -909,15 +866,14 @@ expression: diagnostics
    |
    = help: Change to 'function'
 
-ℹ Safe fix
-32 32 |     X = X + 1
-33 33 | END SUBROUTINE IMPL_PROC
-34 34 | 
-35    |-ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
-   35 |+ELEMENTAL function DOUBLE_VAL(Y) RESULT(RES)
-36 36 |     INTEGER, INTENT(IN) :: Y
-37 37 |     INTEGER :: RES
-38 38 |     RES = Y * 2
+32 |     X = X + 1
+33 | END SUBROUTINE IMPL_PROC
+34 |
+   - ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
+35 + ELEMENTAL function DOUBLE_VAL(Y) RESULT(RES)
+36 |     INTEGER, INTENT(IN) :: Y
+37 |     INTEGER :: RES
+38 |     RES = Y * 2
 
 ./resources/test/fixtures/style/S233.f90:35:34: S233 [*] Keyword 'RESULT' should be 'result'
    |
@@ -930,15 +886,14 @@ expression: diagnostics
    |
    = help: Change to 'result'
 
-ℹ Safe fix
-32 32 |     X = X + 1
-33 33 | END SUBROUTINE IMPL_PROC
-34 34 | 
-35    |-ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
-   35 |+ELEMENTAL FUNCTION DOUBLE_VAL(Y) result(RES)
-36 36 |     INTEGER, INTENT(IN) :: Y
-37 37 |     INTEGER :: RES
-38 38 |     RES = Y * 2
+32 |     X = X + 1
+33 | END SUBROUTINE IMPL_PROC
+34 |
+   - ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
+35 + ELEMENTAL FUNCTION DOUBLE_VAL(Y) result(RES)
+36 |     INTEGER, INTENT(IN) :: Y
+37 |     INTEGER :: RES
+38 |     RES = Y * 2
 
 ./resources/test/fixtures/style/S233.f90:36:5: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -950,15 +905,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-33 33 | END SUBROUTINE IMPL_PROC
-34 34 | 
-35 35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
-36    |-    INTEGER, INTENT(IN) :: Y
-   36 |+    integer, INTENT(IN) :: Y
-37 37 |     INTEGER :: RES
-38 38 |     RES = Y * 2
-39 39 | END FUNCTION DOUBLE_VAL
+33 | END SUBROUTINE IMPL_PROC
+34 |
+35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
+   -     INTEGER, INTENT(IN) :: Y
+36 +     integer, INTENT(IN) :: Y
+37 |     INTEGER :: RES
+38 |     RES = Y * 2
+39 | END FUNCTION DOUBLE_VAL
 
 ./resources/test/fixtures/style/S233.f90:36:14: S233 [*] Keyword 'INTENT' should be 'intent'
    |
@@ -970,15 +924,14 @@ expression: diagnostics
    |
    = help: Change to 'intent'
 
-ℹ Safe fix
-33 33 | END SUBROUTINE IMPL_PROC
-34 34 | 
-35 35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
-36    |-    INTEGER, INTENT(IN) :: Y
-   36 |+    INTEGER, intent(IN) :: Y
-37 37 |     INTEGER :: RES
-38 38 |     RES = Y * 2
-39 39 | END FUNCTION DOUBLE_VAL
+33 | END SUBROUTINE IMPL_PROC
+34 |
+35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
+   -     INTEGER, INTENT(IN) :: Y
+36 +     INTEGER, intent(IN) :: Y
+37 |     INTEGER :: RES
+38 |     RES = Y * 2
+39 | END FUNCTION DOUBLE_VAL
 
 ./resources/test/fixtures/style/S233.f90:36:21: S233 [*] Keyword 'IN' should be 'in'
    |
@@ -990,15 +943,14 @@ expression: diagnostics
    |
    = help: Change to 'in'
 
-ℹ Safe fix
-33 33 | END SUBROUTINE IMPL_PROC
-34 34 | 
-35 35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
-36    |-    INTEGER, INTENT(IN) :: Y
-   36 |+    INTEGER, INTENT(in) :: Y
-37 37 |     INTEGER :: RES
-38 38 |     RES = Y * 2
-39 39 | END FUNCTION DOUBLE_VAL
+33 | END SUBROUTINE IMPL_PROC
+34 |
+35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
+   -     INTEGER, INTENT(IN) :: Y
+36 +     INTEGER, INTENT(in) :: Y
+37 |     INTEGER :: RES
+38 |     RES = Y * 2
+39 | END FUNCTION DOUBLE_VAL
 
 ./resources/test/fixtures/style/S233.f90:37:5: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -1011,15 +963,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-34 34 | 
-35 35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
-36 36 |     INTEGER, INTENT(IN) :: Y
-37    |-    INTEGER :: RES
-   37 |+    integer :: RES
-38 38 |     RES = Y * 2
-39 39 | END FUNCTION DOUBLE_VAL
-40 40 | 
+34 |
+35 | ELEMENTAL FUNCTION DOUBLE_VAL(Y) RESULT(RES)
+36 |     INTEGER, INTENT(IN) :: Y
+   -     INTEGER :: RES
+37 +     integer :: RES
+38 |     RES = Y * 2
+39 | END FUNCTION DOUBLE_VAL
+40 |
 
 ./resources/test/fixtures/style/S233.f90:39:1: S233 [*] Keyword 'END' should be 'end'
    |
@@ -1032,15 +983,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-36 36 |     INTEGER, INTENT(IN) :: Y
-37 37 |     INTEGER :: RES
-38 38 |     RES = Y * 2
-39    |-END FUNCTION DOUBLE_VAL
-   39 |+end FUNCTION DOUBLE_VAL
-40 40 | 
-41 41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
-42 42 |     INTEGER, INTENT(IN) :: N
+36 |     INTEGER, INTENT(IN) :: Y
+37 |     INTEGER :: RES
+38 |     RES = Y * 2
+   - END FUNCTION DOUBLE_VAL
+39 + end FUNCTION DOUBLE_VAL
+40 |
+41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
+42 |     INTEGER, INTENT(IN) :: N
 
 ./resources/test/fixtures/style/S233.f90:39:5: S233 [*] Keyword 'FUNCTION' should be 'function'
    |
@@ -1053,15 +1003,14 @@ expression: diagnostics
    |
    = help: Change to 'function'
 
-ℹ Safe fix
-36 36 |     INTEGER, INTENT(IN) :: Y
-37 37 |     INTEGER :: RES
-38 38 |     RES = Y * 2
-39    |-END FUNCTION DOUBLE_VAL
-   39 |+END function DOUBLE_VAL
-40 40 | 
-41 41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
-42 42 |     INTEGER, INTENT(IN) :: N
+36 |     INTEGER, INTENT(IN) :: Y
+37 |     INTEGER :: RES
+38 |     RES = Y * 2
+   - END FUNCTION DOUBLE_VAL
+39 + END function DOUBLE_VAL
+40 |
+41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
+42 |     INTEGER, INTENT(IN) :: N
 
 ./resources/test/fixtures/style/S233.f90:41:1: S233 [*] Keyword 'RECURSIVE' should be 'recursive'
    |
@@ -1074,15 +1023,14 @@ expression: diagnostics
    |
    = help: Change to 'recursive'
 
-ℹ Safe fix
-38 38 |     RES = Y * 2
-39 39 | END FUNCTION DOUBLE_VAL
-40 40 | 
-41    |-RECURSIVE FUNCTION FACT(N) RESULT(RES)
-   41 |+recursive FUNCTION FACT(N) RESULT(RES)
-42 42 |     INTEGER, INTENT(IN) :: N
-43 43 |     INTEGER :: RES
-44 44 |     IF (N <= 1) THEN
+38 |     RES = Y * 2
+39 | END FUNCTION DOUBLE_VAL
+40 |
+   - RECURSIVE FUNCTION FACT(N) RESULT(RES)
+41 + recursive FUNCTION FACT(N) RESULT(RES)
+42 |     INTEGER, INTENT(IN) :: N
+43 |     INTEGER :: RES
+44 |     IF (N <= 1) THEN
 
 ./resources/test/fixtures/style/S233.f90:41:11: S233 [*] Keyword 'FUNCTION' should be 'function'
    |
@@ -1095,15 +1043,14 @@ expression: diagnostics
    |
    = help: Change to 'function'
 
-ℹ Safe fix
-38 38 |     RES = Y * 2
-39 39 | END FUNCTION DOUBLE_VAL
-40 40 | 
-41    |-RECURSIVE FUNCTION FACT(N) RESULT(RES)
-   41 |+RECURSIVE function FACT(N) RESULT(RES)
-42 42 |     INTEGER, INTENT(IN) :: N
-43 43 |     INTEGER :: RES
-44 44 |     IF (N <= 1) THEN
+38 |     RES = Y * 2
+39 | END FUNCTION DOUBLE_VAL
+40 |
+   - RECURSIVE FUNCTION FACT(N) RESULT(RES)
+41 + RECURSIVE function FACT(N) RESULT(RES)
+42 |     INTEGER, INTENT(IN) :: N
+43 |     INTEGER :: RES
+44 |     IF (N <= 1) THEN
 
 ./resources/test/fixtures/style/S233.f90:41:28: S233 [*] Keyword 'RESULT' should be 'result'
    |
@@ -1116,15 +1063,14 @@ expression: diagnostics
    |
    = help: Change to 'result'
 
-ℹ Safe fix
-38 38 |     RES = Y * 2
-39 39 | END FUNCTION DOUBLE_VAL
-40 40 | 
-41    |-RECURSIVE FUNCTION FACT(N) RESULT(RES)
-   41 |+RECURSIVE FUNCTION FACT(N) result(RES)
-42 42 |     INTEGER, INTENT(IN) :: N
-43 43 |     INTEGER :: RES
-44 44 |     IF (N <= 1) THEN
+38 |     RES = Y * 2
+39 | END FUNCTION DOUBLE_VAL
+40 |
+   - RECURSIVE FUNCTION FACT(N) RESULT(RES)
+41 + RECURSIVE FUNCTION FACT(N) result(RES)
+42 |     INTEGER, INTENT(IN) :: N
+43 |     INTEGER :: RES
+44 |     IF (N <= 1) THEN
 
 ./resources/test/fixtures/style/S233.f90:42:5: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -1136,15 +1082,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-39 39 | END FUNCTION DOUBLE_VAL
-40 40 | 
-41 41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
-42    |-    INTEGER, INTENT(IN) :: N
-   42 |+    integer, INTENT(IN) :: N
-43 43 |     INTEGER :: RES
-44 44 |     IF (N <= 1) THEN
-45 45 |         RES = 1
+39 | END FUNCTION DOUBLE_VAL
+40 |
+41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
+   -     INTEGER, INTENT(IN) :: N
+42 +     integer, INTENT(IN) :: N
+43 |     INTEGER :: RES
+44 |     IF (N <= 1) THEN
+45 |         RES = 1
 
 ./resources/test/fixtures/style/S233.f90:42:14: S233 [*] Keyword 'INTENT' should be 'intent'
    |
@@ -1156,15 +1101,14 @@ expression: diagnostics
    |
    = help: Change to 'intent'
 
-ℹ Safe fix
-39 39 | END FUNCTION DOUBLE_VAL
-40 40 | 
-41 41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
-42    |-    INTEGER, INTENT(IN) :: N
-   42 |+    INTEGER, intent(IN) :: N
-43 43 |     INTEGER :: RES
-44 44 |     IF (N <= 1) THEN
-45 45 |         RES = 1
+39 | END FUNCTION DOUBLE_VAL
+40 |
+41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
+   -     INTEGER, INTENT(IN) :: N
+42 +     INTEGER, intent(IN) :: N
+43 |     INTEGER :: RES
+44 |     IF (N <= 1) THEN
+45 |         RES = 1
 
 ./resources/test/fixtures/style/S233.f90:42:21: S233 [*] Keyword 'IN' should be 'in'
    |
@@ -1176,15 +1120,14 @@ expression: diagnostics
    |
    = help: Change to 'in'
 
-ℹ Safe fix
-39 39 | END FUNCTION DOUBLE_VAL
-40 40 | 
-41 41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
-42    |-    INTEGER, INTENT(IN) :: N
-   42 |+    INTEGER, INTENT(in) :: N
-43 43 |     INTEGER :: RES
-44 44 |     IF (N <= 1) THEN
-45 45 |         RES = 1
+39 | END FUNCTION DOUBLE_VAL
+40 |
+41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
+   -     INTEGER, INTENT(IN) :: N
+42 +     INTEGER, INTENT(in) :: N
+43 |     INTEGER :: RES
+44 |     IF (N <= 1) THEN
+45 |         RES = 1
 
 ./resources/test/fixtures/style/S233.f90:43:5: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -1197,15 +1140,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-40 40 | 
-41 41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
-42 42 |     INTEGER, INTENT(IN) :: N
-43    |-    INTEGER :: RES
-   43 |+    integer :: RES
-44 44 |     IF (N <= 1) THEN
-45 45 |         RES = 1
-46 46 |     ELSE
+40 |
+41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
+42 |     INTEGER, INTENT(IN) :: N
+   -     INTEGER :: RES
+43 +     integer :: RES
+44 |     IF (N <= 1) THEN
+45 |         RES = 1
+46 |     ELSE
 
 ./resources/test/fixtures/style/S233.f90:44:5: S233 [*] Keyword 'IF' should be 'if'
    |
@@ -1218,15 +1160,14 @@ expression: diagnostics
    |
    = help: Change to 'if'
 
-ℹ Safe fix
-41 41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
-42 42 |     INTEGER, INTENT(IN) :: N
-43 43 |     INTEGER :: RES
-44    |-    IF (N <= 1) THEN
-   44 |+    if (N <= 1) THEN
-45 45 |         RES = 1
-46 46 |     ELSE
-47 47 |         RES = N * FACT(N-1)
+41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
+42 |     INTEGER, INTENT(IN) :: N
+43 |     INTEGER :: RES
+   -     IF (N <= 1) THEN
+44 +     if (N <= 1) THEN
+45 |         RES = 1
+46 |     ELSE
+47 |         RES = N * FACT(N-1)
 
 ./resources/test/fixtures/style/S233.f90:44:17: S233 [*] Keyword 'THEN' should be 'then'
    |
@@ -1239,15 +1180,14 @@ expression: diagnostics
    |
    = help: Change to 'then'
 
-ℹ Safe fix
-41 41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
-42 42 |     INTEGER, INTENT(IN) :: N
-43 43 |     INTEGER :: RES
-44    |-    IF (N <= 1) THEN
-   44 |+    IF (N <= 1) then
-45 45 |         RES = 1
-46 46 |     ELSE
-47 47 |         RES = N * FACT(N-1)
+41 | RECURSIVE FUNCTION FACT(N) RESULT(RES)
+42 |     INTEGER, INTENT(IN) :: N
+43 |     INTEGER :: RES
+   -     IF (N <= 1) THEN
+44 +     IF (N <= 1) then
+45 |         RES = 1
+46 |     ELSE
+47 |         RES = N * FACT(N-1)
 
 ./resources/test/fixtures/style/S233.f90:46:5: S233 [*] Keyword 'ELSE' should be 'else'
    |
@@ -1260,15 +1200,14 @@ expression: diagnostics
    |
    = help: Change to 'else'
 
-ℹ Safe fix
-43 43 |     INTEGER :: RES
-44 44 |     IF (N <= 1) THEN
-45 45 |         RES = 1
-46    |-    ELSE
-   46 |+    else
-47 47 |         RES = N * FACT(N-1)
-48 48 |     END IF
-49 49 | END FUNCTION FACT
+43 |     INTEGER :: RES
+44 |     IF (N <= 1) THEN
+45 |         RES = 1
+   -     ELSE
+46 +     else
+47 |         RES = N * FACT(N-1)
+48 |     END IF
+49 | END FUNCTION FACT
 
 ./resources/test/fixtures/style/S233.f90:48:5: S233 [*] Keyword 'END' should be 'end'
    |
@@ -1280,15 +1219,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-45 45 |         RES = 1
-46 46 |     ELSE
-47 47 |         RES = N * FACT(N-1)
-48    |-    END IF
-   48 |+    end IF
-49 49 | END FUNCTION FACT
-50 50 | 
-51 51 | END MODULE MY_MODULE
+45 |         RES = 1
+46 |     ELSE
+47 |         RES = N * FACT(N-1)
+   -     END IF
+48 +     end IF
+49 | END FUNCTION FACT
+50 |
+51 | END MODULE MY_MODULE
 
 ./resources/test/fixtures/style/S233.f90:48:9: S233 [*] Keyword 'IF' should be 'if'
    |
@@ -1300,15 +1238,14 @@ expression: diagnostics
    |
    = help: Change to 'if'
 
-ℹ Safe fix
-45 45 |         RES = 1
-46 46 |     ELSE
-47 47 |         RES = N * FACT(N-1)
-48    |-    END IF
-   48 |+    END if
-49 49 | END FUNCTION FACT
-50 50 | 
-51 51 | END MODULE MY_MODULE
+45 |         RES = 1
+46 |     ELSE
+47 |         RES = N * FACT(N-1)
+   -     END IF
+48 +     END if
+49 | END FUNCTION FACT
+50 |
+51 | END MODULE MY_MODULE
 
 ./resources/test/fixtures/style/S233.f90:49:1: S233 [*] Keyword 'END' should be 'end'
    |
@@ -1321,15 +1258,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-46 46 |     ELSE
-47 47 |         RES = N * FACT(N-1)
-48 48 |     END IF
-49    |-END FUNCTION FACT
-   49 |+end FUNCTION FACT
-50 50 | 
-51 51 | END MODULE MY_MODULE
-52 52 | 
+46 |     ELSE
+47 |         RES = N * FACT(N-1)
+48 |     END IF
+   - END FUNCTION FACT
+49 + end FUNCTION FACT
+50 |
+51 | END MODULE MY_MODULE
+52 |
 
 ./resources/test/fixtures/style/S233.f90:49:5: S233 [*] Keyword 'FUNCTION' should be 'function'
    |
@@ -1342,15 +1278,14 @@ expression: diagnostics
    |
    = help: Change to 'function'
 
-ℹ Safe fix
-46 46 |     ELSE
-47 47 |         RES = N * FACT(N-1)
-48 48 |     END IF
-49    |-END FUNCTION FACT
-   49 |+END function FACT
-50 50 | 
-51 51 | END MODULE MY_MODULE
-52 52 | 
+46 |     ELSE
+47 |         RES = N * FACT(N-1)
+48 |     END IF
+   - END FUNCTION FACT
+49 + END function FACT
+50 |
+51 | END MODULE MY_MODULE
+52 |
 
 ./resources/test/fixtures/style/S233.f90:51:1: S233 [*] Keyword 'END' should be 'end'
    |
@@ -1361,15 +1296,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-48 48 |     END IF
-49 49 | END FUNCTION FACT
-50 50 | 
-51    |-END MODULE MY_MODULE
-   51 |+end MODULE MY_MODULE
-52 52 | 
-53 53 | 
-54 54 | PROGRAM KEYWORD_ZOO
+48 |     END IF
+49 | END FUNCTION FACT
+50 |
+   - END MODULE MY_MODULE
+51 + end MODULE MY_MODULE
+52 |
+53 |
+54 | PROGRAM KEYWORD_ZOO
 
 ./resources/test/fixtures/style/S233.f90:51:5: S233 [*] Keyword 'MODULE' should be 'module'
    |
@@ -1380,15 +1314,14 @@ expression: diagnostics
    |
    = help: Change to 'module'
 
-ℹ Safe fix
-48 48 |     END IF
-49 49 | END FUNCTION FACT
-50 50 | 
-51    |-END MODULE MY_MODULE
-   51 |+END module MY_MODULE
-52 52 | 
-53 53 | 
-54 54 | PROGRAM KEYWORD_ZOO
+48 |     END IF
+49 | END FUNCTION FACT
+50 |
+   - END MODULE MY_MODULE
+51 + END module MY_MODULE
+52 |
+53 |
+54 | PROGRAM KEYWORD_ZOO
 
 ./resources/test/fixtures/style/S233.f90:54:1: S233 [*] Keyword 'PROGRAM' should be 'program'
    |
@@ -1399,15 +1332,14 @@ expression: diagnostics
    |
    = help: Change to 'program'
 
-ℹ Safe fix
-51 51 | END MODULE MY_MODULE
-52 52 | 
-53 53 | 
-54    |-PROGRAM KEYWORD_ZOO
-   54 |+program KEYWORD_ZOO
-55 55 | USE MY_MODULE, ONLY: FACT
-56 56 | USE, INTRINSIC :: ISO_C_BINDING
-57 57 | IMPLICIT NONE
+51 | END MODULE MY_MODULE
+52 |
+53 |
+   - PROGRAM KEYWORD_ZOO
+54 + program KEYWORD_ZOO
+55 | USE MY_MODULE, ONLY: FACT
+56 | USE, INTRINSIC :: ISO_C_BINDING
+57 | IMPLICIT NONE
 
 ./resources/test/fixtures/style/S233.f90:55:1: S233 [*] Keyword 'USE' should be 'use'
    |
@@ -1419,15 +1351,14 @@ expression: diagnostics
    |
    = help: Change to 'use'
 
-ℹ Safe fix
-52 52 | 
-53 53 | 
-54 54 | PROGRAM KEYWORD_ZOO
-55    |-USE MY_MODULE, ONLY: FACT
-   55 |+use MY_MODULE, ONLY: FACT
-56 56 | USE, INTRINSIC :: ISO_C_BINDING
-57 57 | IMPLICIT NONE
-58 58 | 
+52 |
+53 |
+54 | PROGRAM KEYWORD_ZOO
+   - USE MY_MODULE, ONLY: FACT
+55 + use MY_MODULE, ONLY: FACT
+56 | USE, INTRINSIC :: ISO_C_BINDING
+57 | IMPLICIT NONE
+58 |
 
 ./resources/test/fixtures/style/S233.f90:55:16: S233 [*] Keyword 'ONLY' should be 'only'
    |
@@ -1439,15 +1370,14 @@ expression: diagnostics
    |
    = help: Change to 'only'
 
-ℹ Safe fix
-52 52 | 
-53 53 | 
-54 54 | PROGRAM KEYWORD_ZOO
-55    |-USE MY_MODULE, ONLY: FACT
-   55 |+USE MY_MODULE, only: FACT
-56 56 | USE, INTRINSIC :: ISO_C_BINDING
-57 57 | IMPLICIT NONE
-58 58 | 
+52 |
+53 |
+54 | PROGRAM KEYWORD_ZOO
+   - USE MY_MODULE, ONLY: FACT
+55 + USE MY_MODULE, only: FACT
+56 | USE, INTRINSIC :: ISO_C_BINDING
+57 | IMPLICIT NONE
+58 |
 
 ./resources/test/fixtures/style/S233.f90:56:1: S233 [*] Keyword 'USE' should be 'use'
    |
@@ -1459,15 +1389,14 @@ expression: diagnostics
    |
    = help: Change to 'use'
 
-ℹ Safe fix
-53 53 | 
-54 54 | PROGRAM KEYWORD_ZOO
-55 55 | USE MY_MODULE, ONLY: FACT
-56    |-USE, INTRINSIC :: ISO_C_BINDING
-   56 |+use, INTRINSIC :: ISO_C_BINDING
-57 57 | IMPLICIT NONE
-58 58 | 
-59 59 | INTEGER, PARAMETER :: N = 5
+53 |
+54 | PROGRAM KEYWORD_ZOO
+55 | USE MY_MODULE, ONLY: FACT
+   - USE, INTRINSIC :: ISO_C_BINDING
+56 + use, INTRINSIC :: ISO_C_BINDING
+57 | IMPLICIT NONE
+58 |
+59 | INTEGER, PARAMETER :: N = 5
 
 ./resources/test/fixtures/style/S233.f90:56:6: S233 [*] Keyword 'INTRINSIC' should be 'intrinsic'
    |
@@ -1479,15 +1408,14 @@ expression: diagnostics
    |
    = help: Change to 'intrinsic'
 
-ℹ Safe fix
-53 53 | 
-54 54 | PROGRAM KEYWORD_ZOO
-55 55 | USE MY_MODULE, ONLY: FACT
-56    |-USE, INTRINSIC :: ISO_C_BINDING
-   56 |+USE, intrinsic :: ISO_C_BINDING
-57 57 | IMPLICIT NONE
-58 58 | 
-59 59 | INTEGER, PARAMETER :: N = 5
+53 |
+54 | PROGRAM KEYWORD_ZOO
+55 | USE MY_MODULE, ONLY: FACT
+   - USE, INTRINSIC :: ISO_C_BINDING
+56 + USE, intrinsic :: ISO_C_BINDING
+57 | IMPLICIT NONE
+58 |
+59 | INTEGER, PARAMETER :: N = 5
 
 ./resources/test/fixtures/style/S233.f90:57:1: S233 [*] Keyword 'IMPLICIT' should be 'implicit'
    |
@@ -1500,15 +1428,14 @@ expression: diagnostics
    |
    = help: Change to 'implicit'
 
-ℹ Safe fix
-54 54 | PROGRAM KEYWORD_ZOO
-55 55 | USE MY_MODULE, ONLY: FACT
-56 56 | USE, INTRINSIC :: ISO_C_BINDING
-57    |-IMPLICIT NONE
-   57 |+implicit NONE
-58 58 | 
-59 59 | INTEGER, PARAMETER :: N = 5
-60 60 | INTEGER :: I, J
+54 | PROGRAM KEYWORD_ZOO
+55 | USE MY_MODULE, ONLY: FACT
+56 | USE, INTRINSIC :: ISO_C_BINDING
+   - IMPLICIT NONE
+57 + implicit NONE
+58 |
+59 | INTEGER, PARAMETER :: N = 5
+60 | INTEGER :: I, J
 
 ./resources/test/fixtures/style/S233.f90:57:10: S233 [*] Keyword 'NONE' should be 'none'
    |
@@ -1521,15 +1448,14 @@ expression: diagnostics
    |
    = help: Change to 'none'
 
-ℹ Safe fix
-54 54 | PROGRAM KEYWORD_ZOO
-55 55 | USE MY_MODULE, ONLY: FACT
-56 56 | USE, INTRINSIC :: ISO_C_BINDING
-57    |-IMPLICIT NONE
-   57 |+IMPLICIT none
-58 58 | 
-59 59 | INTEGER, PARAMETER :: N = 5
-60 60 | INTEGER :: I, J
+54 | PROGRAM KEYWORD_ZOO
+55 | USE MY_MODULE, ONLY: FACT
+56 | USE, INTRINSIC :: ISO_C_BINDING
+   - IMPLICIT NONE
+57 + IMPLICIT none
+58 |
+59 | INTEGER, PARAMETER :: N = 5
+60 | INTEGER :: I, J
 
 ./resources/test/fixtures/style/S233.f90:59:1: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -1542,15 +1468,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-56 56 | USE, INTRINSIC :: ISO_C_BINDING
-57 57 | IMPLICIT NONE
-58 58 | 
-59    |-INTEGER, PARAMETER :: N = 5
-   59 |+integer, PARAMETER :: N = 5
-60 60 | INTEGER :: I, J
-61 61 | REAL, ALLOCATABLE :: ARR(:)
-62 62 | LOGICAL :: FLAG
+56 | USE, INTRINSIC :: ISO_C_BINDING
+57 | IMPLICIT NONE
+58 |
+   - INTEGER, PARAMETER :: N = 5
+59 + integer, PARAMETER :: N = 5
+60 | INTEGER :: I, J
+61 | REAL, ALLOCATABLE :: ARR(:)
+62 | LOGICAL :: FLAG
 
 ./resources/test/fixtures/style/S233.f90:59:10: S233 [*] Keyword 'PARAMETER' should be 'parameter'
    |
@@ -1563,15 +1488,14 @@ expression: diagnostics
    |
    = help: Change to 'parameter'
 
-ℹ Safe fix
-56 56 | USE, INTRINSIC :: ISO_C_BINDING
-57 57 | IMPLICIT NONE
-58 58 | 
-59    |-INTEGER, PARAMETER :: N = 5
-   59 |+INTEGER, parameter :: N = 5
-60 60 | INTEGER :: I, J
-61 61 | REAL, ALLOCATABLE :: ARR(:)
-62 62 | LOGICAL :: FLAG
+56 | USE, INTRINSIC :: ISO_C_BINDING
+57 | IMPLICIT NONE
+58 |
+   - INTEGER, PARAMETER :: N = 5
+59 + INTEGER, parameter :: N = 5
+60 | INTEGER :: I, J
+61 | REAL, ALLOCATABLE :: ARR(:)
+62 | LOGICAL :: FLAG
 
 ./resources/test/fixtures/style/S233.f90:60:1: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -1583,15 +1507,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-57 57 | IMPLICIT NONE
-58 58 | 
-59 59 | INTEGER, PARAMETER :: N = 5
-60    |-INTEGER :: I, J
-   60 |+integer :: I, J
-61 61 | REAL, ALLOCATABLE :: ARR(:)
-62 62 | LOGICAL :: FLAG
-63 63 | CHARACTER(LEN=10) :: STR
+57 | IMPLICIT NONE
+58 |
+59 | INTEGER, PARAMETER :: N = 5
+   - INTEGER :: I, J
+60 + integer :: I, J
+61 | REAL, ALLOCATABLE :: ARR(:)
+62 | LOGICAL :: FLAG
+63 | CHARACTER(LEN=10) :: STR
 
 ./resources/test/fixtures/style/S233.f90:61:1: S233 [*] Keyword 'REAL' should be 'real'
    |
@@ -1604,15 +1527,14 @@ expression: diagnostics
    |
    = help: Change to 'real'
 
-ℹ Safe fix
-58 58 | 
-59 59 | INTEGER, PARAMETER :: N = 5
-60 60 | INTEGER :: I, J
-61    |-REAL, ALLOCATABLE :: ARR(:)
-   61 |+real, ALLOCATABLE :: ARR(:)
-62 62 | LOGICAL :: FLAG
-63 63 | CHARACTER(LEN=10) :: STR
-64 64 | COMPLEX :: CMPLX
+58 |
+59 | INTEGER, PARAMETER :: N = 5
+60 | INTEGER :: I, J
+   - REAL, ALLOCATABLE :: ARR(:)
+61 + real, ALLOCATABLE :: ARR(:)
+62 | LOGICAL :: FLAG
+63 | CHARACTER(LEN=10) :: STR
+64 | COMPLEX :: CMPLX
 
 ./resources/test/fixtures/style/S233.f90:61:7: S233 [*] Keyword 'ALLOCATABLE' should be 'allocatable'
    |
@@ -1625,15 +1547,14 @@ expression: diagnostics
    |
    = help: Change to 'allocatable'
 
-ℹ Safe fix
-58 58 | 
-59 59 | INTEGER, PARAMETER :: N = 5
-60 60 | INTEGER :: I, J
-61    |-REAL, ALLOCATABLE :: ARR(:)
-   61 |+REAL, allocatable :: ARR(:)
-62 62 | LOGICAL :: FLAG
-63 63 | CHARACTER(LEN=10) :: STR
-64 64 | COMPLEX :: CMPLX
+58 |
+59 | INTEGER, PARAMETER :: N = 5
+60 | INTEGER :: I, J
+   - REAL, ALLOCATABLE :: ARR(:)
+61 + REAL, allocatable :: ARR(:)
+62 | LOGICAL :: FLAG
+63 | CHARACTER(LEN=10) :: STR
+64 | COMPLEX :: CMPLX
 
 ./resources/test/fixtures/style/S233.f90:62:1: S233 [*] Keyword 'LOGICAL' should be 'logical'
    |
@@ -1646,15 +1567,14 @@ expression: diagnostics
    |
    = help: Change to 'logical'
 
-ℹ Safe fix
-59 59 | INTEGER, PARAMETER :: N = 5
-60 60 | INTEGER :: I, J
-61 61 | REAL, ALLOCATABLE :: ARR(:)
-62    |-LOGICAL :: FLAG
-   62 |+logical :: FLAG
-63 63 | CHARACTER(LEN=10) :: STR
-64 64 | COMPLEX :: CMPLX
-65 65 | 
+59 | INTEGER, PARAMETER :: N = 5
+60 | INTEGER :: I, J
+61 | REAL, ALLOCATABLE :: ARR(:)
+   - LOGICAL :: FLAG
+62 + logical :: FLAG
+63 | CHARACTER(LEN=10) :: STR
+64 | COMPLEX :: CMPLX
+65 |
 
 ./resources/test/fixtures/style/S233.f90:63:1: S233 [*] Keyword 'CHARACTER' should be 'character'
    |
@@ -1666,15 +1586,14 @@ expression: diagnostics
    |
    = help: Change to 'character'
 
-ℹ Safe fix
-60 60 | INTEGER :: I, J
-61 61 | REAL, ALLOCATABLE :: ARR(:)
-62 62 | LOGICAL :: FLAG
-63    |-CHARACTER(LEN=10) :: STR
-   63 |+character(LEN=10) :: STR
-64 64 | COMPLEX :: CMPLX
-65 65 | 
-66 66 | INTEGER :: ENDIF, IF, ELSEIF
+60 | INTEGER :: I, J
+61 | REAL, ALLOCATABLE :: ARR(:)
+62 | LOGICAL :: FLAG
+   - CHARACTER(LEN=10) :: STR
+63 + character(LEN=10) :: STR
+64 | COMPLEX :: CMPLX
+65 |
+66 | INTEGER :: ENDIF, IF, ELSEIF
 
 ./resources/test/fixtures/style/S233.f90:64:1: S233 [*] Keyword 'COMPLEX' should be 'complex'
    |
@@ -1687,15 +1606,14 @@ expression: diagnostics
    |
    = help: Change to 'complex'
 
-ℹ Safe fix
-61 61 | REAL, ALLOCATABLE :: ARR(:)
-62 62 | LOGICAL :: FLAG
-63 63 | CHARACTER(LEN=10) :: STR
-64    |-COMPLEX :: CMPLX
-   64 |+complex :: CMPLX
-65 65 | 
-66 66 | INTEGER :: ENDIF, IF, ELSEIF
-67 67 | INTEGER, DIMENSION(2) :: FUNCTION
+61 | REAL, ALLOCATABLE :: ARR(:)
+62 | LOGICAL :: FLAG
+63 | CHARACTER(LEN=10) :: STR
+   - COMPLEX :: CMPLX
+64 + complex :: CMPLX
+65 |
+66 | INTEGER :: ENDIF, IF, ELSEIF
+67 | INTEGER, DIMENSION(2) :: FUNCTION
 
 ./resources/test/fixtures/style/S233.f90:66:1: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -1708,15 +1626,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-63 63 | CHARACTER(LEN=10) :: STR
-64 64 | COMPLEX :: CMPLX
-65 65 | 
-66    |-INTEGER :: ENDIF, IF, ELSEIF
-   66 |+integer :: ENDIF, IF, ELSEIF
-67 67 | INTEGER, DIMENSION(2) :: FUNCTION
-68 68 | ENDIF = 3; IF = 2
-69 69 | 
+63 | CHARACTER(LEN=10) :: STR
+64 | COMPLEX :: CMPLX
+65 |
+   - INTEGER :: ENDIF, IF, ELSEIF
+66 + integer :: ENDIF, IF, ELSEIF
+67 | INTEGER, DIMENSION(2) :: FUNCTION
+68 | ENDIF = 3; IF = 2
+69 |
 
 ./resources/test/fixtures/style/S233.f90:67:1: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -1727,15 +1644,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-64 64 | COMPLEX :: CMPLX
-65 65 | 
-66 66 | INTEGER :: ENDIF, IF, ELSEIF
-67    |-INTEGER, DIMENSION(2) :: FUNCTION
-   67 |+integer, DIMENSION(2) :: FUNCTION
-68 68 | ENDIF = 3; IF = 2
-69 69 | 
-70 70 | TYPE(TEST_TYPE) :: OBJ
+64 | COMPLEX :: CMPLX
+65 |
+66 | INTEGER :: ENDIF, IF, ELSEIF
+   - INTEGER, DIMENSION(2) :: FUNCTION
+67 + integer, DIMENSION(2) :: FUNCTION
+68 | ENDIF = 3; IF = 2
+69 |
+70 | TYPE(TEST_TYPE) :: OBJ
 
 ./resources/test/fixtures/style/S233.f90:67:10: S233 [*] Keyword 'DIMENSION' should be 'dimension'
    |
@@ -1746,15 +1662,14 @@ expression: diagnostics
    |
    = help: Change to 'dimension'
 
-ℹ Safe fix
-64 64 | COMPLEX :: CMPLX
-65 65 | 
-66 66 | INTEGER :: ENDIF, IF, ELSEIF
-67    |-INTEGER, DIMENSION(2) :: FUNCTION
-   67 |+INTEGER, dimension(2) :: FUNCTION
-68 68 | ENDIF = 3; IF = 2
-69 69 | 
-70 70 | TYPE(TEST_TYPE) :: OBJ
+64 | COMPLEX :: CMPLX
+65 |
+66 | INTEGER :: ENDIF, IF, ELSEIF
+   - INTEGER, DIMENSION(2) :: FUNCTION
+67 + INTEGER, dimension(2) :: FUNCTION
+68 | ENDIF = 3; IF = 2
+69 |
+70 | TYPE(TEST_TYPE) :: OBJ
 
 ./resources/test/fixtures/style/S233.f90:70:1: S233 [*] Keyword 'TYPE' should be 'type'
    |
@@ -1766,15 +1681,14 @@ expression: diagnostics
    |
    = help: Change to 'type'
 
-ℹ Safe fix
-67 67 | INTEGER, DIMENSION(2) :: FUNCTION
-68 68 | ENDIF = 3; IF = 2
-69 69 | 
-70    |-TYPE(TEST_TYPE) :: OBJ
-   70 |+type(TEST_TYPE) :: OBJ
-71 71 | CLASS(BASE_TYPE), ALLOCATABLE :: POLY
-72 72 | 
-73 73 | ENUM, BIND(C)
+67 | INTEGER, DIMENSION(2) :: FUNCTION
+68 | ENDIF = 3; IF = 2
+69 |
+   - TYPE(TEST_TYPE) :: OBJ
+70 + type(TEST_TYPE) :: OBJ
+71 | CLASS(BASE_TYPE), ALLOCATABLE :: POLY
+72 |
+73 | ENUM, BIND(C)
 
 ./resources/test/fixtures/style/S233.f90:71:1: S233 [*] Keyword 'CLASS' should be 'class'
    |
@@ -1786,15 +1700,14 @@ expression: diagnostics
    |
    = help: Change to 'class'
 
-ℹ Safe fix
-68 68 | ENDIF = 3; IF = 2
-69 69 | 
-70 70 | TYPE(TEST_TYPE) :: OBJ
-71    |-CLASS(BASE_TYPE), ALLOCATABLE :: POLY
-   71 |+class(BASE_TYPE), ALLOCATABLE :: POLY
-72 72 | 
-73 73 | ENUM, BIND(C)
-74 74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
+68 | ENDIF = 3; IF = 2
+69 |
+70 | TYPE(TEST_TYPE) :: OBJ
+   - CLASS(BASE_TYPE), ALLOCATABLE :: POLY
+71 + class(BASE_TYPE), ALLOCATABLE :: POLY
+72 |
+73 | ENUM, BIND(C)
+74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
 
 ./resources/test/fixtures/style/S233.f90:71:19: S233 [*] Keyword 'ALLOCATABLE' should be 'allocatable'
    |
@@ -1806,15 +1719,14 @@ expression: diagnostics
    |
    = help: Change to 'allocatable'
 
-ℹ Safe fix
-68 68 | ENDIF = 3; IF = 2
-69 69 | 
-70 70 | TYPE(TEST_TYPE) :: OBJ
-71    |-CLASS(BASE_TYPE), ALLOCATABLE :: POLY
-   71 |+CLASS(BASE_TYPE), allocatable :: POLY
-72 72 | 
-73 73 | ENUM, BIND(C)
-74 74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
+68 | ENDIF = 3; IF = 2
+69 |
+70 | TYPE(TEST_TYPE) :: OBJ
+   - CLASS(BASE_TYPE), ALLOCATABLE :: POLY
+71 + CLASS(BASE_TYPE), allocatable :: POLY
+72 |
+73 | ENUM, BIND(C)
+74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
 
 ./resources/test/fixtures/style/S233.f90:73:1: S233 [*] Keyword 'ENUM' should be 'enum'
    |
@@ -1827,15 +1739,14 @@ expression: diagnostics
    |
    = help: Change to 'enum'
 
-ℹ Safe fix
-70 70 | TYPE(TEST_TYPE) :: OBJ
-71 71 | CLASS(BASE_TYPE), ALLOCATABLE :: POLY
-72 72 | 
-73    |-ENUM, BIND(C)
-   73 |+enum, BIND(C)
-74 74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
-75 75 | END ENUM
-76 76 | 
+70 | TYPE(TEST_TYPE) :: OBJ
+71 | CLASS(BASE_TYPE), ALLOCATABLE :: POLY
+72 |
+   - ENUM, BIND(C)
+73 + enum, BIND(C)
+74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
+75 | END ENUM
+76 |
 
 ./resources/test/fixtures/style/S233.f90:73:7: S233 [*] Keyword 'BIND' should be 'bind'
    |
@@ -1848,15 +1759,14 @@ expression: diagnostics
    |
    = help: Change to 'bind'
 
-ℹ Safe fix
-70 70 | TYPE(TEST_TYPE) :: OBJ
-71 71 | CLASS(BASE_TYPE), ALLOCATABLE :: POLY
-72 72 | 
-73    |-ENUM, BIND(C)
-   73 |+ENUM, bind(C)
-74 74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
-75 75 | END ENUM
-76 76 | 
+70 | TYPE(TEST_TYPE) :: OBJ
+71 | CLASS(BASE_TYPE), ALLOCATABLE :: POLY
+72 |
+   - ENUM, BIND(C)
+73 + ENUM, bind(C)
+74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
+75 | END ENUM
+76 |
 
 ./resources/test/fixtures/style/S233.f90:74:5: S233 [*] Keyword 'ENUMERATOR' should be 'enumerator'
    |
@@ -1867,15 +1777,14 @@ expression: diagnostics
    |
    = help: Change to 'enumerator'
 
-ℹ Safe fix
-71 71 | CLASS(BASE_TYPE), ALLOCATABLE :: POLY
-72 72 | 
-73 73 | ENUM, BIND(C)
-74    |-    ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
-   74 |+    enumerator :: RED = 1, GREEN = 2, BLUE = 3
-75 75 | END ENUM
-76 76 | 
-77 77 | IF (ENDIF == 2) then
+71 | CLASS(BASE_TYPE), ALLOCATABLE :: POLY
+72 |
+73 | ENUM, BIND(C)
+   -     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
+74 +     enumerator :: RED = 1, GREEN = 2, BLUE = 3
+75 | END ENUM
+76 |
+77 | IF (ENDIF == 2) then
 
 ./resources/test/fixtures/style/S233.f90:75:1: S233 [*] Keyword 'END' should be 'end'
    |
@@ -1888,15 +1797,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-72 72 | 
-73 73 | ENUM, BIND(C)
-74 74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
-75    |-END ENUM
-   75 |+end ENUM
-76 76 | 
-77 77 | IF (ENDIF == 2) then
-78 78 |     ENDIF = 5
+72 |
+73 | ENUM, BIND(C)
+74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
+   - END ENUM
+75 + end ENUM
+76 |
+77 | IF (ENDIF == 2) then
+78 |     ENDIF = 5
 
 ./resources/test/fixtures/style/S233.f90:75:5: S233 [*] Keyword 'ENUM' should be 'enum'
    |
@@ -1909,15 +1817,14 @@ expression: diagnostics
    |
    = help: Change to 'enum'
 
-ℹ Safe fix
-72 72 | 
-73 73 | ENUM, BIND(C)
-74 74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
-75    |-END ENUM
-   75 |+END enum
-76 76 | 
-77 77 | IF (ENDIF == 2) then
-78 78 |     ENDIF = 5
+72 |
+73 | ENUM, BIND(C)
+74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
+   - END ENUM
+75 + END enum
+76 |
+77 | IF (ENDIF == 2) then
+78 |     ENDIF = 5
 
 ./resources/test/fixtures/style/S233.f90:77:1: S233 [*] Keyword 'IF' should be 'if'
    |
@@ -1930,15 +1837,14 @@ expression: diagnostics
    |
    = help: Change to 'if'
 
-ℹ Safe fix
-74 74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
-75 75 | END ENUM
-76 76 | 
-77    |-IF (ENDIF == 2) then
-   77 |+if (ENDIF == 2) then
-78 78 |     ENDIF = 5
-79 79 |     ELSEIF = IF + 4*(ENDIF + &
-80 80 |                     2**10)
+74 |     ENUMERATOR :: RED = 1, GREEN = 2, BLUE = 3
+75 | END ENUM
+76 |
+   - IF (ENDIF == 2) then
+77 + if (ENDIF == 2) then
+78 |     ENDIF = 5
+79 |     ELSEIF = IF + 4*(ENDIF + &
+80 |                     2**10)
 
 ./resources/test/fixtures/style/S233.f90:81:5: S233 [*] Keyword 'ELSEIF' should be 'elseif'
    |
@@ -1951,15 +1857,14 @@ expression: diagnostics
    |
    = help: Change to 'elseif'
 
-ℹ Safe fix
-78 78 |     ENDIF = 5
-79 79 |     ELSEIF = IF + 4*(ENDIF + &
-80 80 |                     2**10)
-81    |-    ELSEIF (ENDIF == 3) THEN
-   81 |+    elseif (ENDIF == 3) THEN
-82 82 |     FUNCTION(IF) = ENDIF/ELSEIF
-83 83 |     PRINT *, ENDIF
-84 84 | ENDIF
+78 |     ENDIF = 5
+79 |     ELSEIF = IF + 4*(ENDIF + &
+80 |                     2**10)
+   -     ELSEIF (ENDIF == 3) THEN
+81 +     elseif (ENDIF == 3) THEN
+82 |     FUNCTION(IF) = ENDIF/ELSEIF
+83 |     PRINT *, ENDIF
+84 | ENDIF
 
 ./resources/test/fixtures/style/S233.f90:81:25: S233 [*] Keyword 'THEN' should be 'then'
    |
@@ -1972,15 +1877,14 @@ expression: diagnostics
    |
    = help: Change to 'then'
 
-ℹ Safe fix
-78 78 |     ENDIF = 5
-79 79 |     ELSEIF = IF + 4*(ENDIF + &
-80 80 |                     2**10)
-81    |-    ELSEIF (ENDIF == 3) THEN
-   81 |+    ELSEIF (ENDIF == 3) then
-82 82 |     FUNCTION(IF) = ENDIF/ELSEIF
-83 83 |     PRINT *, ENDIF
-84 84 | ENDIF
+78 |     ENDIF = 5
+79 |     ELSEIF = IF + 4*(ENDIF + &
+80 |                     2**10)
+   -     ELSEIF (ENDIF == 3) THEN
+81 +     ELSEIF (ENDIF == 3) then
+82 |     FUNCTION(IF) = ENDIF/ELSEIF
+83 |     PRINT *, ENDIF
+84 | ENDIF
 
 ./resources/test/fixtures/style/S233.f90:83:5: S233 [*] Keyword 'PRINT' should be 'print'
    |
@@ -1992,15 +1896,14 @@ expression: diagnostics
    |
    = help: Change to 'print'
 
-ℹ Safe fix
-80 80 |                     2**10)
-81 81 |     ELSEIF (ENDIF == 3) THEN
-82 82 |     FUNCTION(IF) = ENDIF/ELSEIF
-83    |-    PRINT *, ENDIF
-   83 |+    print *, ENDIF
-84 84 | ENDIF
-85 85 | 
-86 86 | ALLOCATE(ARR(N))
+80 |                     2**10)
+81 |     ELSEIF (ENDIF == 3) THEN
+82 |     FUNCTION(IF) = ENDIF/ELSEIF
+   -     PRINT *, ENDIF
+83 +     print *, ENDIF
+84 | ENDIF
+85 |
+86 | ALLOCATE(ARR(N))
 
 ./resources/test/fixtures/style/S233.f90:84:1: S233 [*] Keyword 'ENDIF' should be 'endif'
    |
@@ -2013,15 +1916,14 @@ expression: diagnostics
    |
    = help: Change to 'endif'
 
-ℹ Safe fix
-81 81 |     ELSEIF (ENDIF == 3) THEN
-82 82 |     FUNCTION(IF) = ENDIF/ELSEIF
-83 83 |     PRINT *, ENDIF
-84    |-ENDIF
-   84 |+endif
-85 85 | 
-86 86 | ALLOCATE(ARR(N))
-87 87 | ARR = 0.0
+81 |     ELSEIF (ENDIF == 3) THEN
+82 |     FUNCTION(IF) = ENDIF/ELSEIF
+83 |     PRINT *, ENDIF
+   - ENDIF
+84 + endif
+85 |
+86 | ALLOCATE(ARR(N))
+87 | ARR = 0.0
 
 ./resources/test/fixtures/style/S233.f90:86:1: S233 [*] Keyword 'ALLOCATE' should be 'allocate'
    |
@@ -2033,15 +1935,14 @@ expression: diagnostics
    |
    = help: Change to 'allocate'
 
-ℹ Safe fix
-83 83 |     PRINT *, ENDIF
-84 84 | ENDIF
-85 85 | 
-86    |-ALLOCATE(ARR(N))
-   86 |+allocate(ARR(N))
-87 87 | ARR = 0.0
-88 88 | 
-89 89 | ALLOCATE(TEST_TYPE :: POLY)
+83 |     PRINT *, ENDIF
+84 | ENDIF
+85 |
+   - ALLOCATE(ARR(N))
+86 + allocate(ARR(N))
+87 | ARR = 0.0
+88 |
+89 | ALLOCATE(TEST_TYPE :: POLY)
 
 ./resources/test/fixtures/style/S233.f90:89:1: S233 [*] Keyword 'ALLOCATE' should be 'allocate'
    |
@@ -2054,15 +1955,14 @@ expression: diagnostics
    |
    = help: Change to 'allocate'
 
-ℹ Safe fix
-86 86 | ALLOCATE(ARR(N))
-87 87 | ARR = 0.0
-88 88 | 
-89    |-ALLOCATE(TEST_TYPE :: POLY)
-   89 |+allocate(TEST_TYPE :: POLY)
-90 90 | 
-91 91 | ASSOCIATE (TMP => ARR)
-92 92 |     TMP = 1.0
+86 | ALLOCATE(ARR(N))
+87 | ARR = 0.0
+88 |
+   - ALLOCATE(TEST_TYPE :: POLY)
+89 + allocate(TEST_TYPE :: POLY)
+90 |
+91 | ASSOCIATE (TMP => ARR)
+92 |     TMP = 1.0
 
 ./resources/test/fixtures/style/S233.f90:91:1: S233 [*] Keyword 'ASSOCIATE' should be 'associate'
    |
@@ -2075,15 +1975,14 @@ expression: diagnostics
    |
    = help: Change to 'associate'
 
-ℹ Safe fix
-88 88 | 
-89 89 | ALLOCATE(TEST_TYPE :: POLY)
-90 90 | 
-91    |-ASSOCIATE (TMP => ARR)
-   91 |+associate (TMP => ARR)
-92 92 |     TMP = 1.0
-93 93 | END ASSOCIATE
-94 94 | 
+88 |
+89 | ALLOCATE(TEST_TYPE :: POLY)
+90 |
+   - ASSOCIATE (TMP => ARR)
+91 + associate (TMP => ARR)
+92 |     TMP = 1.0
+93 | END ASSOCIATE
+94 |
 
 ./resources/test/fixtures/style/S233.f90:93:1: S233 [*] Keyword 'END' should be 'end'
    |
@@ -2096,15 +1995,14 @@ expression: diagnostics
    |
    = help: Change to 'end'
 
-ℹ Safe fix
-90 90 | 
-91 91 | ASSOCIATE (TMP => ARR)
-92 92 |     TMP = 1.0
-93    |-END ASSOCIATE
-   93 |+end ASSOCIATE
-94 94 | 
-95 95 | BLOCK
-96 96 |     INTEGER :: LOCAL
+90 |
+91 | ASSOCIATE (TMP => ARR)
+92 |     TMP = 1.0
+   - END ASSOCIATE
+93 + end ASSOCIATE
+94 |
+95 | BLOCK
+96 |     INTEGER :: LOCAL
 
 ./resources/test/fixtures/style/S233.f90:93:5: S233 [*] Keyword 'ASSOCIATE' should be 'associate'
    |
@@ -2117,15 +2015,14 @@ expression: diagnostics
    |
    = help: Change to 'associate'
 
-ℹ Safe fix
-90 90 | 
-91 91 | ASSOCIATE (TMP => ARR)
-92 92 |     TMP = 1.0
-93    |-END ASSOCIATE
-   93 |+END associate
-94 94 | 
-95 95 | BLOCK
-96 96 |     INTEGER :: LOCAL
+90 |
+91 | ASSOCIATE (TMP => ARR)
+92 |     TMP = 1.0
+   - END ASSOCIATE
+93 + END associate
+94 |
+95 | BLOCK
+96 |     INTEGER :: LOCAL
 
 ./resources/test/fixtures/style/S233.f90:95:1: S233 [*] Keyword 'BLOCK' should be 'block'
    |
@@ -2138,15 +2035,14 @@ expression: diagnostics
    |
    = help: Change to 'block'
 
-ℹ Safe fix
-92 92 |     TMP = 1.0
-93 93 | END ASSOCIATE
-94 94 | 
-95    |-BLOCK
-   95 |+block
-96 96 |     INTEGER :: LOCAL
-97 97 |     LOCAL = 42
-98 98 | END BLOCK
+92 |     TMP = 1.0
+93 | END ASSOCIATE
+94 |
+   - BLOCK
+95 + block
+96 |     INTEGER :: LOCAL
+97 |     LOCAL = 42
+98 | END BLOCK
 
 ./resources/test/fixtures/style/S233.f90:96:5: S233 [*] Keyword 'INTEGER' should be 'integer'
    |
@@ -2158,15 +2054,14 @@ expression: diagnostics
    |
    = help: Change to 'integer'
 
-ℹ Safe fix
-93 93 | END ASSOCIATE
-94 94 | 
-95 95 | BLOCK
-96    |-    INTEGER :: LOCAL
-   96 |+    integer :: LOCAL
-97 97 |     LOCAL = 42
-98 98 | END BLOCK
-99 99 | 
+93 | END ASSOCIATE
+94 |
+95 | BLOCK
+   -     INTEGER :: LOCAL
+96 +     integer :: LOCAL
+97 |     LOCAL = 42
+98 | END BLOCK
+99 |
 
 ./resources/test/fixtures/style/S233.f90:98:1: S233 [*] Keyword 'END' should be 'end'
     |
@@ -2179,15 +2074,14 @@ expression: diagnostics
     |
     = help: Change to 'end'
 
-ℹ Safe fix
-95 95 | BLOCK
-96 96 |     INTEGER :: LOCAL
-97 97 |     LOCAL = 42
-98    |-END BLOCK
-   98 |+end BLOCK
-99 99 | 
-100 100 | CRITICAL
-101 101 |     PRINT *, "CRITICAL SECTION"
+95  | BLOCK
+96  |     INTEGER :: LOCAL
+97  |     LOCAL = 42
+    - END BLOCK
+98  + end BLOCK
+99  |
+100 | CRITICAL
+101 |     PRINT *, "CRITICAL SECTION"
 
 ./resources/test/fixtures/style/S233.f90:98:5: S233 [*] Keyword 'BLOCK' should be 'block'
     |
@@ -2200,15 +2094,14 @@ expression: diagnostics
     |
     = help: Change to 'block'
 
-ℹ Safe fix
-95 95 | BLOCK
-96 96 |     INTEGER :: LOCAL
-97 97 |     LOCAL = 42
-98    |-END BLOCK
-   98 |+END block
-99 99 | 
-100 100 | CRITICAL
-101 101 |     PRINT *, "CRITICAL SECTION"
+95  | BLOCK
+96  |     INTEGER :: LOCAL
+97  |     LOCAL = 42
+    - END BLOCK
+98  + END block
+99  |
+100 | CRITICAL
+101 |     PRINT *, "CRITICAL SECTION"
 
 ./resources/test/fixtures/style/S233.f90:100:1: S233 [*] Keyword 'CRITICAL' should be 'critical'
     |
@@ -2221,15 +2114,14 @@ expression: diagnostics
     |
     = help: Change to 'critical'
 
-ℹ Safe fix
-97  97  |     LOCAL = 42
-98  98  | END BLOCK
-99  99  | 
-100     |-CRITICAL
-    100 |+critical
-101 101 |     PRINT *, "CRITICAL SECTION"
-102 102 | END CRITICAL
-103 103 | 
+97  |     LOCAL = 42
+98  | END BLOCK
+99  |
+    - CRITICAL
+100 + critical
+101 |     PRINT *, "CRITICAL SECTION"
+102 | END CRITICAL
+103 |
 
 ./resources/test/fixtures/style/S233.f90:101:5: S233 [*] Keyword 'PRINT' should be 'print'
     |
@@ -2240,15 +2132,14 @@ expression: diagnostics
     |
     = help: Change to 'print'
 
-ℹ Safe fix
-98  98  | END BLOCK
-99  99  | 
-100 100 | CRITICAL
-101     |-    PRINT *, "CRITICAL SECTION"
-    101 |+    print *, "CRITICAL SECTION"
-102 102 | END CRITICAL
-103 103 | 
-104 104 | DO CONCURRENT (I = 1:N)
+98  | END BLOCK
+99  |
+100 | CRITICAL
+    -     PRINT *, "CRITICAL SECTION"
+101 +     print *, "CRITICAL SECTION"
+102 | END CRITICAL
+103 |
+104 | DO CONCURRENT (I = 1:N)
 
 ./resources/test/fixtures/style/S233.f90:102:1: S233 [*] Keyword 'END' should be 'end'
     |
@@ -2261,15 +2152,14 @@ expression: diagnostics
     |
     = help: Change to 'end'
 
-ℹ Safe fix
-99  99  | 
-100 100 | CRITICAL
-101 101 |     PRINT *, "CRITICAL SECTION"
-102     |-END CRITICAL
-    102 |+end CRITICAL
-103 103 | 
-104 104 | DO CONCURRENT (I = 1:N)
-105 105 |     ARR(I) = I
+99  |
+100 | CRITICAL
+101 |     PRINT *, "CRITICAL SECTION"
+    - END CRITICAL
+102 + end CRITICAL
+103 |
+104 | DO CONCURRENT (I = 1:N)
+105 |     ARR(I) = I
 
 ./resources/test/fixtures/style/S233.f90:102:5: S233 [*] Keyword 'CRITICAL' should be 'critical'
     |
@@ -2282,15 +2172,14 @@ expression: diagnostics
     |
     = help: Change to 'critical'
 
-ℹ Safe fix
-99  99  | 
-100 100 | CRITICAL
-101 101 |     PRINT *, "CRITICAL SECTION"
-102     |-END CRITICAL
-    102 |+END critical
-103 103 | 
-104 104 | DO CONCURRENT (I = 1:N)
-105 105 |     ARR(I) = I
+99  |
+100 | CRITICAL
+101 |     PRINT *, "CRITICAL SECTION"
+    - END CRITICAL
+102 + END critical
+103 |
+104 | DO CONCURRENT (I = 1:N)
+105 |     ARR(I) = I
 
 ./resources/test/fixtures/style/S233.f90:104:1: S233 [*] Keyword 'DO' should be 'do'
     |
@@ -2303,15 +2192,14 @@ expression: diagnostics
     |
     = help: Change to 'do'
 
-ℹ Safe fix
-101 101 |     PRINT *, "CRITICAL SECTION"
-102 102 | END CRITICAL
-103 103 | 
-104     |-DO CONCURRENT (I = 1:N)
-    104 |+do CONCURRENT (I = 1:N)
-105 105 |     ARR(I) = I
-106 106 | END DO
-107 107 | 
+101 |     PRINT *, "CRITICAL SECTION"
+102 | END CRITICAL
+103 |
+    - DO CONCURRENT (I = 1:N)
+104 + do CONCURRENT (I = 1:N)
+105 |     ARR(I) = I
+106 | END DO
+107 |
 
 ./resources/test/fixtures/style/S233.f90:104:4: S233 [*] Keyword 'CONCURRENT' should be 'concurrent'
     |
@@ -2324,15 +2212,14 @@ expression: diagnostics
     |
     = help: Change to 'concurrent'
 
-ℹ Safe fix
-101 101 |     PRINT *, "CRITICAL SECTION"
-102 102 | END CRITICAL
-103 103 | 
-104     |-DO CONCURRENT (I = 1:N)
-    104 |+DO concurrent (I = 1:N)
-105 105 |     ARR(I) = I
-106 106 | END DO
-107 107 | 
+101 |     PRINT *, "CRITICAL SECTION"
+102 | END CRITICAL
+103 |
+    - DO CONCURRENT (I = 1:N)
+104 + DO concurrent (I = 1:N)
+105 |     ARR(I) = I
+106 | END DO
+107 |
 
 ./resources/test/fixtures/style/S233.f90:106:1: S233 [*] Keyword 'END' should be 'end'
     |
@@ -2345,15 +2232,14 @@ expression: diagnostics
     |
     = help: Change to 'end'
 
-ℹ Safe fix
-103 103 | 
-104 104 | DO CONCURRENT (I = 1:N)
-105 105 |     ARR(I) = I
-106     |-END DO
-    106 |+end DO
-107 107 | 
-108 108 | FORALL (J = 1:N)
-109 109 |     ARR(J) = ARR(J) * 2
+103 |
+104 | DO CONCURRENT (I = 1:N)
+105 |     ARR(I) = I
+    - END DO
+106 + end DO
+107 |
+108 | FORALL (J = 1:N)
+109 |     ARR(J) = ARR(J) * 2
 
 ./resources/test/fixtures/style/S233.f90:106:5: S233 [*] Keyword 'DO' should be 'do'
     |
@@ -2366,15 +2252,14 @@ expression: diagnostics
     |
     = help: Change to 'do'
 
-ℹ Safe fix
-103 103 | 
-104 104 | DO CONCURRENT (I = 1:N)
-105 105 |     ARR(I) = I
-106     |-END DO
-    106 |+END do
-107 107 | 
-108 108 | FORALL (J = 1:N)
-109 109 |     ARR(J) = ARR(J) * 2
+103 |
+104 | DO CONCURRENT (I = 1:N)
+105 |     ARR(I) = I
+    - END DO
+106 + END do
+107 |
+108 | FORALL (J = 1:N)
+109 |     ARR(J) = ARR(J) * 2
 
 ./resources/test/fixtures/style/S233.f90:108:1: S233 [*] Keyword 'FORALL' should be 'forall'
     |
@@ -2387,15 +2272,14 @@ expression: diagnostics
     |
     = help: Change to 'forall'
 
-ℹ Safe fix
-105 105 |     ARR(I) = I
-106 106 | END DO
-107 107 | 
-108     |-FORALL (J = 1:N)
-    108 |+forall (J = 1:N)
-109 109 |     ARR(J) = ARR(J) * 2
-110 110 | END FORALL
-111 111 | 
+105 |     ARR(I) = I
+106 | END DO
+107 |
+    - FORALL (J = 1:N)
+108 + forall (J = 1:N)
+109 |     ARR(J) = ARR(J) * 2
+110 | END FORALL
+111 |
 
 ./resources/test/fixtures/style/S233.f90:110:1: S233 [*] Keyword 'END' should be 'end'
     |
@@ -2408,15 +2292,14 @@ expression: diagnostics
     |
     = help: Change to 'end'
 
-ℹ Safe fix
-107 107 | 
-108 108 | FORALL (J = 1:N)
-109 109 |     ARR(J) = ARR(J) * 2
-110     |-END FORALL
-    110 |+end FORALL
-111 111 | 
-112 112 | WHERE (ARR > 2.0)
-113 113 |     ARR = ARR + 1.0
+107 |
+108 | FORALL (J = 1:N)
+109 |     ARR(J) = ARR(J) * 2
+    - END FORALL
+110 + end FORALL
+111 |
+112 | WHERE (ARR > 2.0)
+113 |     ARR = ARR + 1.0
 
 ./resources/test/fixtures/style/S233.f90:110:5: S233 [*] Keyword 'FORALL' should be 'forall'
     |
@@ -2429,15 +2312,14 @@ expression: diagnostics
     |
     = help: Change to 'forall'
 
-ℹ Safe fix
-107 107 | 
-108 108 | FORALL (J = 1:N)
-109 109 |     ARR(J) = ARR(J) * 2
-110     |-END FORALL
-    110 |+END forall
-111 111 | 
-112 112 | WHERE (ARR > 2.0)
-113 113 |     ARR = ARR + 1.0
+107 |
+108 | FORALL (J = 1:N)
+109 |     ARR(J) = ARR(J) * 2
+    - END FORALL
+110 + END forall
+111 |
+112 | WHERE (ARR > 2.0)
+113 |     ARR = ARR + 1.0
 
 ./resources/test/fixtures/style/S233.f90:112:1: S233 [*] Keyword 'WHERE' should be 'where'
     |
@@ -2450,15 +2332,14 @@ expression: diagnostics
     |
     = help: Change to 'where'
 
-ℹ Safe fix
-109 109 |     ARR(J) = ARR(J) * 2
-110 110 | END FORALL
-111 111 | 
-112     |-WHERE (ARR > 2.0)
-    112 |+where (ARR > 2.0)
-113 113 |     ARR = ARR + 1.0
-114 114 | ELSEWHERE
-115 115 |     ARR = 0.0
+109 |     ARR(J) = ARR(J) * 2
+110 | END FORALL
+111 |
+    - WHERE (ARR > 2.0)
+112 + where (ARR > 2.0)
+113 |     ARR = ARR + 1.0
+114 | ELSEWHERE
+115 |     ARR = 0.0
 
 ./resources/test/fixtures/style/S233.f90:114:1: S233 [*] Keyword 'ELSEWHERE' should be 'elsewhere'
     |
@@ -2471,15 +2352,14 @@ expression: diagnostics
     |
     = help: Change to 'elsewhere'
 
-ℹ Safe fix
-111 111 | 
-112 112 | WHERE (ARR > 2.0)
-113 113 |     ARR = ARR + 1.0
-114     |-ELSEWHERE
-    114 |+elsewhere
-115 115 |     ARR = 0.0
-116 116 | END WHERE
-117 117 | 
+111 |
+112 | WHERE (ARR > 2.0)
+113 |     ARR = ARR + 1.0
+    - ELSEWHERE
+114 + elsewhere
+115 |     ARR = 0.0
+116 | END WHERE
+117 |
 
 ./resources/test/fixtures/style/S233.f90:116:1: S233 [*] Keyword 'END' should be 'end'
     |
@@ -2492,15 +2372,14 @@ expression: diagnostics
     |
     = help: Change to 'end'
 
-ℹ Safe fix
-113 113 |     ARR = ARR + 1.0
-114 114 | ELSEWHERE
-115 115 |     ARR = 0.0
-116     |-END WHERE
-    116 |+end WHERE
-117 117 | 
-118 118 | SELECT CASE (N)
-119 119 | CASE (1)
+113 |     ARR = ARR + 1.0
+114 | ELSEWHERE
+115 |     ARR = 0.0
+    - END WHERE
+116 + end WHERE
+117 |
+118 | SELECT CASE (N)
+119 | CASE (1)
 
 ./resources/test/fixtures/style/S233.f90:116:5: S233 [*] Keyword 'WHERE' should be 'where'
     |
@@ -2513,15 +2392,14 @@ expression: diagnostics
     |
     = help: Change to 'where'
 
-ℹ Safe fix
-113 113 |     ARR = ARR + 1.0
-114 114 | ELSEWHERE
-115 115 |     ARR = 0.0
-116     |-END WHERE
-    116 |+END where
-117 117 | 
-118 118 | SELECT CASE (N)
-119 119 | CASE (1)
+113 |     ARR = ARR + 1.0
+114 | ELSEWHERE
+115 |     ARR = 0.0
+    - END WHERE
+116 + END where
+117 |
+118 | SELECT CASE (N)
+119 | CASE (1)
 
 ./resources/test/fixtures/style/S233.f90:118:1: S233 [*] Keyword 'SELECT' should be 'select'
     |
@@ -2534,15 +2412,14 @@ expression: diagnostics
     |
     = help: Change to 'select'
 
-ℹ Safe fix
-115 115 |     ARR = 0.0
-116 116 | END WHERE
-117 117 | 
-118     |-SELECT CASE (N)
-    118 |+select CASE (N)
-119 119 | CASE (1)
-120 120 |     PRINT *, "ONE"
-121 121 | CASE DEFAULT
+115 |     ARR = 0.0
+116 | END WHERE
+117 |
+    - SELECT CASE (N)
+118 + select CASE (N)
+119 | CASE (1)
+120 |     PRINT *, "ONE"
+121 | CASE DEFAULT
 
 ./resources/test/fixtures/style/S233.f90:118:8: S233 [*] Keyword 'CASE' should be 'case'
     |
@@ -2555,15 +2432,14 @@ expression: diagnostics
     |
     = help: Change to 'case'
 
-ℹ Safe fix
-115 115 |     ARR = 0.0
-116 116 | END WHERE
-117 117 | 
-118     |-SELECT CASE (N)
-    118 |+SELECT case (N)
-119 119 | CASE (1)
-120 120 |     PRINT *, "ONE"
-121 121 | CASE DEFAULT
+115 |     ARR = 0.0
+116 | END WHERE
+117 |
+    - SELECT CASE (N)
+118 + SELECT case (N)
+119 | CASE (1)
+120 |     PRINT *, "ONE"
+121 | CASE DEFAULT
 
 ./resources/test/fixtures/style/S233.f90:119:1: S233 [*] Keyword 'CASE' should be 'case'
     |
@@ -2575,15 +2451,14 @@ expression: diagnostics
     |
     = help: Change to 'case'
 
-ℹ Safe fix
-116 116 | END WHERE
-117 117 | 
-118 118 | SELECT CASE (N)
-119     |-CASE (1)
-    119 |+case (1)
-120 120 |     PRINT *, "ONE"
-121 121 | CASE DEFAULT
-122 122 |     PRINT *, "OTHER"
+116 | END WHERE
+117 |
+118 | SELECT CASE (N)
+    - CASE (1)
+119 + case (1)
+120 |     PRINT *, "ONE"
+121 | CASE DEFAULT
+122 |     PRINT *, "OTHER"
 
 ./resources/test/fixtures/style/S233.f90:120:5: S233 [*] Keyword 'PRINT' should be 'print'
     |
@@ -2596,15 +2471,14 @@ expression: diagnostics
     |
     = help: Change to 'print'
 
-ℹ Safe fix
-117 117 | 
-118 118 | SELECT CASE (N)
-119 119 | CASE (1)
-120     |-    PRINT *, "ONE"
-    120 |+    print *, "ONE"
-121 121 | CASE DEFAULT
-122 122 |     PRINT *, "OTHER"
-123 123 | END SELECT
+117 |
+118 | SELECT CASE (N)
+119 | CASE (1)
+    -     PRINT *, "ONE"
+120 +     print *, "ONE"
+121 | CASE DEFAULT
+122 |     PRINT *, "OTHER"
+123 | END SELECT
 
 ./resources/test/fixtures/style/S233.f90:121:1: S233 [*] Keyword 'CASE' should be 'case'
     |
@@ -2617,15 +2491,14 @@ expression: diagnostics
     |
     = help: Change to 'case'
 
-ℹ Safe fix
-118 118 | SELECT CASE (N)
-119 119 | CASE (1)
-120 120 |     PRINT *, "ONE"
-121     |-CASE DEFAULT
-    121 |+case DEFAULT
-122 122 |     PRINT *, "OTHER"
-123 123 | END SELECT
-124 124 | 
+118 | SELECT CASE (N)
+119 | CASE (1)
+120 |     PRINT *, "ONE"
+    - CASE DEFAULT
+121 + case DEFAULT
+122 |     PRINT *, "OTHER"
+123 | END SELECT
+124 |
 
 ./resources/test/fixtures/style/S233.f90:121:6: S233 [*] Keyword 'DEFAULT' should be 'default'
     |
@@ -2638,15 +2511,14 @@ expression: diagnostics
     |
     = help: Change to 'default'
 
-ℹ Safe fix
-118 118 | SELECT CASE (N)
-119 119 | CASE (1)
-120 120 |     PRINT *, "ONE"
-121     |-CASE DEFAULT
-    121 |+CASE default
-122 122 |     PRINT *, "OTHER"
-123 123 | END SELECT
-124 124 | 
+118 | SELECT CASE (N)
+119 | CASE (1)
+120 |     PRINT *, "ONE"
+    - CASE DEFAULT
+121 + CASE default
+122 |     PRINT *, "OTHER"
+123 | END SELECT
+124 |
 
 ./resources/test/fixtures/style/S233.f90:122:5: S233 [*] Keyword 'PRINT' should be 'print'
     |
@@ -2658,15 +2530,14 @@ expression: diagnostics
     |
     = help: Change to 'print'
 
-ℹ Safe fix
-119 119 | CASE (1)
-120 120 |     PRINT *, "ONE"
-121 121 | CASE DEFAULT
-122     |-    PRINT *, "OTHER"
-    122 |+    print *, "OTHER"
-123 123 | END SELECT
-124 124 | 
-125 125 | SELECT TYPE (POLY)
+119 | CASE (1)
+120 |     PRINT *, "ONE"
+121 | CASE DEFAULT
+    -     PRINT *, "OTHER"
+122 +     print *, "OTHER"
+123 | END SELECT
+124 |
+125 | SELECT TYPE (POLY)
 
 ./resources/test/fixtures/style/S233.f90:123:1: S233 [*] Keyword 'END' should be 'end'
     |
@@ -2679,15 +2550,14 @@ expression: diagnostics
     |
     = help: Change to 'end'
 
-ℹ Safe fix
-120 120 |     PRINT *, "ONE"
-121 121 | CASE DEFAULT
-122 122 |     PRINT *, "OTHER"
-123     |-END SELECT
-    123 |+end SELECT
-124 124 | 
-125 125 | SELECT TYPE (POLY)
-126 126 | TYPE IS (TEST_TYPE)
+120 |     PRINT *, "ONE"
+121 | CASE DEFAULT
+122 |     PRINT *, "OTHER"
+    - END SELECT
+123 + end SELECT
+124 |
+125 | SELECT TYPE (POLY)
+126 | TYPE IS (TEST_TYPE)
 
 ./resources/test/fixtures/style/S233.f90:123:5: S233 [*] Keyword 'SELECT' should be 'select'
     |
@@ -2700,15 +2570,14 @@ expression: diagnostics
     |
     = help: Change to 'select'
 
-ℹ Safe fix
-120 120 |     PRINT *, "ONE"
-121 121 | CASE DEFAULT
-122 122 |     PRINT *, "OTHER"
-123     |-END SELECT
-    123 |+END select
-124 124 | 
-125 125 | SELECT TYPE (POLY)
-126 126 | TYPE IS (TEST_TYPE)
+120 |     PRINT *, "ONE"
+121 | CASE DEFAULT
+122 |     PRINT *, "OTHER"
+    - END SELECT
+123 + END select
+124 |
+125 | SELECT TYPE (POLY)
+126 | TYPE IS (TEST_TYPE)
 
 ./resources/test/fixtures/style/S233.f90:125:1: S233 [*] Keyword 'SELECT' should be 'select'
     |
@@ -2721,15 +2590,14 @@ expression: diagnostics
     |
     = help: Change to 'select'
 
-ℹ Safe fix
-122 122 |     PRINT *, "OTHER"
-123 123 | END SELECT
-124 124 | 
-125     |-SELECT TYPE (POLY)
-    125 |+select TYPE (POLY)
-126 126 | TYPE IS (TEST_TYPE)
-127 127 |     PRINT *, "TEST_TYPE"
-128 128 | CLASS DEFAULT
+122 |     PRINT *, "OTHER"
+123 | END SELECT
+124 |
+    - SELECT TYPE (POLY)
+125 + select TYPE (POLY)
+126 | TYPE IS (TEST_TYPE)
+127 |     PRINT *, "TEST_TYPE"
+128 | CLASS DEFAULT
 
 ./resources/test/fixtures/style/S233.f90:125:8: S233 [*] Keyword 'TYPE' should be 'type'
     |
@@ -2742,15 +2610,14 @@ expression: diagnostics
     |
     = help: Change to 'type'
 
-ℹ Safe fix
-122 122 |     PRINT *, "OTHER"
-123 123 | END SELECT
-124 124 | 
-125     |-SELECT TYPE (POLY)
-    125 |+SELECT type (POLY)
-126 126 | TYPE IS (TEST_TYPE)
-127 127 |     PRINT *, "TEST_TYPE"
-128 128 | CLASS DEFAULT
+122 |     PRINT *, "OTHER"
+123 | END SELECT
+124 |
+    - SELECT TYPE (POLY)
+125 + SELECT type (POLY)
+126 | TYPE IS (TEST_TYPE)
+127 |     PRINT *, "TEST_TYPE"
+128 | CLASS DEFAULT
 
 ./resources/test/fixtures/style/S233.f90:126:1: S233 [*] Keyword 'TYPE' should be 'type'
     |
@@ -2762,15 +2629,14 @@ expression: diagnostics
     |
     = help: Change to 'type'
 
-ℹ Safe fix
-123 123 | END SELECT
-124 124 | 
-125 125 | SELECT TYPE (POLY)
-126     |-TYPE IS (TEST_TYPE)
-    126 |+type IS (TEST_TYPE)
-127 127 |     PRINT *, "TEST_TYPE"
-128 128 | CLASS DEFAULT
-129 129 |     PRINT *, "UNKNOWN"
+123 | END SELECT
+124 |
+125 | SELECT TYPE (POLY)
+    - TYPE IS (TEST_TYPE)
+126 + type IS (TEST_TYPE)
+127 |     PRINT *, "TEST_TYPE"
+128 | CLASS DEFAULT
+129 |     PRINT *, "UNKNOWN"
 
 ./resources/test/fixtures/style/S233.f90:126:6: S233 [*] Keyword 'IS' should be 'is'
     |
@@ -2782,15 +2648,14 @@ expression: diagnostics
     |
     = help: Change to 'is'
 
-ℹ Safe fix
-123 123 | END SELECT
-124 124 | 
-125 125 | SELECT TYPE (POLY)
-126     |-TYPE IS (TEST_TYPE)
-    126 |+TYPE is (TEST_TYPE)
-127 127 |     PRINT *, "TEST_TYPE"
-128 128 | CLASS DEFAULT
-129 129 |     PRINT *, "UNKNOWN"
+123 | END SELECT
+124 |
+125 | SELECT TYPE (POLY)
+    - TYPE IS (TEST_TYPE)
+126 + TYPE is (TEST_TYPE)
+127 |     PRINT *, "TEST_TYPE"
+128 | CLASS DEFAULT
+129 |     PRINT *, "UNKNOWN"
 
 ./resources/test/fixtures/style/S233.f90:127:5: S233 [*] Keyword 'PRINT' should be 'print'
     |
@@ -2803,15 +2668,14 @@ expression: diagnostics
     |
     = help: Change to 'print'
 
-ℹ Safe fix
-124 124 | 
-125 125 | SELECT TYPE (POLY)
-126 126 | TYPE IS (TEST_TYPE)
-127     |-    PRINT *, "TEST_TYPE"
-    127 |+    print *, "TEST_TYPE"
-128 128 | CLASS DEFAULT
-129 129 |     PRINT *, "UNKNOWN"
-130 130 | END SELECT
+124 |
+125 | SELECT TYPE (POLY)
+126 | TYPE IS (TEST_TYPE)
+    -     PRINT *, "TEST_TYPE"
+127 +     print *, "TEST_TYPE"
+128 | CLASS DEFAULT
+129 |     PRINT *, "UNKNOWN"
+130 | END SELECT
 
 ./resources/test/fixtures/style/S233.f90:128:1: S233 [*] Keyword 'CLASS' should be 'class'
     |
@@ -2824,15 +2688,14 @@ expression: diagnostics
     |
     = help: Change to 'class'
 
-ℹ Safe fix
-125 125 | SELECT TYPE (POLY)
-126 126 | TYPE IS (TEST_TYPE)
-127 127 |     PRINT *, "TEST_TYPE"
-128     |-CLASS DEFAULT
-    128 |+class DEFAULT
-129 129 |     PRINT *, "UNKNOWN"
-130 130 | END SELECT
-131 131 | 
+125 | SELECT TYPE (POLY)
+126 | TYPE IS (TEST_TYPE)
+127 |     PRINT *, "TEST_TYPE"
+    - CLASS DEFAULT
+128 + class DEFAULT
+129 |     PRINT *, "UNKNOWN"
+130 | END SELECT
+131 |
 
 ./resources/test/fixtures/style/S233.f90:128:7: S233 [*] Keyword 'DEFAULT' should be 'default'
     |
@@ -2845,15 +2708,14 @@ expression: diagnostics
     |
     = help: Change to 'default'
 
-ℹ Safe fix
-125 125 | SELECT TYPE (POLY)
-126 126 | TYPE IS (TEST_TYPE)
-127 127 |     PRINT *, "TEST_TYPE"
-128     |-CLASS DEFAULT
-    128 |+CLASS default
-129 129 |     PRINT *, "UNKNOWN"
-130 130 | END SELECT
-131 131 | 
+125 | SELECT TYPE (POLY)
+126 | TYPE IS (TEST_TYPE)
+127 |     PRINT *, "TEST_TYPE"
+    - CLASS DEFAULT
+128 + CLASS default
+129 |     PRINT *, "UNKNOWN"
+130 | END SELECT
+131 |
 
 ./resources/test/fixtures/style/S233.f90:129:5: S233 [*] Keyword 'PRINT' should be 'print'
     |
@@ -2865,15 +2727,14 @@ expression: diagnostics
     |
     = help: Change to 'print'
 
-ℹ Safe fix
-126 126 | TYPE IS (TEST_TYPE)
-127 127 |     PRINT *, "TEST_TYPE"
-128 128 | CLASS DEFAULT
-129     |-    PRINT *, "UNKNOWN"
-    129 |+    print *, "UNKNOWN"
-130 130 | END SELECT
-131 131 | 
-132 132 | IF (N > 0) THEN
+126 | TYPE IS (TEST_TYPE)
+127 |     PRINT *, "TEST_TYPE"
+128 | CLASS DEFAULT
+    -     PRINT *, "UNKNOWN"
+129 +     print *, "UNKNOWN"
+130 | END SELECT
+131 |
+132 | IF (N > 0) THEN
 
 ./resources/test/fixtures/style/S233.f90:130:1: S233 [*] Keyword 'END' should be 'end'
     |
@@ -2886,15 +2747,14 @@ expression: diagnostics
     |
     = help: Change to 'end'
 
-ℹ Safe fix
-127 127 |     PRINT *, "TEST_TYPE"
-128 128 | CLASS DEFAULT
-129 129 |     PRINT *, "UNKNOWN"
-130     |-END SELECT
-    130 |+end SELECT
-131 131 | 
-132 132 | IF (N > 0) THEN
-133 133 |     CALL TEST_PROC(I)
+127 |     PRINT *, "TEST_TYPE"
+128 | CLASS DEFAULT
+129 |     PRINT *, "UNKNOWN"
+    - END SELECT
+130 + end SELECT
+131 |
+132 | IF (N > 0) THEN
+133 |     CALL TEST_PROC(I)
 
 ./resources/test/fixtures/style/S233.f90:130:5: S233 [*] Keyword 'SELECT' should be 'select'
     |
@@ -2907,15 +2767,14 @@ expression: diagnostics
     |
     = help: Change to 'select'
 
-ℹ Safe fix
-127 127 |     PRINT *, "TEST_TYPE"
-128 128 | CLASS DEFAULT
-129 129 |     PRINT *, "UNKNOWN"
-130     |-END SELECT
-    130 |+END select
-131 131 | 
-132 132 | IF (N > 0) THEN
-133 133 |     CALL TEST_PROC(I)
+127 |     PRINT *, "TEST_TYPE"
+128 | CLASS DEFAULT
+129 |     PRINT *, "UNKNOWN"
+    - END SELECT
+130 + END select
+131 |
+132 | IF (N > 0) THEN
+133 |     CALL TEST_PROC(I)
 
 ./resources/test/fixtures/style/S233.f90:132:1: S233 [*] Keyword 'IF' should be 'if'
     |
@@ -2928,15 +2787,14 @@ expression: diagnostics
     |
     = help: Change to 'if'
 
-ℹ Safe fix
-129 129 |     PRINT *, "UNKNOWN"
-130 130 | END SELECT
-131 131 | 
-132     |-IF (N > 0) THEN
-    132 |+if (N > 0) THEN
-133 133 |     CALL TEST_PROC(I)
-134 134 | ELSE IF (N == 0) THEN
-135 135 |     STOP
+129 |     PRINT *, "UNKNOWN"
+130 | END SELECT
+131 |
+    - IF (N > 0) THEN
+132 + if (N > 0) THEN
+133 |     CALL TEST_PROC(I)
+134 | ELSE IF (N == 0) THEN
+135 |     STOP
 
 ./resources/test/fixtures/style/S233.f90:132:12: S233 [*] Keyword 'THEN' should be 'then'
     |
@@ -2949,15 +2807,14 @@ expression: diagnostics
     |
     = help: Change to 'then'
 
-ℹ Safe fix
-129 129 |     PRINT *, "UNKNOWN"
-130 130 | END SELECT
-131 131 | 
-132     |-IF (N > 0) THEN
-    132 |+IF (N > 0) then
-133 133 |     CALL TEST_PROC(I)
-134 134 | ELSE IF (N == 0) THEN
-135 135 |     STOP
+129 |     PRINT *, "UNKNOWN"
+130 | END SELECT
+131 |
+    - IF (N > 0) THEN
+132 + IF (N > 0) then
+133 |     CALL TEST_PROC(I)
+134 | ELSE IF (N == 0) THEN
+135 |     STOP
 
 ./resources/test/fixtures/style/S233.f90:133:5: S233 [*] Keyword 'CALL' should be 'call'
     |
@@ -2969,15 +2826,14 @@ expression: diagnostics
     |
     = help: Change to 'call'
 
-ℹ Safe fix
-130 130 | END SELECT
-131 131 | 
-132 132 | IF (N > 0) THEN
-133     |-    CALL TEST_PROC(I)
-    133 |+    call TEST_PROC(I)
-134 134 | ELSE IF (N == 0) THEN
-135 135 |     STOP
-136 136 | ELSE
+130 | END SELECT
+131 |
+132 | IF (N > 0) THEN
+    -     CALL TEST_PROC(I)
+133 +     call TEST_PROC(I)
+134 | ELSE IF (N == 0) THEN
+135 |     STOP
+136 | ELSE
 
 ./resources/test/fixtures/style/S233.f90:134:1: S233 [*] Keyword 'ELSE' should be 'else'
     |
@@ -2990,15 +2846,14 @@ expression: diagnostics
     |
     = help: Change to 'else'
 
-ℹ Safe fix
-131 131 | 
-132 132 | IF (N > 0) THEN
-133 133 |     CALL TEST_PROC(I)
-134     |-ELSE IF (N == 0) THEN
-    134 |+else IF (N == 0) THEN
-135 135 |     STOP
-136 136 | ELSE
-137 137 |     ERROR STOP "NEGATIVE"
+131 |
+132 | IF (N > 0) THEN
+133 |     CALL TEST_PROC(I)
+    - ELSE IF (N == 0) THEN
+134 + else IF (N == 0) THEN
+135 |     STOP
+136 | ELSE
+137 |     ERROR STOP "NEGATIVE"
 
 ./resources/test/fixtures/style/S233.f90:134:6: S233 [*] Keyword 'IF' should be 'if'
     |
@@ -3011,15 +2866,14 @@ expression: diagnostics
     |
     = help: Change to 'if'
 
-ℹ Safe fix
-131 131 | 
-132 132 | IF (N > 0) THEN
-133 133 |     CALL TEST_PROC(I)
-134     |-ELSE IF (N == 0) THEN
-    134 |+ELSE if (N == 0) THEN
-135 135 |     STOP
-136 136 | ELSE
-137 137 |     ERROR STOP "NEGATIVE"
+131 |
+132 | IF (N > 0) THEN
+133 |     CALL TEST_PROC(I)
+    - ELSE IF (N == 0) THEN
+134 + ELSE if (N == 0) THEN
+135 |     STOP
+136 | ELSE
+137 |     ERROR STOP "NEGATIVE"
 
 ./resources/test/fixtures/style/S233.f90:134:18: S233 [*] Keyword 'THEN' should be 'then'
     |
@@ -3032,15 +2886,14 @@ expression: diagnostics
     |
     = help: Change to 'then'
 
-ℹ Safe fix
-131 131 | 
-132 132 | IF (N > 0) THEN
-133 133 |     CALL TEST_PROC(I)
-134     |-ELSE IF (N == 0) THEN
-    134 |+ELSE IF (N == 0) then
-135 135 |     STOP
-136 136 | ELSE
-137 137 |     ERROR STOP "NEGATIVE"
+131 |
+132 | IF (N > 0) THEN
+133 |     CALL TEST_PROC(I)
+    - ELSE IF (N == 0) THEN
+134 + ELSE IF (N == 0) then
+135 |     STOP
+136 | ELSE
+137 |     ERROR STOP "NEGATIVE"
 
 ./resources/test/fixtures/style/S233.f90:135:5: S233 [*] Keyword 'STOP' should be 'stop'
     |
@@ -3053,15 +2906,14 @@ expression: diagnostics
     |
     = help: Change to 'stop'
 
-ℹ Safe fix
-132 132 | IF (N > 0) THEN
-133 133 |     CALL TEST_PROC(I)
-134 134 | ELSE IF (N == 0) THEN
-135     |-    STOP
-    135 |+    stop
-136 136 | ELSE
-137 137 |     ERROR STOP "NEGATIVE"
-138 138 | END IF
+132 | IF (N > 0) THEN
+133 |     CALL TEST_PROC(I)
+134 | ELSE IF (N == 0) THEN
+    -     STOP
+135 +     stop
+136 | ELSE
+137 |     ERROR STOP "NEGATIVE"
+138 | END IF
 
 ./resources/test/fixtures/style/S233.f90:136:1: S233 [*] Keyword 'ELSE' should be 'else'
     |
@@ -3074,15 +2926,14 @@ expression: diagnostics
     |
     = help: Change to 'else'
 
-ℹ Safe fix
-133 133 |     CALL TEST_PROC(I)
-134 134 | ELSE IF (N == 0) THEN
-135 135 |     STOP
-136     |-ELSE
-    136 |+else
-137 137 |     ERROR STOP "NEGATIVE"
-138 138 | END IF
-139 139 | 
+133 |     CALL TEST_PROC(I)
+134 | ELSE IF (N == 0) THEN
+135 |     STOP
+    - ELSE
+136 + else
+137 |     ERROR STOP "NEGATIVE"
+138 | END IF
+139 |
 
 ./resources/test/fixtures/style/S233.f90:137:5: S233 [*] Keyword 'ERROR' should be 'error'
     |
@@ -3094,15 +2945,14 @@ expression: diagnostics
     |
     = help: Change to 'error'
 
-ℹ Safe fix
-134 134 | ELSE IF (N == 0) THEN
-135 135 |     STOP
-136 136 | ELSE
-137     |-    ERROR STOP "NEGATIVE"
-    137 |+    error STOP "NEGATIVE"
-138 138 | END IF
-139 139 | 
-140 140 | DO I = 1, N
+134 | ELSE IF (N == 0) THEN
+135 |     STOP
+136 | ELSE
+    -     ERROR STOP "NEGATIVE"
+137 +     error STOP "NEGATIVE"
+138 | END IF
+139 |
+140 | DO I = 1, N
 
 ./resources/test/fixtures/style/S233.f90:137:11: S233 [*] Keyword 'STOP' should be 'stop'
     |
@@ -3114,15 +2964,14 @@ expression: diagnostics
     |
     = help: Change to 'stop'
 
-ℹ Safe fix
-134 134 | ELSE IF (N == 0) THEN
-135 135 |     STOP
-136 136 | ELSE
-137     |-    ERROR STOP "NEGATIVE"
-    137 |+    ERROR stop "NEGATIVE"
-138 138 | END IF
-139 139 | 
-140 140 | DO I = 1, N
+134 | ELSE IF (N == 0) THEN
+135 |     STOP
+136 | ELSE
+    -     ERROR STOP "NEGATIVE"
+137 +     ERROR stop "NEGATIVE"
+138 | END IF
+139 |
+140 | DO I = 1, N
 
 ./resources/test/fixtures/style/S233.f90:138:1: S233 [*] Keyword 'END' should be 'end'
     |
@@ -3135,15 +2984,14 @@ expression: diagnostics
     |
     = help: Change to 'end'
 
-ℹ Safe fix
-135 135 |     STOP
-136 136 | ELSE
-137 137 |     ERROR STOP "NEGATIVE"
-138     |-END IF
-    138 |+end IF
-139 139 | 
-140 140 | DO I = 1, N
-141 141 |     IF (I == 3) CYCLE
+135 |     STOP
+136 | ELSE
+137 |     ERROR STOP "NEGATIVE"
+    - END IF
+138 + end IF
+139 |
+140 | DO I = 1, N
+141 |     IF (I == 3) CYCLE
 
 ./resources/test/fixtures/style/S233.f90:138:5: S233 [*] Keyword 'IF' should be 'if'
     |
@@ -3156,15 +3004,14 @@ expression: diagnostics
     |
     = help: Change to 'if'
 
-ℹ Safe fix
-135 135 |     STOP
-136 136 | ELSE
-137 137 |     ERROR STOP "NEGATIVE"
-138     |-END IF
-    138 |+END if
-139 139 | 
-140 140 | DO I = 1, N
-141 141 |     IF (I == 3) CYCLE
+135 |     STOP
+136 | ELSE
+137 |     ERROR STOP "NEGATIVE"
+    - END IF
+138 + END if
+139 |
+140 | DO I = 1, N
+141 |     IF (I == 3) CYCLE
 
 ./resources/test/fixtures/style/S233.f90:140:1: S233 [*] Keyword 'DO' should be 'do'
     |
@@ -3177,15 +3024,14 @@ expression: diagnostics
     |
     = help: Change to 'do'
 
-ℹ Safe fix
-137 137 |     ERROR STOP "NEGATIVE"
-138 138 | END IF
-139 139 | 
-140     |-DO I = 1, N
-    140 |+do I = 1, N
-141 141 |     IF (I == 3) CYCLE
-142 142 |     IF (I == 4) EXIT
-143 143 | END DO
+137 |     ERROR STOP "NEGATIVE"
+138 | END IF
+139 |
+    - DO I = 1, N
+140 + do I = 1, N
+141 |     IF (I == 3) CYCLE
+142 |     IF (I == 4) EXIT
+143 | END DO
 
 ./resources/test/fixtures/style/S233.f90:141:5: S233 [*] Keyword 'IF' should be 'if'
     |
@@ -3197,15 +3043,14 @@ expression: diagnostics
     |
     = help: Change to 'if'
 
-ℹ Safe fix
-138 138 | END IF
-139 139 | 
-140 140 | DO I = 1, N
-141     |-    IF (I == 3) CYCLE
-    141 |+    if (I == 3) CYCLE
-142 142 |     IF (I == 4) EXIT
-143 143 | END DO
-144 144 | 
+138 | END IF
+139 |
+140 | DO I = 1, N
+    -     IF (I == 3) CYCLE
+141 +     if (I == 3) CYCLE
+142 |     IF (I == 4) EXIT
+143 | END DO
+144 |
 
 ./resources/test/fixtures/style/S233.f90:141:17: S233 [*] Keyword 'CYCLE' should be 'cycle'
     |
@@ -3217,15 +3062,14 @@ expression: diagnostics
     |
     = help: Change to 'cycle'
 
-ℹ Safe fix
-138 138 | END IF
-139 139 | 
-140 140 | DO I = 1, N
-141     |-    IF (I == 3) CYCLE
-    141 |+    IF (I == 3) cycle
-142 142 |     IF (I == 4) EXIT
-143 143 | END DO
-144 144 | 
+138 | END IF
+139 |
+140 | DO I = 1, N
+    -     IF (I == 3) CYCLE
+141 +     IF (I == 3) cycle
+142 |     IF (I == 4) EXIT
+143 | END DO
+144 |
 
 ./resources/test/fixtures/style/S233.f90:142:5: S233 [*] Keyword 'IF' should be 'if'
     |
@@ -3237,15 +3081,14 @@ expression: diagnostics
     |
     = help: Change to 'if'
 
-ℹ Safe fix
-139 139 | 
-140 140 | DO I = 1, N
-141 141 |     IF (I == 3) CYCLE
-142     |-    IF (I == 4) EXIT
-    142 |+    if (I == 4) EXIT
-143 143 | END DO
-144 144 | 
-145 145 | GOTO 100
+139 |
+140 | DO I = 1, N
+141 |     IF (I == 3) CYCLE
+    -     IF (I == 4) EXIT
+142 +     if (I == 4) EXIT
+143 | END DO
+144 |
+145 | GOTO 100
 
 ./resources/test/fixtures/style/S233.f90:142:17: S233 [*] Keyword 'EXIT' should be 'exit'
     |
@@ -3257,15 +3100,14 @@ expression: diagnostics
     |
     = help: Change to 'exit'
 
-ℹ Safe fix
-139 139 | 
-140 140 | DO I = 1, N
-141 141 |     IF (I == 3) CYCLE
-142     |-    IF (I == 4) EXIT
-    142 |+    IF (I == 4) exit
-143 143 | END DO
-144 144 | 
-145 145 | GOTO 100
+139 |
+140 | DO I = 1, N
+141 |     IF (I == 3) CYCLE
+    -     IF (I == 4) EXIT
+142 +     IF (I == 4) exit
+143 | END DO
+144 |
+145 | GOTO 100
 
 ./resources/test/fixtures/style/S233.f90:143:1: S233 [*] Keyword 'END' should be 'end'
     |
@@ -3278,15 +3120,14 @@ expression: diagnostics
     |
     = help: Change to 'end'
 
-ℹ Safe fix
-140 140 | DO I = 1, N
-141 141 |     IF (I == 3) CYCLE
-142 142 |     IF (I == 4) EXIT
-143     |-END DO
-    143 |+end DO
-144 144 | 
-145 145 | GOTO 100
-146 146 | GO TO 100
+140 | DO I = 1, N
+141 |     IF (I == 3) CYCLE
+142 |     IF (I == 4) EXIT
+    - END DO
+143 + end DO
+144 |
+145 | GOTO 100
+146 | GO TO 100
 
 ./resources/test/fixtures/style/S233.f90:143:5: S233 [*] Keyword 'DO' should be 'do'
     |
@@ -3299,15 +3140,14 @@ expression: diagnostics
     |
     = help: Change to 'do'
 
-ℹ Safe fix
-140 140 | DO I = 1, N
-141 141 |     IF (I == 3) CYCLE
-142 142 |     IF (I == 4) EXIT
-143     |-END DO
-    143 |+END do
-144 144 | 
-145 145 | GOTO 100
-146 146 | GO TO 100
+140 | DO I = 1, N
+141 |     IF (I == 3) CYCLE
+142 |     IF (I == 4) EXIT
+    - END DO
+143 + END do
+144 |
+145 | GOTO 100
+146 | GO TO 100
 
 ./resources/test/fixtures/style/S233.f90:145:1: S233 [*] Keyword 'GOTO' should be 'goto'
     |
@@ -3320,15 +3160,14 @@ expression: diagnostics
     |
     = help: Change to 'goto'
 
-ℹ Safe fix
-142 142 |     IF (I == 4) EXIT
-143 143 | END DO
-144 144 | 
-145     |-GOTO 100
-    145 |+goto 100
-146 146 | GO TO 100
-147 147 | PRINT *, "SHOULD NOT PRINT"
-148 148 | 100 CONTINUE
+142 |     IF (I == 4) EXIT
+143 | END DO
+144 |
+    - GOTO 100
+145 + goto 100
+146 | GO TO 100
+147 | PRINT *, "SHOULD NOT PRINT"
+148 | 100 CONTINUE
 
 ./resources/test/fixtures/style/S233.f90:146:1: S233 [*] Keyword 'GO' should be 'go'
     |
@@ -3340,15 +3179,14 @@ expression: diagnostics
     |
     = help: Change to 'go'
 
-ℹ Safe fix
-143 143 | END DO
-144 144 | 
-145 145 | GOTO 100
-146     |-GO TO 100
-    146 |+go TO 100
-147 147 | PRINT *, "SHOULD NOT PRINT"
-148 148 | 100 CONTINUE
-149 149 | 
+143 | END DO
+144 |
+145 | GOTO 100
+    - GO TO 100
+146 + go TO 100
+147 | PRINT *, "SHOULD NOT PRINT"
+148 | 100 CONTINUE
+149 |
 
 ./resources/test/fixtures/style/S233.f90:146:4: S233 [*] Keyword 'TO' should be 'to'
     |
@@ -3360,15 +3198,14 @@ expression: diagnostics
     |
     = help: Change to 'to'
 
-ℹ Safe fix
-143 143 | END DO
-144 144 | 
-145 145 | GOTO 100
-146     |-GO TO 100
-    146 |+GO to 100
-147 147 | PRINT *, "SHOULD NOT PRINT"
-148 148 | 100 CONTINUE
-149 149 | 
+143 | END DO
+144 |
+145 | GOTO 100
+    - GO TO 100
+146 + GO to 100
+147 | PRINT *, "SHOULD NOT PRINT"
+148 | 100 CONTINUE
+149 |
 
 ./resources/test/fixtures/style/S233.f90:147:1: S233 [*] Keyword 'PRINT' should be 'print'
     |
@@ -3380,15 +3217,14 @@ expression: diagnostics
     |
     = help: Change to 'print'
 
-ℹ Safe fix
-144 144 | 
-145 145 | GOTO 100
-146 146 | GO TO 100
-147     |-PRINT *, "SHOULD NOT PRINT"
-    147 |+print *, "SHOULD NOT PRINT"
-148 148 | 100 CONTINUE
-149 149 | 
-150 150 | CALL C_F_POINTER(C_NULL_PTR, ARR)
+144 |
+145 | GOTO 100
+146 | GO TO 100
+    - PRINT *, "SHOULD NOT PRINT"
+147 + print *, "SHOULD NOT PRINT"
+148 | 100 CONTINUE
+149 |
+150 | CALL C_F_POINTER(C_NULL_PTR, ARR)
 
 ./resources/test/fixtures/style/S233.f90:148:5: S233 [*] Keyword 'CONTINUE' should be 'continue'
     |
@@ -3401,15 +3237,14 @@ expression: diagnostics
     |
     = help: Change to 'continue'
 
-ℹ Safe fix
-145 145 | GOTO 100
-146 146 | GO TO 100
-147 147 | PRINT *, "SHOULD NOT PRINT"
-148     |-100 CONTINUE
-    148 |+100 continue
-149 149 | 
-150 150 | CALL C_F_POINTER(C_NULL_PTR, ARR)
-151 151 | 
+145 | GOTO 100
+146 | GO TO 100
+147 | PRINT *, "SHOULD NOT PRINT"
+    - 100 CONTINUE
+148 + 100 continue
+149 |
+150 | CALL C_F_POINTER(C_NULL_PTR, ARR)
+151 |
 
 ./resources/test/fixtures/style/S233.f90:150:1: S233 [*] Keyword 'CALL' should be 'call'
     |
@@ -3422,15 +3257,14 @@ expression: diagnostics
     |
     = help: Change to 'call'
 
-ℹ Safe fix
-147 147 | PRINT *, "SHOULD NOT PRINT"
-148 148 | 100 CONTINUE
-149 149 | 
-150     |-CALL C_F_POINTER(C_NULL_PTR, ARR)
-    150 |+call C_F_POINTER(C_NULL_PTR, ARR)
-151 151 | 
-152 152 | SYNC ALL
-153 153 | 
+147 | PRINT *, "SHOULD NOT PRINT"
+148 | 100 CONTINUE
+149 |
+    - CALL C_F_POINTER(C_NULL_PTR, ARR)
+150 + call C_F_POINTER(C_NULL_PTR, ARR)
+151 |
+152 | SYNC ALL
+153 |
 
 ./resources/test/fixtures/style/S233.f90:152:1: S233 [*] Keyword 'SYNC' should be 'sync'
     |
@@ -3443,15 +3277,14 @@ expression: diagnostics
     |
     = help: Change to 'sync'
 
-ℹ Safe fix
-149 149 | 
-150 150 | CALL C_F_POINTER(C_NULL_PTR, ARR)
-151 151 | 
-152     |-SYNC ALL
-    152 |+sync ALL
-153 153 | 
-154 154 | OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
-155 155 | WRITE(10,*) "HELLO"
+149 |
+150 | CALL C_F_POINTER(C_NULL_PTR, ARR)
+151 |
+    - SYNC ALL
+152 + sync ALL
+153 |
+154 | OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
+155 | WRITE(10,*) "HELLO"
 
 ./resources/test/fixtures/style/S233.f90:152:6: S233 [*] Keyword 'ALL' should be 'all'
     |
@@ -3464,15 +3297,14 @@ expression: diagnostics
     |
     = help: Change to 'all'
 
-ℹ Safe fix
-149 149 | 
-150 150 | CALL C_F_POINTER(C_NULL_PTR, ARR)
-151 151 | 
-152     |-SYNC ALL
-    152 |+SYNC all
-153 153 | 
-154 154 | OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
-155 155 | WRITE(10,*) "HELLO"
+149 |
+150 | CALL C_F_POINTER(C_NULL_PTR, ARR)
+151 |
+    - SYNC ALL
+152 + SYNC all
+153 |
+154 | OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
+155 | WRITE(10,*) "HELLO"
 
 ./resources/test/fixtures/style/S233.f90:154:1: S233 [*] Keyword 'OPEN' should be 'open'
     |
@@ -3485,15 +3317,14 @@ expression: diagnostics
     |
     = help: Change to 'open'
 
-ℹ Safe fix
-151 151 | 
-152 152 | SYNC ALL
-153 153 | 
-154     |-OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
-    154 |+open(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
-155 155 | WRITE(10,*) "HELLO"
-156 156 | READ(10,*) STR
-157 157 | CLOSE(10)
+151 |
+152 | SYNC ALL
+153 |
+    - OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
+154 + open(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
+155 | WRITE(10,*) "HELLO"
+156 | READ(10,*) STR
+157 | CLOSE(10)
 
 ./resources/test/fixtures/style/S233.f90:154:6: S233 [*] Keyword 'UNIT' should be 'unit'
     |
@@ -3506,15 +3337,14 @@ expression: diagnostics
     |
     = help: Change to 'unit'
 
-ℹ Safe fix
-151 151 | 
-152 152 | SYNC ALL
-153 153 | 
-154     |-OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
-    154 |+OPEN(unit=10, FILE="test.txt", STATUS="UNKNOWN")
-155 155 | WRITE(10,*) "HELLO"
-156 156 | READ(10,*) STR
-157 157 | CLOSE(10)
+151 |
+152 | SYNC ALL
+153 |
+    - OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
+154 + OPEN(unit=10, FILE="test.txt", STATUS="UNKNOWN")
+155 | WRITE(10,*) "HELLO"
+156 | READ(10,*) STR
+157 | CLOSE(10)
 
 ./resources/test/fixtures/style/S233.f90:155:1: S233 [*] Keyword 'WRITE' should be 'write'
     |
@@ -3526,15 +3356,14 @@ expression: diagnostics
     |
     = help: Change to 'write'
 
-ℹ Safe fix
-152 152 | SYNC ALL
-153 153 | 
-154 154 | OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
-155     |-WRITE(10,*) "HELLO"
-    155 |+write(10,*) "HELLO"
-156 156 | READ(10,*) STR
-157 157 | CLOSE(10)
-158 158 | 
+152 | SYNC ALL
+153 |
+154 | OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
+    - WRITE(10,*) "HELLO"
+155 + write(10,*) "HELLO"
+156 | READ(10,*) STR
+157 | CLOSE(10)
+158 |
 
 ./resources/test/fixtures/style/S233.f90:156:1: S233 [*] Keyword 'READ' should be 'read'
     |
@@ -3546,15 +3375,14 @@ expression: diagnostics
     |
     = help: Change to 'read'
 
-ℹ Safe fix
-153 153 | 
-154 154 | OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
-155 155 | WRITE(10,*) "HELLO"
-156     |-READ(10,*) STR
-    156 |+read(10,*) STR
-157 157 | CLOSE(10)
-158 158 | 
-159 159 | INQUIRE(FILE="test.txt", EXIST=FLAG)
+153 |
+154 | OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
+155 | WRITE(10,*) "HELLO"
+    - READ(10,*) STR
+156 + read(10,*) STR
+157 | CLOSE(10)
+158 |
+159 | INQUIRE(FILE="test.txt", EXIST=FLAG)
 
 ./resources/test/fixtures/style/S233.f90:157:1: S233 [*] Keyword 'CLOSE' should be 'close'
     |
@@ -3567,15 +3395,14 @@ expression: diagnostics
     |
     = help: Change to 'close'
 
-ℹ Safe fix
-154 154 | OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
-155 155 | WRITE(10,*) "HELLO"
-156 156 | READ(10,*) STR
-157     |-CLOSE(10)
-    157 |+close(10)
-158 158 | 
-159 159 | INQUIRE(FILE="test.txt", EXIST=FLAG)
-160 160 | 
+154 | OPEN(UNIT=10, FILE="test.txt", STATUS="UNKNOWN")
+155 | WRITE(10,*) "HELLO"
+156 | READ(10,*) STR
+    - CLOSE(10)
+157 + close(10)
+158 |
+159 | INQUIRE(FILE="test.txt", EXIST=FLAG)
+160 |
 
 ./resources/test/fixtures/style/S233.f90:159:1: S233 [*] Keyword 'INQUIRE' should be 'inquire'
     |
@@ -3588,15 +3415,14 @@ expression: diagnostics
     |
     = help: Change to 'inquire'
 
-ℹ Safe fix
-156 156 | READ(10,*) STR
-157 157 | CLOSE(10)
-158 158 | 
-159     |-INQUIRE(FILE="test.txt", EXIST=FLAG)
-    159 |+inquire(FILE="test.txt", EXIST=FLAG)
-160 160 | 
-161 161 | NULLIFY(POLY)
-162 162 | 
+156 | READ(10,*) STR
+157 | CLOSE(10)
+158 |
+    - INQUIRE(FILE="test.txt", EXIST=FLAG)
+159 + inquire(FILE="test.txt", EXIST=FLAG)
+160 |
+161 | NULLIFY(POLY)
+162 |
 
 ./resources/test/fixtures/style/S233.f90:161:1: S233 [*] Keyword 'NULLIFY' should be 'nullify'
     |
@@ -3609,15 +3435,14 @@ expression: diagnostics
     |
     = help: Change to 'nullify'
 
-ℹ Safe fix
-158 158 | 
-159 159 | INQUIRE(FILE="test.txt", EXIST=FLAG)
-160 160 | 
-161     |-NULLIFY(POLY)
-    161 |+nullify(POLY)
-162 162 | 
-163 163 | DEALLOCATE(ARR)
-164 164 | 
+158 |
+159 | INQUIRE(FILE="test.txt", EXIST=FLAG)
+160 |
+    - NULLIFY(POLY)
+161 + nullify(POLY)
+162 |
+163 | DEALLOCATE(ARR)
+164 |
 
 ./resources/test/fixtures/style/S233.f90:163:1: S233 [*] Keyword 'DEALLOCATE' should be 'deallocate'
     |
@@ -3630,15 +3455,14 @@ expression: diagnostics
     |
     = help: Change to 'deallocate'
 
-ℹ Safe fix
-160 160 | 
-161 161 | NULLIFY(POLY)
-162 162 | 
-163     |-DEALLOCATE(ARR)
-    163 |+deallocate(ARR)
-164 164 | 
-165 165 | STOP
-166 166 | END PROGRAM KEYWORD_ZOO
+160 |
+161 | NULLIFY(POLY)
+162 |
+    - DEALLOCATE(ARR)
+163 + deallocate(ARR)
+164 |
+165 | STOP
+166 | END PROGRAM KEYWORD_ZOO
 
 ./resources/test/fixtures/style/S233.f90:165:1: S233 [*] Keyword 'STOP' should be 'stop'
     |
@@ -3650,13 +3474,12 @@ expression: diagnostics
     |
     = help: Change to 'stop'
 
-ℹ Safe fix
-162 162 | 
-163 163 | DEALLOCATE(ARR)
-164 164 | 
-165     |-STOP
-    165 |+stop
-166 166 | END PROGRAM KEYWORD_ZOO
+162 |
+163 | DEALLOCATE(ARR)
+164 |
+    - STOP
+165 + stop
+166 | END PROGRAM KEYWORD_ZOO
 
 ./resources/test/fixtures/style/S233.f90:166:1: S233 [*] Keyword 'END' should be 'end'
     |
@@ -3666,12 +3489,11 @@ expression: diagnostics
     |
     = help: Change to 'end'
 
-ℹ Safe fix
-163 163 | DEALLOCATE(ARR)
-164 164 | 
-165 165 | STOP
-166     |-END PROGRAM KEYWORD_ZOO
-    166 |+end PROGRAM KEYWORD_ZOO
+163 | DEALLOCATE(ARR)
+164 |
+165 | STOP
+    - END PROGRAM KEYWORD_ZOO
+166 + end PROGRAM KEYWORD_ZOO
 
 ./resources/test/fixtures/style/S233.f90:166:5: S233 [*] Keyword 'PROGRAM' should be 'program'
     |
@@ -3681,9 +3503,8 @@ expression: diagnostics
     |
     = help: Change to 'program'
 
-ℹ Safe fix
-163 163 | DEALLOCATE(ARR)
-164 164 | 
-165 165 | STOP
-166     |-END PROGRAM KEYWORD_ZOO
-    166 |+END program KEYWORD_ZOO
+163 | DEALLOCATE(ARR)
+164 |
+165 | STOP
+    - END PROGRAM KEYWORD_ZOO
+166 + END program KEYWORD_ZOO

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-space-around-double-colon_S103.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-space-around-double-colon_S103.f90.snap
@@ -1,6 +1,7 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S103.f90:3:17: S103 [*] Missing space around `::`
   |
@@ -13,14 +14,13 @@ expression: diagnostics
   |
   = help: Add extra whitespace
 
-ℹ Safe fix
-1 1 | program myprog
-2 2 |   implicit none
-3   |-  use, intrinsic:: iso_fortran_env, only:int64, real64 ! This should add a space before the double colon and not change the single colon
-  3 |+  use, intrinsic :: iso_fortran_env, only:int64, real64 ! This should add a space before the double colon and not change the single colon
-4 4 |   private
-5 5 |   integer ::i ! This should add a space after the double colon
-6 6 |   integer :: j ! ::in comments should be unchanged
+1 | program myprog
+2 |   implicit none
+  -   use, intrinsic:: iso_fortran_env, only:int64, real64 ! This should add a space before the double colon and not change the single colon
+3 +   use, intrinsic :: iso_fortran_env, only:int64, real64 ! This should add a space before the double colon and not change the single colon
+4 |   private
+5 |   integer ::i ! This should add a space after the double colon
+6 |   integer :: j ! ::in comments should be unchanged
 
 ./resources/test/fixtures/style/S103.f90:5:11: S103 [*] Missing space around `::`
   |
@@ -33,15 +33,14 @@ expression: diagnostics
   |
   = help: Add extra whitespace
 
-ℹ Safe fix
-2 2 |   implicit none
-3 3 |   use, intrinsic:: iso_fortran_env, only:int64, real64 ! This should add a space before the double colon and not change the single colon
-4 4 |   private
-5   |-  integer ::i ! This should add a space after the double colon
-  5 |+  integer :: i ! This should add a space after the double colon
-6 6 |   integer :: j ! ::in comments should be unchanged
-7 7 |   integer :: k ! This should be unchanged
-8 8 |   character::x, y, z! This should add spaces before and after the double colon
+2 |   implicit none
+3 |   use, intrinsic:: iso_fortran_env, only:int64, real64 ! This should add a space before the double colon and not change the single colon
+4 |   private
+  -   integer ::i ! This should add a space after the double colon
+5 +   integer :: i ! This should add a space after the double colon
+6 |   integer :: j ! ::in comments should be unchanged
+7 |   integer :: k ! This should be unchanged
+8 |   character::x, y, z! This should add spaces before and after the double colon
 
 ./resources/test/fixtures/style/S103.f90:8:12: S103 [*] Missing space around `::`
    |
@@ -54,15 +53,14 @@ expression: diagnostics
    |
    = help: Add extra whitespace
 
-ℹ Safe fix
-5 5 |   integer ::i ! This should add a space after the double colon
-6 6 |   integer :: j ! ::in comments should be unchanged
-7 7 |   integer :: k ! This should be unchanged
-8   |-  character::x, y, z! This should add spaces before and after the double colon
-  8 |+  character :: x, y, z! This should add spaces before and after the double colon
-9 9 |   allocate(character(10) :: x) ! This should be unchanged
-10 10 |   allocate(character(10):: y) ! This should add a space before the double colon
-11 11 |   allocate(character(10) ::z) ! This should add a space after the double colon
+5  |   integer ::i ! This should add a space after the double colon
+6  |   integer :: j ! ::in comments should be unchanged
+7  |   integer :: k ! This should be unchanged
+   -   character::x, y, z! This should add spaces before and after the double colon
+8  +   character :: x, y, z! This should add spaces before and after the double colon
+9  |   allocate(character(10) :: x) ! This should be unchanged
+10 |   allocate(character(10):: y) ! This should add a space before the double colon
+11 |   allocate(character(10) ::z) ! This should add a space after the double colon
 
 ./resources/test/fixtures/style/S103.f90:10:25: S103 [*] Missing space around `::`
    |
@@ -75,14 +73,13 @@ expression: diagnostics
    |
    = help: Add extra whitespace
 
-ℹ Safe fix
-7  7  |   integer :: k ! This should be unchanged
-8  8  |   character::x, y, z! This should add spaces before and after the double colon
-9  9  |   allocate(character(10) :: x) ! This should be unchanged
-10    |-  allocate(character(10):: y) ! This should add a space before the double colon
-   10 |+  allocate(character(10) :: y) ! This should add a space before the double colon
-11 11 |   allocate(character(10) ::z) ! This should add a space after the double colon
-12 12 | end program myprog
+7  |   integer :: k ! This should be unchanged
+8  |   character::x, y, z! This should add spaces before and after the double colon
+9  |   allocate(character(10) :: x) ! This should be unchanged
+   -   allocate(character(10):: y) ! This should add a space before the double colon
+10 +   allocate(character(10) :: y) ! This should add a space before the double colon
+11 |   allocate(character(10) ::z) ! This should add a space after the double colon
+12 | end program myprog
 
 ./resources/test/fixtures/style/S103.f90:11:26: S103 [*] Missing space around `::`
    |
@@ -94,10 +91,9 @@ expression: diagnostics
    |
    = help: Add extra whitespace
 
-ℹ Safe fix
-8  8  |   character::x, y, z! This should add spaces before and after the double colon
-9  9  |   allocate(character(10) :: x) ! This should be unchanged
-10 10 |   allocate(character(10):: y) ! This should add a space before the double colon
-11    |-  allocate(character(10) ::z) ! This should add a space after the double colon
-   11 |+  allocate(character(10) :: z) ! This should add a space after the double colon
-12 12 | end program myprog
+8  |   character::x, y, z! This should add spaces before and after the double colon
+9  |   allocate(character(10) :: x) ! This should be unchanged
+10 |   allocate(character(10):: y) ! This should add a space before the double colon
+   -   allocate(character(10) ::z) ! This should add a space after the double colon
+11 +   allocate(character(10) :: z) ! This should add a space after the double colon
+12 | end program myprog

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-space-before-comment_S102.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-space-before-comment_S102.f90.snap
@@ -14,14 +14,13 @@ snapshot_kind: text
   |
   = help: Add extra whitespace
 
-ℹ Safe fix
-1 1 | ! This is fine
-2 2 |  ! This isn't but we'll let it pass
-3   |-module mymod! This should be given two extra spaces
-  3 |+module mymod  ! This should be given two extra spaces
-4 4 |   implicit none ! This should be given one extra space
-5 5 |   private  ! This is fine
-6 6 |   ! This is fine
+1 | ! This is fine
+2 |  ! This isn't but we'll let it pass
+  - module mymod! This should be given two extra spaces
+3 + module mymod  ! This should be given two extra spaces
+4 |   implicit none ! This should be given one extra space
+5 |   private  ! This is fine
+6 |   ! This is fine
 
 ./resources/test/fixtures/style/S102.f90:4:16: S102 [*] need at least 2 spaces before inline comment
   |
@@ -34,12 +33,11 @@ snapshot_kind: text
   |
   = help: Add extra whitespace
 
-ℹ Safe fix
-1 1 | ! This is fine
-2 2 |  ! This isn't but we'll let it pass
-3 3 | module mymod! This should be given two extra spaces
-4   |-  implicit none ! This should be given one extra space
-  4 |+  implicit none  ! This should be given one extra space
-5 5 |   private  ! This is fine
-6 6 |   ! This is fine
-7 7 | ! As is this
+1 | ! This is fine
+2 |  ! This isn't but we'll let it pass
+3 | module mymod! This should be given two extra spaces
+  -   implicit none ! This should be given one extra space
+4 +   implicit none  ! This should be given one extra space
+5 |   private  ! This is fine
+6 |   ! This is fine
+7 | ! As is this

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-space-between-brackets_S104.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-space-between-brackets_S104.f90.snap
@@ -1,6 +1,7 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S104.f90:5:14: S104 [*] Should be 0 space after the opening bracket
   |
@@ -13,15 +14,14 @@ expression: diagnostics
   |
   = help: remove extra whitespace
 
-ℹ Safe fix
-2 2 |   implicit none
-3 3 |   integer :: a(3)
-4 4 |   a = [1, 2, 3] ! This should be unchanged
-5   |-  call mysub( a) ! This should remove the space after the (
-  5 |+  call mysub(a) ! This should remove the space after the (
-6 6 | contains
-7 7 |   subroutine mysub( a) ! This should remove the space after the (
-8 8 |     implicit none
+2 |   implicit none
+3 |   integer :: a(3)
+4 |   a = [1, 2, 3] ! This should be unchanged
+  -   call mysub( a) ! This should remove the space after the (
+5 +   call mysub(a) ! This should remove the space after the (
+6 | contains
+7 |   subroutine mysub( a) ! This should remove the space after the (
+8 |     implicit none
 
 ./resources/test/fixtures/style/S104.f90:7:20: S104 [*] Should be 0 space after the opening bracket
   |
@@ -34,15 +34,14 @@ expression: diagnostics
   |
   = help: remove extra whitespace
 
-ℹ Safe fix
-4 4 |   a = [1, 2, 3] ! This should be unchanged
-5 5 |   call mysub( a) ! This should remove the space after the (
-6 6 | contains
-7   |-  subroutine mysub( a) ! This should remove the space after the (
-  7 |+  subroutine mysub(a) ! This should remove the space after the (
-8 8 |     implicit none
-9 9 |     integer, intent( in) :: a( 3) ! This should remove the space after both the brackets
-10 10 |     integer, dimension(2) :: b ! This should be unchanged
+4  |   a = [1, 2, 3] ! This should be unchanged
+5  |   call mysub( a) ! This should remove the space after the (
+6  | contains
+   -   subroutine mysub( a) ! This should remove the space after the (
+7  +   subroutine mysub(a) ! This should remove the space after the (
+8  |     implicit none
+9  |     integer, intent( in) :: a( 3) ! This should remove the space after both the brackets
+10 |     integer, dimension(2) :: b ! This should be unchanged
 
 ./resources/test/fixtures/style/S104.f90:9:21: S104 [*] Should be 0 space after the opening bracket
    |
@@ -55,15 +54,14 @@ expression: diagnostics
    |
    = help: remove extra whitespace
 
-ℹ Safe fix
-6  6  | contains
-7  7  |   subroutine mysub( a) ! This should remove the space after the (
-8  8  |     implicit none
-9     |-    integer, intent( in) :: a( 3) ! This should remove the space after both the brackets
-   9  |+    integer, intent(in) :: a( 3) ! This should remove the space after both the brackets
-10 10 |     integer, dimension(2) :: b ! This should be unchanged
-11 11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
-12 12 |     b = [ 4, & ! This should remove the space after the [
+6  | contains
+7  |   subroutine mysub( a) ! This should remove the space after the (
+8  |     implicit none
+   -     integer, intent( in) :: a( 3) ! This should remove the space after both the brackets
+9  +     integer, intent(in) :: a( 3) ! This should remove the space after both the brackets
+10 |     integer, dimension(2) :: b ! This should be unchanged
+11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
+12 |     b = [ 4, & ! This should remove the space after the [
 
 ./resources/test/fixtures/style/S104.f90:9:31: S104 [*] Should be 0 space after the opening bracket
    |
@@ -76,15 +74,14 @@ expression: diagnostics
    |
    = help: remove extra whitespace
 
-ℹ Safe fix
-6  6  | contains
-7  7  |   subroutine mysub( a) ! This should remove the space after the (
-8  8  |     implicit none
-9     |-    integer, intent( in) :: a( 3) ! This should remove the space after both the brackets
-   9  |+    integer, intent( in) :: a(3) ! This should remove the space after both the brackets
-10 10 |     integer, dimension(2) :: b ! This should be unchanged
-11 11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
-12 12 |     b = [ 4, & ! This should remove the space after the [
+6  | contains
+7  |   subroutine mysub( a) ! This should remove the space after the (
+8  |     implicit none
+   -     integer, intent( in) :: a( 3) ! This should remove the space after both the brackets
+9  +     integer, intent( in) :: a(3) ! This should remove the space after both the brackets
+10 |     integer, dimension(2) :: b ! This should be unchanged
+11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
+12 |     b = [ 4, & ! This should remove the space after the [
 
 ./resources/test/fixtures/style/S104.f90:11:24: S104 [*] Should be 0 space after the opening bracket
    |
@@ -97,15 +94,14 @@ expression: diagnostics
    |
    = help: remove extra whitespace
 
-ℹ Safe fix
-8  8  |     implicit none
-9  9  |     integer, intent( in) :: a( 3) ! This should remove the space after both the brackets
-10 10 |     integer, dimension(2) :: b ! This should be unchanged
-11    |-    integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
-   11 |+    integer, dimension(2) :: c = [6, 7] ! This should remove the spaces after the (
-12 12 |     b = [ 4, & ! This should remove the space after the [
-13 13 |           5 ] ! This should remove the space before the ]
-14 14 |     write( *,* ) a, b, c ! This should remove the space before the ) and after the (
+8  |     implicit none
+9  |     integer, intent( in) :: a( 3) ! This should remove the space after both the brackets
+10 |     integer, dimension(2) :: b ! This should be unchanged
+   -     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
+11 +     integer, dimension(2) :: c = [6, 7] ! This should remove the spaces after the (
+12 |     b = [ 4, & ! This should remove the space after the [
+13 |           5 ] ! This should remove the space before the ]
+14 |     write( *,* ) a, b, c ! This should remove the space before the ) and after the (
 
 ./resources/test/fixtures/style/S104.f90:12:10: S104 [*] Should be 0 space after the opening bracket
    |
@@ -118,15 +114,14 @@ expression: diagnostics
    |
    = help: remove extra whitespace
 
-ℹ Safe fix
-9  9  |     integer, intent( in) :: a( 3) ! This should remove the space after both the brackets
-10 10 |     integer, dimension(2) :: b ! This should be unchanged
-11 11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
-12    |-    b = [ 4, & ! This should remove the space after the [
-   12 |+    b = [4, & ! This should remove the space after the [
-13 13 |           5 ] ! This should remove the space before the ]
-14 14 |     write( *,* ) a, b, c ! This should remove the space before the ) and after the (
-15 15 |   end subroutine mysub
+9  |     integer, intent( in) :: a( 3) ! This should remove the space after both the brackets
+10 |     integer, dimension(2) :: b ! This should be unchanged
+11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
+   -     b = [ 4, & ! This should remove the space after the [
+12 +     b = [4, & ! This should remove the space after the [
+13 |           5 ] ! This should remove the space before the ]
+14 |     write( *,* ) a, b, c ! This should remove the space before the ) and after the (
+15 |   end subroutine mysub
 
 ./resources/test/fixtures/style/S104.f90:13:12: S104 [*] Should be 0 space before the closing bracket
    |
@@ -139,15 +134,14 @@ expression: diagnostics
    |
    = help: remove extra whitespace
 
-ℹ Safe fix
-10 10 |     integer, dimension(2) :: b ! This should be unchanged
-11 11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
-12 12 |     b = [ 4, & ! This should remove the space after the [
-13    |-          5 ] ! This should remove the space before the ]
-   13 |+          5] ! This should remove the space before the ]
-14 14 |     write( *,* ) a, b, c ! This should remove the space before the ) and after the (
-15 15 |   end subroutine mysub
-16 16 |   subroutine myothersub( & ! This should be allowed for long parameter lists
+10 |     integer, dimension(2) :: b ! This should be unchanged
+11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
+12 |     b = [ 4, & ! This should remove the space after the [
+   -           5 ] ! This should remove the space before the ]
+13 +           5] ! This should remove the space before the ]
+14 |     write( *,* ) a, b, c ! This should remove the space before the ) and after the (
+15 |   end subroutine mysub
+16 |   subroutine myothersub( & ! This should be allowed for long parameter lists
 
 ./resources/test/fixtures/style/S104.f90:14:11: S104 [*] Should be 0 space after the opening bracket
    |
@@ -160,15 +154,14 @@ expression: diagnostics
    |
    = help: remove extra whitespace
 
-ℹ Safe fix
-11 11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
-12 12 |     b = [ 4, & ! This should remove the space after the [
-13 13 |           5 ] ! This should remove the space before the ]
-14    |-    write( *,* ) a, b, c ! This should remove the space before the ) and after the (
-   14 |+    write(*,* ) a, b, c ! This should remove the space before the ) and after the (
-15 15 |   end subroutine mysub
-16 16 |   subroutine myothersub( & ! This should be allowed for long parameter lists
-17 17 |     a &
+11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
+12 |     b = [ 4, & ! This should remove the space after the [
+13 |           5 ] ! This should remove the space before the ]
+   -     write( *,* ) a, b, c ! This should remove the space before the ) and after the (
+14 +     write(*,* ) a, b, c ! This should remove the space before the ) and after the (
+15 |   end subroutine mysub
+16 |   subroutine myothersub( & ! This should be allowed for long parameter lists
+17 |     a &
 
 ./resources/test/fixtures/style/S104.f90:14:15: S104 [*] Should be 0 space before the closing bracket
    |
@@ -181,15 +174,14 @@ expression: diagnostics
    |
    = help: remove extra whitespace
 
-ℹ Safe fix
-11 11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
-12 12 |     b = [ 4, & ! This should remove the space after the [
-13 13 |           5 ] ! This should remove the space before the ]
-14    |-    write( *,* ) a, b, c ! This should remove the space before the ) and after the (
-   14 |+    write( *,*) a, b, c ! This should remove the space before the ) and after the (
-15 15 |   end subroutine mysub
-16 16 |   subroutine myothersub( & ! This should be allowed for long parameter lists
-17 17 |     a &
+11 |     integer, dimension(   2) :: c = [6, 7] ! This should remove the spaces after the (
+12 |     b = [ 4, & ! This should remove the space after the [
+13 |           5 ] ! This should remove the space before the ]
+   -     write( *,* ) a, b, c ! This should remove the space before the ) and after the (
+14 +     write( *,*) a, b, c ! This should remove the space before the ) and after the (
+15 |   end subroutine mysub
+16 |   subroutine myothersub( & ! This should be allowed for long parameter lists
+17 |     a &
 
 ./resources/test/fixtures/style/S104.f90:24:33: S104 [*] Should be 0 space before the closing bracket
    |
@@ -202,11 +194,10 @@ expression: diagnostics
    |
    = help: remove extra whitespace
 
-ℹ Safe fix
-21 21 |     a = (1 + 1 &
-22 22 |     & ) ! This should be unchanged
-23 23 |   end subroutine myothersub
-24    |-  subroutine emptyparantesessub( ) ! This should remove the space between the brackets
-   24 |+  subroutine emptyparantesessub() ! This should remove the space between the brackets
-25 25 |   end subroutine emptyparantesessub
-26 26 | end program myprog
+21 |     a = (1 + 1 &
+22 |     & ) ! This should be unchanged
+23 |   end subroutine myothersub
+   -   subroutine emptyparantesessub( ) ! This should remove the space between the brackets
+24 +   subroutine emptyparantesessub() ! This should remove the space between the brackets
+25 |   end subroutine emptyparantesessub
+26 | end program myprog

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__keyword-has-whitespace_S231.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__keyword-has-whitespace_S231.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,15 +14,14 @@ snapshot_kind: text
    |
    = help: Replace with 'inout'
 
-ℹ Safe fix
-41 41 | contains
-42 42 |   integer function f1(x, y)
-43 43 |     integer, intent(inoUt) :: x
-44    |-    integer, intent(in out) :: y
-   44 |+    integer, intent(inout) :: y
-45 45 |     select case (x)
-46 46 |       case(1)
-47 47 |         print *, x
+41 | contains
+42 |   integer function f1(x, y)
+43 |     integer, intent(inoUt) :: x
+   -     integer, intent(in out) :: y
+44 +     integer, intent(inout) :: y
+45 |     select case (x)
+46 |       case(1)
+47 |         print *, x
 
 ./resources/test/fixtures/style/S231.f90:219:15: S232 [*] Whitespace included in 'go to'
     |
@@ -35,15 +34,14 @@ snapshot_kind: text
     |
     = help: Replace with 'goto'
 
-ℹ Safe fix
-216 216 |   10 continue
-217 217 |   i = i + 1
-218 218 |   if (i < 10) goTo 10
-219     |-  if (i < 20) gO To 10
-    219 |+  if (i < 20) gOTo 10
-220 220 |   if (i < 30) go  & ! helpful comment!
-221 221 |     to 10
-222 222 | 
+216 |   10 continue
+217 |   i = i + 1
+218 |   if (i < 10) goTo 10
+    -   if (i < 20) gO To 10
+219 +   if (i < 20) gOTo 10
+220 |   if (i < 30) go  & ! helpful comment!
+221 |     to 10
+222 |
 
 ./resources/test/fixtures/style/S231.f90:220:15: S232 Whitespace included in 'go to'
     |

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__keywords-missing-space_S231.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__keywords-missing-space_S231.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,15 +14,14 @@ snapshot_kind: text
   |
   = help: Replace with 'end function'
 
-ℹ Safe fix
-1 1 | integer function f(x) result(y)
-2 2 |   integer, intent(in) :: x
-3 3 |   y = x
-4   |-endfunction f
-  4 |+end function f
-5 5 | 
-6 6 | module m
-7 7 |   implicit none
+1 | integer function f(x) result(y)
+2 |   integer, intent(in) :: x
+3 |   y = x
+  - endfunction f
+4 + end function f
+5 |
+6 | module m
+7 |   implicit none
 
 ./resources/test/fixtures/style/S231.f90:31:3: S231 [*] Missing space in 'endtype'
    |
@@ -35,15 +34,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end type'
 
-ℹ Safe fix
-28 28 | 
-29 29 |   type, extends(point_2d) :: point_3d
-30 30 |     real :: z
-31    |-  endtype point_3d
-   31 |+  end type point_3d
-32 32 | 
-33 33 |   enum, bind(c)
-34 34 |     enumerator :: a = 1
+28 |
+29 |   type, extends(point_2d) :: point_3d
+30 |     real :: z
+   -   endtype point_3d
+31 +   end type point_3d
+32 |
+33 |   enum, bind(c)
+34 |     enumerator :: a = 1
 
 ./resources/test/fixtures/style/S231.f90:39:3: S231 [*] Missing space in 'endenum'
    |
@@ -56,15 +54,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end enum'
 
-ℹ Safe fix
-36 36 | 
-37 37 |   enum, bind(c)
-38 38 |     enumerator :: b = 2
-39    |-  EndEnum
-   39 |+  End Enum
-40 40 | 
-41 41 | contains
-42 42 |   integer function f1(x, y)
+36 |
+37 |   enum, bind(c)
+38 |     enumerator :: b = 2
+   -   EndEnum
+39 +   End Enum
+40 |
+41 | contains
+42 |   integer function f1(x, y)
 
 ./resources/test/fixtures/style/S231.f90:51:5: S231 [*] Missing space in 'selectcase'
    |
@@ -77,15 +74,14 @@ snapshot_kind: text
    |
    = help: Replace with 'select case'
 
-ℹ Safe fix
-48 48 |       case default
-49 49 |         print *, y
-50 50 |     end select
-51    |-    selectcase (y)
-   51 |+    select case (y)
-52 52 |       case(1)
-53 53 |         f1 = y
-54 54 |       case default
+48 |       case default
+49 |         print *, y
+50 |     end select
+   -     selectcase (y)
+51 +     select case (y)
+52 |       case(1)
+53 |         f1 = y
+54 |       case default
 
 ./resources/test/fixtures/style/S231.f90:56:5: S231 [*] Missing space in 'endselect'
    |
@@ -97,15 +93,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end select'
 
-ℹ Safe fix
-53 53 |         f1 = y
-54 54 |       case default
-55 55 |         f1 = x
-56    |-    endselect
-   56 |+    end select
-57 57 |   end function f1
-58 58 | 
-59 59 |   integer function f2(x)
+53 |         f1 = y
+54 |       case default
+55 |         f1 = x
+   -     endselect
+56 +     end select
+57 |   end function f1
+58 |
+59 |   integer function f2(x)
 
 ./resources/test/fixtures/style/S231.f90:67:5: S231 [*] Missing space in 'endblock'
    |
@@ -118,15 +113,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end block'
 
-ℹ Safe fix
-64 64 |     end block
-65 65 |     block_name: block
-66 66 |       integer :: k
-67    |-    endblock block_name
-   67 |+    end block block_name
-68 68 |     print *, "x"
-69 69 |     f2 = x
-70 70 |   endfunction f2
+64 |     end block
+65 |     block_name: block
+66 |       integer :: k
+   -     endblock block_name
+67 +     end block block_name
+68 |     print *, "x"
+69 |     f2 = x
+70 |   endfunction f2
 
 ./resources/test/fixtures/style/S231.f90:70:3: S231 [*] Missing space in 'endfunction'
    |
@@ -139,15 +133,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end function'
 
-ℹ Safe fix
-67 67 |     endblock block_name
-68 68 |     print *, "x"
-69 69 |     f2 = x
-70    |-  endfunction f2
-   70 |+  end function f2
-71 71 | 
-72 72 |   subroutine s1()
-73 73 |     integer, parameter :: N = 3
+67 |     endblock block_name
+68 |     print *, "x"
+69 |     f2 = x
+   -   endfunction f2
+70 +   end function f2
+71 |
+72 |   subroutine s1()
+73 |     integer, parameter :: N = 3
 
 ./resources/test/fixtures/style/S231.f90:84:7: S231 [*] Missing space in 'endforall'
    |
@@ -160,15 +153,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end forall'
 
-ℹ Safe fix
-81 81 |     named_associate: associate(A => matrix)
-82 82 |       forall(i = 1:N, j = 1:N, i /= j)
-83 83 |         A(i, j) = 0.0
-84    |-      endforall
-   84 |+      end forall
-85 85 |     endassociate named_associate
-86 86 |     print *, A
-87 87 |   end subroutine s1
+81 |     named_associate: associate(A => matrix)
+82 |       forall(i = 1:N, j = 1:N, i /= j)
+83 |         A(i, j) = 0.0
+   -       endforall
+84 +       end forall
+85 |     endassociate named_associate
+86 |     print *, A
+87 |   end subroutine s1
 
 ./resources/test/fixtures/style/S231.f90:85:5: S231 [*] Missing space in 'endassociate'
    |
@@ -181,15 +173,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end associate'
 
-ℹ Safe fix
-82 82 |       forall(i = 1:N, j = 1:N, i /= j)
-83 83 |         A(i, j) = 0.0
-84 84 |       endforall
-85    |-    endassociate named_associate
-   85 |+    end associate named_associate
-86 86 |     print *, A
-87 87 |   end subroutine s1
-88 88 | 
+82 |       forall(i = 1:N, j = 1:N, i /= j)
+83 |         A(i, j) = 0.0
+84 |       endforall
+   -     endassociate named_associate
+85 +     end associate named_associate
+86 |     print *, A
+87 |   end subroutine s1
+88 |
 
 ./resources/test/fixtures/style/S231.f90:98:5: S231 [*] Missing space in 'selecttype'
     |
@@ -202,15 +193,14 @@ snapshot_kind: text
     |
     = help: Replace with 'select type'
 
-ℹ Safe fix
-95 95 |       class is (point_2d) ! should trigger for either
-96 96 |         print *, ptr%x, ptr%y
-97 97 |     end select
-98    |-    selecttype(ptr)
-   98 |+    select type(ptr)
-99 99 |       type is(point_3d) ! only trigger for 3d
-100 100 |         print *, ptr%x, ptr%y, ptr%z
-101 101 |     endselect
+95  |       class is (point_2d) ! should trigger for either
+96  |         print *, ptr%x, ptr%y
+97  |     end select
+    -     selecttype(ptr)
+98  +     select type(ptr)
+99  |       type is(point_3d) ! only trigger for 3d
+100 |         print *, ptr%x, ptr%y, ptr%z
+101 |     endselect
 
 ./resources/test/fixtures/style/S231.f90:101:5: S231 [*] Missing space in 'endselect'
     |
@@ -222,15 +212,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end select'
 
-ℹ Safe fix
-98  98  |     selecttype(ptr)
-99  99  |       type is(point_3d) ! only trigger for 3d
-100 100 |         print *, ptr%x, ptr%y, ptr%z
-101     |-    endselect
-    101 |+    end select
-102 102 |   endsubroutine s2
-103 103 | 
-104 104 | end module m
+98  |     selecttype(ptr)
+99  |       type is(point_3d) ! only trigger for 3d
+100 |         print *, ptr%x, ptr%y, ptr%z
+    -     endselect
+101 +     end select
+102 |   endsubroutine s2
+103 |
+104 | end module m
 
 ./resources/test/fixtures/style/S231.f90:102:3: S231 [*] Missing space in 'endsubroutine'
     |
@@ -243,15 +232,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end subroutine'
 
-ℹ Safe fix
-99  99  |       type is(point_3d) ! only trigger for 3d
-100 100 |         print *, ptr%x, ptr%y, ptr%z
-101 101 |     endselect
-102     |-  endsubroutine s2
-    102 |+  end subroutine s2
-103 103 | 
-104 104 | end module m
-105 105 | 
+99  |       type is(point_3d) ! only trigger for 3d
+100 |         print *, ptr%x, ptr%y, ptr%z
+101 |     endselect
+    -   endsubroutine s2
+102 +   end subroutine s2
+103 |
+104 | end module m
+105 |
 
 ./resources/test/fixtures/style/S231.f90:125:7: S231 [*] Missing space in 'endcritical'
     |
@@ -264,15 +252,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end critical'
 
-ℹ Safe fix
-122 122 |     change team(team_id)
-123 123 |       critical
-124 124 |         total = total + this
-125     |-      endcritical
-    125 |+      end critical
-126 126 |       sync all
-127 127 |     endteam
-128 128 |   end function coarray_stuff
+122 |     change team(team_id)
+123 |       critical
+124 |         total = total + this
+    -       endcritical
+125 +       end critical
+126 |       sync all
+127 |     endteam
+128 |   end function coarray_stuff
 
 ./resources/test/fixtures/style/S231.f90:127:5: S231 [*] Missing space in 'endteam'
     |
@@ -285,15 +272,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end team'
 
-ℹ Safe fix
-124 124 |         total = total + this
-125 125 |       endcritical
-126 126 |       sync all
-127     |-    endteam
-    127 |+    end team
-128 128 |   end function coarray_stuff
-129 129 | endmodule m2
-130 130 | 
+124 |         total = total + this
+125 |       endcritical
+126 |       sync all
+    -     endteam
+127 +     end team
+128 |   end function coarray_stuff
+129 | endmodule m2
+130 |
 
 ./resources/test/fixtures/style/S231.f90:129:1: S231 [*] Missing space in 'endmodule'
     |
@@ -306,15 +292,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end module'
 
-ℹ Safe fix
-126 126 |       sync all
-127 127 |     endteam
-128 128 |   end function coarray_stuff
-129     |-endmodule m2
-    129 |+end module m2
-130 130 | 
-131 131 | submodule (m) s1
-132 132 |   implicit none
+126 |       sync all
+127 |     endteam
+128 |   end function coarray_stuff
+    - endmodule m2
+129 + end module m2
+130 |
+131 | submodule (m) s1
+132 |   implicit none
 
 ./resources/test/fixtures/style/S231.f90:135:3: S231 [*] Missing space in 'endprocedure'
     |
@@ -327,15 +312,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end procedure'
 
-ℹ Safe fix
-132 132 |   implicit none
-133 133 | contains
-134 134 |   module procedure procedure_1
-135     |-  endprocedure procedure_1
-    135 |+  end procedure procedure_1
-136 136 |   integer function submodule_f1(x)
-137 137 |     integer, intent(in) :: x
-138 138 |     submodule_f1 = x
+132 |   implicit none
+133 | contains
+134 |   module procedure procedure_1
+    -   endprocedure procedure_1
+135 +   end procedure procedure_1
+136 |   integer function submodule_f1(x)
+137 |     integer, intent(in) :: x
+138 |     submodule_f1 = x
 
 ./resources/test/fixtures/style/S231.f90:151:1: S231 [*] Missing space in 'endsubmodule'
     |
@@ -348,15 +332,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end submodule'
 
-ℹ Safe fix
-148 148 |     integer, intent(in) :: x
-149 149 |     submodule_f2 = x
-150 150 |   end function submodule_f2
-151     |-endSubmodule s2
-    151 |+end Submodule s2
-152 152 | 
-153 153 | program p
-154 154 |   use :: m, only: s1, s2, point_2d, point_3d
+148 |     integer, intent(in) :: x
+149 |     submodule_f2 = x
+150 |   end function submodule_f2
+    - endSubmodule s2
+151 + end Submodule s2
+152 |
+153 | program p
+154 |   use :: m, only: s1, s2, point_2d, point_3d
 
 ./resources/test/fixtures/style/S231.f90:159:3: S231 [*] Missing space in 'doubleprecision'
     |
@@ -369,15 +352,14 @@ snapshot_kind: text
     |
     = help: Replace with 'double precision'
 
-ℹ Safe fix
-156 156 |   integer, parameter :: n = 10
-157 157 |   double precision :: A(n)
-158 158 |   double complex :: b
-159     |-  DoublePrecision :: c
-    159 |+  Double Precision :: c
-160 160 |   DoubleComplex :: d
-161 161 |   integer :: i, j, k
-162 162 |   type(point_2d) :: p2d
+156 |   integer, parameter :: n = 10
+157 |   double precision :: A(n)
+158 |   double complex :: b
+    -   DoublePrecision :: c
+159 +   Double Precision :: c
+160 |   DoubleComplex :: d
+161 |   integer :: i, j, k
+162 |   type(point_2d) :: p2d
 
 ./resources/test/fixtures/style/S231.f90:160:3: S231 [*] Missing space in 'doublecomplex'
     |
@@ -390,15 +372,14 @@ snapshot_kind: text
     |
     = help: Replace with 'double complex'
 
-ℹ Safe fix
-157 157 |   double precision :: A(n)
-158 158 |   double complex :: b
-159 159 |   DoublePrecision :: c
-160     |-  DoubleComplex :: d
-    160 |+  Double Complex :: d
-161 161 |   integer :: i, j, k
-162 162 |   type(point_2d) :: p2d
-163 163 |   type(point_3d) :: p3d
+157 |   double precision :: A(n)
+158 |   double complex :: b
+159 |   DoublePrecision :: c
+    -   DoubleComplex :: d
+160 +   Double Complex :: d
+161 |   integer :: i, j, k
+162 |   type(point_2d) :: p2d
+163 |   type(point_3d) :: p3d
 
 ./resources/test/fixtures/style/S231.f90:170:3: S231 [*] Missing space in 'endinterface'
     |
@@ -411,15 +392,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end interface'
 
-ℹ Safe fix
-167 167 |     function f(x)
-168 168 |       integer, intent(in) :: x
-169 169 |     end function f
-170     |-  endinterface
-    170 |+  end interface
-171 171 | 
-172 172 |   do i = 1, n
-173 173 |     A(i) = real(i)
+167 |     function f(x)
+168 |       integer, intent(in) :: x
+169 |     end function f
+    -   endinterface
+170 +   end interface
+171 |
+172 |   do i = 1, n
+173 |     A(i) = real(i)
 
 ./resources/test/fixtures/style/S231.f90:178:3: S231 [*] Missing space in 'enddo'
     |
@@ -432,15 +412,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end do'
 
-ℹ Safe fix
-175 175 | 
-176 176 |   do_name: do i = 1, n
-177 177 |     A(i) = A(i) + 1
-178     |-  enddo do_name
-    178 |+  end do do_name
-179 179 | 
-180 180 |   where (A > 5.0)
-181 181 |     A = A * 2.0
+175 |
+176 |   do_name: do i = 1, n
+177 |     A(i) = A(i) + 1
+    -   enddo do_name
+178 +   end do do_name
+179 |
+180 |   where (A > 5.0)
+181 |     A = A * 2.0
 
 ./resources/test/fixtures/style/S231.f90:182:3: S231 [*] Missing space in 'elsewhere'
     |
@@ -453,15 +432,14 @@ snapshot_kind: text
     |
     = help: Replace with 'else where'
 
-ℹ Safe fix
-179 179 | 
-180 180 |   where (A > 5.0)
-181 181 |     A = A * 2.0
-182     |-  eLseWHere
-    182 |+  eLse WHere
-183 183 |     A = A + 10.0
-184 184 |   endwheRe
-185 185 | 
+179 |
+180 |   where (A > 5.0)
+181 |     A = A * 2.0
+    -   eLseWHere
+182 +   eLse WHere
+183 |     A = A + 10.0
+184 |   endwheRe
+185 |
 
 ./resources/test/fixtures/style/S231.f90:184:3: S231 [*] Missing space in 'endwhere'
     |
@@ -474,15 +452,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end where'
 
-ℹ Safe fix
-181 181 |     A = A * 2.0
-182 182 |   eLseWHere
-183 183 |     A = A + 10.0
-184     |-  endwheRe
-    184 |+  end wheRe
-185 185 | 
-186 186 |   where (A > 15.0)
-187 187 |     A = A + 3.0
+181 |     A = A * 2.0
+182 |   eLseWHere
+183 |     A = A + 10.0
+    -   endwheRe
+184 +   end wheRe
+185 |
+186 |   where (A > 15.0)
+187 |     A = A + 3.0
 
 ./resources/test/fixtures/style/S231.f90:194:3: S231 [*] Missing space in 'elseif'
     |
@@ -495,15 +472,14 @@ snapshot_kind: text
     |
     = help: Replace with 'else if'
 
-ℹ Safe fix
-191 191 | 
-192 192 |   if (A(1) == 11.0) then
-193 193 |     print *, "foo"
-194     |-  eLsEIf (A(1) == 12.0) then
-    194 |+  eLsE If (A(1) == 12.0) then
-195 195 |     print *, "bar"
-196 196 |   else if (A(2) == 12.0) then
-197 197 |     print *, "baz"
+191 |
+192 |   if (A(1) == 11.0) then
+193 |     print *, "foo"
+    -   eLsEIf (A(1) == 12.0) then
+194 +   eLsE If (A(1) == 12.0) then
+195 |     print *, "bar"
+196 |   else if (A(2) == 12.0) then
+197 |     print *, "baz"
 
 ./resources/test/fixtures/style/S231.f90:204:3: S231 [*] Missing space in 'endif'
     |
@@ -516,15 +492,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end if'
 
-ℹ Safe fix
-201 201 | 
-202 202 |   if (A(1) == 11.0) then
-203 203 |     print *, "foo"
-204     |-  EndIf
-    204 |+  End If
-205 205 | 
-206 206 |   call s1()
-207 207 | 
+201 |
+202 |   if (A(1) == 11.0) then
+203 |     print *, "foo"
+    -   EndIf
+204 +   End If
+205 |
+206 |   call s1()
+207 |
 
 ./resources/test/fixtures/style/S231.f90:229:1: S231 [*] Missing space in 'endprogram'
     |
@@ -535,9 +510,8 @@ snapshot_kind: text
     |
     = help: Replace with 'end program'
 
-ℹ Safe fix
-226 226 |       out) :: x
-227 227 |     fff = x
-228 228 |   end function fff
-229     |-endprogram p
-    229 |+end program p
+226 |       out) :: x
+227 |     fff = x
+228 |   end function fff
+    - endprogram p
+229 + end program p

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__keywords-missing-space_S231.f90_include_inout_goto.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__keywords-missing-space_S231.f90_include_inout_goto.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,15 +14,14 @@ snapshot_kind: text
   |
   = help: Replace with 'end function'
 
-ℹ Safe fix
-1 1 | integer function f(x) result(y)
-2 2 |   integer, intent(in) :: x
-3 3 |   y = x
-4   |-endfunction f
-  4 |+end function f
-5 5 | 
-6 6 | module m
-7 7 |   implicit none
+1 | integer function f(x) result(y)
+2 |   integer, intent(in) :: x
+3 |   y = x
+  - endfunction f
+4 + end function f
+5 |
+6 | module m
+7 |   implicit none
 
 ./resources/test/fixtures/style/S231.f90:31:3: S231 [*] Missing space in 'endtype'
    |
@@ -35,15 +34,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end type'
 
-ℹ Safe fix
-28 28 | 
-29 29 |   type, extends(point_2d) :: point_3d
-30 30 |     real :: z
-31    |-  endtype point_3d
-   31 |+  end type point_3d
-32 32 | 
-33 33 |   enum, bind(c)
-34 34 |     enumerator :: a = 1
+28 |
+29 |   type, extends(point_2d) :: point_3d
+30 |     real :: z
+   -   endtype point_3d
+31 +   end type point_3d
+32 |
+33 |   enum, bind(c)
+34 |     enumerator :: a = 1
 
 ./resources/test/fixtures/style/S231.f90:39:3: S231 [*] Missing space in 'endenum'
    |
@@ -56,15 +54,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end enum'
 
-ℹ Safe fix
-36 36 | 
-37 37 |   enum, bind(c)
-38 38 |     enumerator :: b = 2
-39    |-  EndEnum
-   39 |+  End Enum
-40 40 | 
-41 41 | contains
-42 42 |   integer function f1(x, y)
+36 |
+37 |   enum, bind(c)
+38 |     enumerator :: b = 2
+   -   EndEnum
+39 +   End Enum
+40 |
+41 | contains
+42 |   integer function f1(x, y)
 
 ./resources/test/fixtures/style/S231.f90:43:21: S231 [*] Missing space in 'inout'
    |
@@ -77,15 +74,14 @@ snapshot_kind: text
    |
    = help: Replace with 'in out'
 
-ℹ Safe fix
-40 40 | 
-41 41 | contains
-42 42 |   integer function f1(x, y)
-43    |-    integer, intent(inoUt) :: x
-   43 |+    integer, intent(in oUt) :: x
-44 44 |     integer, intent(in out) :: y
-45 45 |     select case (x)
-46 46 |       case(1)
+40 |
+41 | contains
+42 |   integer function f1(x, y)
+   -     integer, intent(inoUt) :: x
+43 +     integer, intent(in oUt) :: x
+44 |     integer, intent(in out) :: y
+45 |     select case (x)
+46 |       case(1)
 
 ./resources/test/fixtures/style/S231.f90:51:5: S231 [*] Missing space in 'selectcase'
    |
@@ -98,15 +94,14 @@ snapshot_kind: text
    |
    = help: Replace with 'select case'
 
-ℹ Safe fix
-48 48 |       case default
-49 49 |         print *, y
-50 50 |     end select
-51    |-    selectcase (y)
-   51 |+    select case (y)
-52 52 |       case(1)
-53 53 |         f1 = y
-54 54 |       case default
+48 |       case default
+49 |         print *, y
+50 |     end select
+   -     selectcase (y)
+51 +     select case (y)
+52 |       case(1)
+53 |         f1 = y
+54 |       case default
 
 ./resources/test/fixtures/style/S231.f90:56:5: S231 [*] Missing space in 'endselect'
    |
@@ -118,15 +113,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end select'
 
-ℹ Safe fix
-53 53 |         f1 = y
-54 54 |       case default
-55 55 |         f1 = x
-56    |-    endselect
-   56 |+    end select
-57 57 |   end function f1
-58 58 | 
-59 59 |   integer function f2(x)
+53 |         f1 = y
+54 |       case default
+55 |         f1 = x
+   -     endselect
+56 +     end select
+57 |   end function f1
+58 |
+59 |   integer function f2(x)
 
 ./resources/test/fixtures/style/S231.f90:67:5: S231 [*] Missing space in 'endblock'
    |
@@ -139,15 +133,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end block'
 
-ℹ Safe fix
-64 64 |     end block
-65 65 |     block_name: block
-66 66 |       integer :: k
-67    |-    endblock block_name
-   67 |+    end block block_name
-68 68 |     print *, "x"
-69 69 |     f2 = x
-70 70 |   endfunction f2
+64 |     end block
+65 |     block_name: block
+66 |       integer :: k
+   -     endblock block_name
+67 +     end block block_name
+68 |     print *, "x"
+69 |     f2 = x
+70 |   endfunction f2
 
 ./resources/test/fixtures/style/S231.f90:70:3: S231 [*] Missing space in 'endfunction'
    |
@@ -160,15 +153,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end function'
 
-ℹ Safe fix
-67 67 |     endblock block_name
-68 68 |     print *, "x"
-69 69 |     f2 = x
-70    |-  endfunction f2
-   70 |+  end function f2
-71 71 | 
-72 72 |   subroutine s1()
-73 73 |     integer, parameter :: N = 3
+67 |     endblock block_name
+68 |     print *, "x"
+69 |     f2 = x
+   -   endfunction f2
+70 +   end function f2
+71 |
+72 |   subroutine s1()
+73 |     integer, parameter :: N = 3
 
 ./resources/test/fixtures/style/S231.f90:84:7: S231 [*] Missing space in 'endforall'
    |
@@ -181,15 +173,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end forall'
 
-ℹ Safe fix
-81 81 |     named_associate: associate(A => matrix)
-82 82 |       forall(i = 1:N, j = 1:N, i /= j)
-83 83 |         A(i, j) = 0.0
-84    |-      endforall
-   84 |+      end forall
-85 85 |     endassociate named_associate
-86 86 |     print *, A
-87 87 |   end subroutine s1
+81 |     named_associate: associate(A => matrix)
+82 |       forall(i = 1:N, j = 1:N, i /= j)
+83 |         A(i, j) = 0.0
+   -       endforall
+84 +       end forall
+85 |     endassociate named_associate
+86 |     print *, A
+87 |   end subroutine s1
 
 ./resources/test/fixtures/style/S231.f90:85:5: S231 [*] Missing space in 'endassociate'
    |
@@ -202,15 +193,14 @@ snapshot_kind: text
    |
    = help: Replace with 'end associate'
 
-ℹ Safe fix
-82 82 |       forall(i = 1:N, j = 1:N, i /= j)
-83 83 |         A(i, j) = 0.0
-84 84 |       endforall
-85    |-    endassociate named_associate
-   85 |+    end associate named_associate
-86 86 |     print *, A
-87 87 |   end subroutine s1
-88 88 | 
+82 |       forall(i = 1:N, j = 1:N, i /= j)
+83 |         A(i, j) = 0.0
+84 |       endforall
+   -     endassociate named_associate
+85 +     end associate named_associate
+86 |     print *, A
+87 |   end subroutine s1
+88 |
 
 ./resources/test/fixtures/style/S231.f90:98:5: S231 [*] Missing space in 'selecttype'
     |
@@ -223,15 +213,14 @@ snapshot_kind: text
     |
     = help: Replace with 'select type'
 
-ℹ Safe fix
-95 95 |       class is (point_2d) ! should trigger for either
-96 96 |         print *, ptr%x, ptr%y
-97 97 |     end select
-98    |-    selecttype(ptr)
-   98 |+    select type(ptr)
-99 99 |       type is(point_3d) ! only trigger for 3d
-100 100 |         print *, ptr%x, ptr%y, ptr%z
-101 101 |     endselect
+95  |       class is (point_2d) ! should trigger for either
+96  |         print *, ptr%x, ptr%y
+97  |     end select
+    -     selecttype(ptr)
+98  +     select type(ptr)
+99  |       type is(point_3d) ! only trigger for 3d
+100 |         print *, ptr%x, ptr%y, ptr%z
+101 |     endselect
 
 ./resources/test/fixtures/style/S231.f90:101:5: S231 [*] Missing space in 'endselect'
     |
@@ -243,15 +232,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end select'
 
-ℹ Safe fix
-98  98  |     selecttype(ptr)
-99  99  |       type is(point_3d) ! only trigger for 3d
-100 100 |         print *, ptr%x, ptr%y, ptr%z
-101     |-    endselect
-    101 |+    end select
-102 102 |   endsubroutine s2
-103 103 | 
-104 104 | end module m
+98  |     selecttype(ptr)
+99  |       type is(point_3d) ! only trigger for 3d
+100 |         print *, ptr%x, ptr%y, ptr%z
+    -     endselect
+101 +     end select
+102 |   endsubroutine s2
+103 |
+104 | end module m
 
 ./resources/test/fixtures/style/S231.f90:102:3: S231 [*] Missing space in 'endsubroutine'
     |
@@ -264,15 +252,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end subroutine'
 
-ℹ Safe fix
-99  99  |       type is(point_3d) ! only trigger for 3d
-100 100 |         print *, ptr%x, ptr%y, ptr%z
-101 101 |     endselect
-102     |-  endsubroutine s2
-    102 |+  end subroutine s2
-103 103 | 
-104 104 | end module m
-105 105 | 
+99  |       type is(point_3d) ! only trigger for 3d
+100 |         print *, ptr%x, ptr%y, ptr%z
+101 |     endselect
+    -   endsubroutine s2
+102 +   end subroutine s2
+103 |
+104 | end module m
+105 |
 
 ./resources/test/fixtures/style/S231.f90:125:7: S231 [*] Missing space in 'endcritical'
     |
@@ -285,15 +272,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end critical'
 
-ℹ Safe fix
-122 122 |     change team(team_id)
-123 123 |       critical
-124 124 |         total = total + this
-125     |-      endcritical
-    125 |+      end critical
-126 126 |       sync all
-127 127 |     endteam
-128 128 |   end function coarray_stuff
+122 |     change team(team_id)
+123 |       critical
+124 |         total = total + this
+    -       endcritical
+125 +       end critical
+126 |       sync all
+127 |     endteam
+128 |   end function coarray_stuff
 
 ./resources/test/fixtures/style/S231.f90:127:5: S231 [*] Missing space in 'endteam'
     |
@@ -306,15 +292,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end team'
 
-ℹ Safe fix
-124 124 |         total = total + this
-125 125 |       endcritical
-126 126 |       sync all
-127     |-    endteam
-    127 |+    end team
-128 128 |   end function coarray_stuff
-129 129 | endmodule m2
-130 130 | 
+124 |         total = total + this
+125 |       endcritical
+126 |       sync all
+    -     endteam
+127 +     end team
+128 |   end function coarray_stuff
+129 | endmodule m2
+130 |
 
 ./resources/test/fixtures/style/S231.f90:129:1: S231 [*] Missing space in 'endmodule'
     |
@@ -327,15 +312,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end module'
 
-ℹ Safe fix
-126 126 |       sync all
-127 127 |     endteam
-128 128 |   end function coarray_stuff
-129     |-endmodule m2
-    129 |+end module m2
-130 130 | 
-131 131 | submodule (m) s1
-132 132 |   implicit none
+126 |       sync all
+127 |     endteam
+128 |   end function coarray_stuff
+    - endmodule m2
+129 + end module m2
+130 |
+131 | submodule (m) s1
+132 |   implicit none
 
 ./resources/test/fixtures/style/S231.f90:135:3: S231 [*] Missing space in 'endprocedure'
     |
@@ -348,15 +332,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end procedure'
 
-ℹ Safe fix
-132 132 |   implicit none
-133 133 | contains
-134 134 |   module procedure procedure_1
-135     |-  endprocedure procedure_1
-    135 |+  end procedure procedure_1
-136 136 |   integer function submodule_f1(x)
-137 137 |     integer, intent(in) :: x
-138 138 |     submodule_f1 = x
+132 |   implicit none
+133 | contains
+134 |   module procedure procedure_1
+    -   endprocedure procedure_1
+135 +   end procedure procedure_1
+136 |   integer function submodule_f1(x)
+137 |     integer, intent(in) :: x
+138 |     submodule_f1 = x
 
 ./resources/test/fixtures/style/S231.f90:151:1: S231 [*] Missing space in 'endsubmodule'
     |
@@ -369,15 +352,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end submodule'
 
-ℹ Safe fix
-148 148 |     integer, intent(in) :: x
-149 149 |     submodule_f2 = x
-150 150 |   end function submodule_f2
-151     |-endSubmodule s2
-    151 |+end Submodule s2
-152 152 | 
-153 153 | program p
-154 154 |   use :: m, only: s1, s2, point_2d, point_3d
+148 |     integer, intent(in) :: x
+149 |     submodule_f2 = x
+150 |   end function submodule_f2
+    - endSubmodule s2
+151 + end Submodule s2
+152 |
+153 | program p
+154 |   use :: m, only: s1, s2, point_2d, point_3d
 
 ./resources/test/fixtures/style/S231.f90:159:3: S231 [*] Missing space in 'doubleprecision'
     |
@@ -390,15 +372,14 @@ snapshot_kind: text
     |
     = help: Replace with 'double precision'
 
-ℹ Safe fix
-156 156 |   integer, parameter :: n = 10
-157 157 |   double precision :: A(n)
-158 158 |   double complex :: b
-159     |-  DoublePrecision :: c
-    159 |+  Double Precision :: c
-160 160 |   DoubleComplex :: d
-161 161 |   integer :: i, j, k
-162 162 |   type(point_2d) :: p2d
+156 |   integer, parameter :: n = 10
+157 |   double precision :: A(n)
+158 |   double complex :: b
+    -   DoublePrecision :: c
+159 +   Double Precision :: c
+160 |   DoubleComplex :: d
+161 |   integer :: i, j, k
+162 |   type(point_2d) :: p2d
 
 ./resources/test/fixtures/style/S231.f90:160:3: S231 [*] Missing space in 'doublecomplex'
     |
@@ -411,15 +392,14 @@ snapshot_kind: text
     |
     = help: Replace with 'double complex'
 
-ℹ Safe fix
-157 157 |   double precision :: A(n)
-158 158 |   double complex :: b
-159 159 |   DoublePrecision :: c
-160     |-  DoubleComplex :: d
-    160 |+  Double Complex :: d
-161 161 |   integer :: i, j, k
-162 162 |   type(point_2d) :: p2d
-163 163 |   type(point_3d) :: p3d
+157 |   double precision :: A(n)
+158 |   double complex :: b
+159 |   DoublePrecision :: c
+    -   DoubleComplex :: d
+160 +   Double Complex :: d
+161 |   integer :: i, j, k
+162 |   type(point_2d) :: p2d
+163 |   type(point_3d) :: p3d
 
 ./resources/test/fixtures/style/S231.f90:170:3: S231 [*] Missing space in 'endinterface'
     |
@@ -432,15 +412,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end interface'
 
-ℹ Safe fix
-167 167 |     function f(x)
-168 168 |       integer, intent(in) :: x
-169 169 |     end function f
-170     |-  endinterface
-    170 |+  end interface
-171 171 | 
-172 172 |   do i = 1, n
-173 173 |     A(i) = real(i)
+167 |     function f(x)
+168 |       integer, intent(in) :: x
+169 |     end function f
+    -   endinterface
+170 +   end interface
+171 |
+172 |   do i = 1, n
+173 |     A(i) = real(i)
 
 ./resources/test/fixtures/style/S231.f90:178:3: S231 [*] Missing space in 'enddo'
     |
@@ -453,15 +432,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end do'
 
-ℹ Safe fix
-175 175 | 
-176 176 |   do_name: do i = 1, n
-177 177 |     A(i) = A(i) + 1
-178     |-  enddo do_name
-    178 |+  end do do_name
-179 179 | 
-180 180 |   where (A > 5.0)
-181 181 |     A = A * 2.0
+175 |
+176 |   do_name: do i = 1, n
+177 |     A(i) = A(i) + 1
+    -   enddo do_name
+178 +   end do do_name
+179 |
+180 |   where (A > 5.0)
+181 |     A = A * 2.0
 
 ./resources/test/fixtures/style/S231.f90:182:3: S231 [*] Missing space in 'elsewhere'
     |
@@ -474,15 +452,14 @@ snapshot_kind: text
     |
     = help: Replace with 'else where'
 
-ℹ Safe fix
-179 179 | 
-180 180 |   where (A > 5.0)
-181 181 |     A = A * 2.0
-182     |-  eLseWHere
-    182 |+  eLse WHere
-183 183 |     A = A + 10.0
-184 184 |   endwheRe
-185 185 | 
+179 |
+180 |   where (A > 5.0)
+181 |     A = A * 2.0
+    -   eLseWHere
+182 +   eLse WHere
+183 |     A = A + 10.0
+184 |   endwheRe
+185 |
 
 ./resources/test/fixtures/style/S231.f90:184:3: S231 [*] Missing space in 'endwhere'
     |
@@ -495,15 +472,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end where'
 
-ℹ Safe fix
-181 181 |     A = A * 2.0
-182 182 |   eLseWHere
-183 183 |     A = A + 10.0
-184     |-  endwheRe
-    184 |+  end wheRe
-185 185 | 
-186 186 |   where (A > 15.0)
-187 187 |     A = A + 3.0
+181 |     A = A * 2.0
+182 |   eLseWHere
+183 |     A = A + 10.0
+    -   endwheRe
+184 +   end wheRe
+185 |
+186 |   where (A > 15.0)
+187 |     A = A + 3.0
 
 ./resources/test/fixtures/style/S231.f90:194:3: S231 [*] Missing space in 'elseif'
     |
@@ -516,15 +492,14 @@ snapshot_kind: text
     |
     = help: Replace with 'else if'
 
-ℹ Safe fix
-191 191 | 
-192 192 |   if (A(1) == 11.0) then
-193 193 |     print *, "foo"
-194     |-  eLsEIf (A(1) == 12.0) then
-    194 |+  eLsE If (A(1) == 12.0) then
-195 195 |     print *, "bar"
-196 196 |   else if (A(2) == 12.0) then
-197 197 |     print *, "baz"
+191 |
+192 |   if (A(1) == 11.0) then
+193 |     print *, "foo"
+    -   eLsEIf (A(1) == 12.0) then
+194 +   eLsE If (A(1) == 12.0) then
+195 |     print *, "bar"
+196 |   else if (A(2) == 12.0) then
+197 |     print *, "baz"
 
 ./resources/test/fixtures/style/S231.f90:204:3: S231 [*] Missing space in 'endif'
     |
@@ -537,15 +512,14 @@ snapshot_kind: text
     |
     = help: Replace with 'end if'
 
-ℹ Safe fix
-201 201 | 
-202 202 |   if (A(1) == 11.0) then
-203 203 |     print *, "foo"
-204     |-  EndIf
-    204 |+  End If
-205 205 | 
-206 206 |   call s1()
-207 207 | 
+201 |
+202 |   if (A(1) == 11.0) then
+203 |     print *, "foo"
+    -   EndIf
+204 +   End If
+205 |
+206 |   call s1()
+207 |
 
 ./resources/test/fixtures/style/S231.f90:218:15: S231 [*] Missing space in 'goto'
     |
@@ -558,15 +532,14 @@ snapshot_kind: text
     |
     = help: Replace with 'go to'
 
-ℹ Safe fix
-215 215 |   i = 1
-216 216 |   10 continue
-217 217 |   i = i + 1
-218     |-  if (i < 10) goTo 10
-    218 |+  if (i < 10) go To 10
-219 219 |   if (i < 20) gO To 10
-220 220 |   if (i < 30) go  & ! helpful comment!
-221 221 |     to 10
+215 |   i = 1
+216 |   10 continue
+217 |   i = i + 1
+    -   if (i < 10) goTo 10
+218 +   if (i < 10) go To 10
+219 |   if (i < 20) gO To 10
+220 |   if (i < 30) go  & ! helpful comment!
+221 |     to 10
 
 ./resources/test/fixtures/style/S231.f90:229:1: S231 [*] Missing space in 'endprogram'
     |
@@ -577,9 +550,8 @@ snapshot_kind: text
     |
     = help: Replace with 'end program'
 
-ℹ Safe fix
-226 226 |       out) :: x
-227 227 |     fff = x
-228 228 |   end function fff
-229     |-endprogram p
-    229 |+end program p
+226 |       out) :: x
+227 |     fff = x
+228 |   end function fff
+    - endprogram p
+229 + end program p

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__missing-double-colon_S071.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__missing-double-colon_S071.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,14 +14,13 @@ snapshot_kind: text
   |
   = help: Add '::'
 
-ℹ Safe fix
-1 1 | program test
-2 2 |   implicit none
-3   |-  real these, are
-  3 |+  real :: these, are
-4 4 |   type(real(kind=kind(1.0d0))) all(42), bad
-5 5 |   integer :: but, these_ones, are_fine
-6 6 | end program test
+1 | program test
+2 |   implicit none
+  -   real these, are
+3 +   real :: these, are
+4 |   type(real(kind=kind(1.0d0))) all(42), bad
+5 |   integer :: but, these_ones, are_fine
+6 | end program test
 
 ./resources/test/fixtures/style/S071.f90:4:3: S071 [*] variable declaration missing '::'
   |
@@ -34,11 +33,10 @@ snapshot_kind: text
   |
   = help: Add '::'
 
-ℹ Safe fix
-1 1 | program test
-2 2 |   implicit none
-3 3 |   real these, are
-4   |-  type(real(kind=kind(1.0d0))) all(42), bad
-  4 |+  type(real(kind=kind(1.0d0))) :: all(42), bad
-5 5 |   integer :: but, these_ones, are_fine
-6 6 | end program test
+1 | program test
+2 |   implicit none
+3 |   real these, are
+  -   type(real(kind=kind(1.0d0))) all(42), bad
+4 +   type(real(kind=kind(1.0d0))) :: all(42), bad
+5 |   integer :: but, these_ones, are_fine
+6 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__missing-newline-at-end-of-file_S002.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__missing-newline-at-end-of-file_S002.f90.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S002.f90:2:75: S002 [*] missing newline at end of file
   |
@@ -10,7 +11,6 @@ expression: diagnostics
   |
   = help: Add newline at end of file
 
-ℹ Safe fix
-1 1 | program p
-2   |-end program p ! Missing newline, be careful with tools that might add one!
-  2 |+end program p ! Missing newline, be careful with tools that might add one!
+1 | program p
+  - end program p ! Missing newline, be careful with tools that might add one!
+2 + end program p ! Missing newline, be careful with tools that might add one!

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__mixed-scalar-array-declaration_S262.f90_always.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__mixed-scalar-array-declaration_S262.f90_always.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-3 3 |   ! these are ok
-4 4 |   real, dimension(1) :: x, y(2), z(3, 4)
-5 5 |   ! these are bad
-6   |-  real :: a, b(5), c, d(2) = [1, 2]
-  6 |+  real :: a,  c, d(2) = [1, 2]
-  7 |+  real, dimension(5) :: b
-7 8 |   ! shouldn't complain if all arrays
-8 9 |   real :: e(2), f(2)
-9 10 | end program test
+3  |   ! these are ok
+4  |   real, dimension(1) :: x, y(2), z(3, 4)
+5  |   ! these are bad
+   -   real :: a, b(5), c, d(2) = [1, 2]
+6  +   real :: a,  c, d(2) = [1, 2]
+7  +   real, dimension(5) :: b
+8  |   ! shouldn't complain if all arrays
+9  |   real :: e(2), f(2)
+10 | end program test
 
 ./resources/test/fixtures/style/S262.f90:6:23: S262 [*] Mixed declaration of scalar(s) and array
   |
@@ -36,13 +35,12 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-3 3 |   ! these are ok
-4 4 |   real, dimension(1) :: x, y(2), z(3, 4)
-5 5 |   ! these are bad
-6   |-  real :: a, b(5), c, d(2) = [1, 2]
-  6 |+  real :: a, b(5), c
-  7 |+  real, dimension(2) :: d = [1, 2]
-7 8 |   ! shouldn't complain if all arrays
-8 9 |   real :: e(2), f(2)
-9 10 | end program test
+3  |   ! these are ok
+4  |   real, dimension(1) :: x, y(2), z(3, 4)
+5  |   ! these are bad
+   -   real :: a, b(5), c, d(2) = [1, 2]
+6  +   real :: a, b(5), c
+7  +   real, dimension(2) :: d = [1, 2]
+8  |   ! shouldn't complain if all arrays
+9  |   real :: e(2), f(2)
+10 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__mixed-scalar-array-declaration_S262.f90_keep.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__mixed-scalar-array-declaration_S262.f90_keep.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-3 3 |   ! these are ok
-4 4 |   real, dimension(1) :: x, y(2), z(3, 4)
-5 5 |   ! these are bad
-6   |-  real :: a, b(5), c, d(2) = [1, 2]
-  6 |+  real :: a,  c, d(2) = [1, 2]
-  7 |+  real :: b(5)
-7 8 |   ! shouldn't complain if all arrays
-8 9 |   real :: e(2), f(2)
-9 10 | end program test
+3  |   ! these are ok
+4  |   real, dimension(1) :: x, y(2), z(3, 4)
+5  |   ! these are bad
+   -   real :: a, b(5), c, d(2) = [1, 2]
+6  +   real :: a,  c, d(2) = [1, 2]
+7  +   real :: b(5)
+8  |   ! shouldn't complain if all arrays
+9  |   real :: e(2), f(2)
+10 | end program test
 
 ./resources/test/fixtures/style/S262.f90:6:23: S262 [*] Mixed declaration of scalar(s) and array
   |
@@ -36,13 +35,12 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-3 3 |   ! these are ok
-4 4 |   real, dimension(1) :: x, y(2), z(3, 4)
-5 5 |   ! these are bad
-6   |-  real :: a, b(5), c, d(2) = [1, 2]
-  6 |+  real :: a, b(5), c
-  7 |+  real :: d(2) = [1, 2]
-7 8 |   ! shouldn't complain if all arrays
-8 9 |   real :: e(2), f(2)
-9 10 | end program test
+3  |   ! these are ok
+4  |   real, dimension(1) :: x, y(2), z(3, 4)
+5  |   ! these are bad
+   -   real :: a, b(5), c, d(2) = [1, 2]
+6  +   real :: a, b(5), c
+7  +   real :: d(2) = [1, 2]
+8  |   ! shouldn't complain if all arrays
+9  |   real :: e(2), f(2)
+10 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__mixed-scalar-array-declaration_S262.f90_never.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__mixed-scalar-array-declaration_S262.f90_never.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-3 3 |   ! these are ok
-4 4 |   real, dimension(1) :: x, y(2), z(3, 4)
-5 5 |   ! these are bad
-6   |-  real :: a, b(5), c, d(2) = [1, 2]
-  6 |+  real :: a,  c, d(2) = [1, 2]
-  7 |+  real :: b(5)
-7 8 |   ! shouldn't complain if all arrays
-8 9 |   real :: e(2), f(2)
-9 10 | end program test
+3  |   ! these are ok
+4  |   real, dimension(1) :: x, y(2), z(3, 4)
+5  |   ! these are bad
+   -   real :: a, b(5), c, d(2) = [1, 2]
+6  +   real :: a,  c, d(2) = [1, 2]
+7  +   real :: b(5)
+8  |   ! shouldn't complain if all arrays
+9  |   real :: e(2), f(2)
+10 | end program test
 
 ./resources/test/fixtures/style/S262.f90:6:23: S262 [*] Mixed declaration of scalar(s) and array
   |
@@ -36,13 +35,12 @@ snapshot_kind: text
   |
   = help: Move variable declaration to separate statement
 
-ℹ Unsafe fix
-3 3 |   ! these are ok
-4 4 |   real, dimension(1) :: x, y(2), z(3, 4)
-5 5 |   ! these are bad
-6   |-  real :: a, b(5), c, d(2) = [1, 2]
-  6 |+  real :: a, b(5), c
-  7 |+  real :: d(2) = [1, 2]
-7 8 |   ! shouldn't complain if all arrays
-8 9 |   real :: e(2), f(2)
-9 10 | end program test
+3  |   ! these are ok
+4  |   real, dimension(1) :: x, y(2), z(3, 4)
+5  |   ! these are bad
+   -   real :: a, b(5), c, d(2) = [1, 2]
+6  +   real :: a, b(5), c
+7  +   real :: d(2) = [1, 2]
+8  |   ! shouldn't complain if all arrays
+9  |   real :: e(2), f(2)
+10 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__multiple-statements-per-line_S082.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__multiple-statements-per-line_S082.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -14,15 +14,14 @@ snapshot_kind: text
    |
    = help: Separate over two lines
 
-ℹ Safe fix
-8  8  |   implicit none;
-9  9  |   integer :: i;
-10 10 |   integer :: j;
-11    |-  i = 1;; j = 2;
-   11 |+  i = 1
-   12 |+  ; j = 2;
-12 13 |   i = i + j; write (*, *) i;;
-13 14 | end program p;
+8  |   implicit none;
+9  |   integer :: i;
+10 |   integer :: j;
+   -   i = 1;; j = 2;
+11 +   i = 1
+12 +   ; j = 2;
+13 |   i = i + j; write (*, *) i;;
+14 | end program p;
 
 ./resources/test/fixtures/style/S082.f90:12:12: S082 [*] multiple statements per line
    |
@@ -34,14 +33,13 @@ snapshot_kind: text
    |
    = help: Separate over two lines
 
-ℹ Safe fix
-9  9  |   integer :: i;
-10 10 |   integer :: j;
-11 11 |   i = 1;; j = 2;
-12    |-  i = i + j; write (*, *) i;;
-   12 |+  i = i + j
-   13 |+  write (*, *) i;;
-13 14 | end program p;
+9  |   integer :: i;
+10 |   integer :: j;
+11 |   i = 1;; j = 2;
+   -   i = i + j; write (*, *) i;;
+12 +   i = i + j
+13 +   write (*, *) i;;
+14 | end program p;
 
 ./resources/test/fixtures/style/S082.f90:12:28: S082 [*] multiple statements per line
    |
@@ -53,11 +51,10 @@ snapshot_kind: text
    |
    = help: Separate over two lines
 
-ℹ Safe fix
-9  9  |   integer :: i;
-10 10 |   integer :: j;
-11 11 |   i = 1;; j = 2;
-12    |-  i = i + j; write (*, *) i;;
-   12 |+  i = i + j; write (*, *) i
-   13 |+  ;
-13 14 | end program p;
+9  |   integer :: i;
+10 |   integer :: j;
+11 |   i = 1;; j = 2;
+   -   i = i + j; write (*, *) i;;
+12 +   i = i + j; write (*, *) i
+13 +   ;
+14 | end program p;

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-else-cycle_S253.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-else-cycle_S253.f90.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else-if'
 
-ℹ Safe fix
-20 20 |     do i = 1, a
-21 21 |       if ((i - b) < 0) then
-22 22 |         cycle
-23    |-      else if ((i - b) > 10) then
-   23 |+      end if
-   24 |+      if ((i - b) > 10) then
-24 25 |         cycle
-25 26 |       else
-26 27 |         capped_sub = capped_sub - b
+20 |     do i = 1, a
+21 |       if ((i - b) < 0) then
+22 |         cycle
+   -       else if ((i - b) > 10) then
+23 +       end if
+24 +       if ((i - b) > 10) then
+25 |         cycle
+26 |       else
+27 |         capped_sub = capped_sub - b
 
 ./resources/test/fixtures/style/S253.f90:24:9: S253 [*] Unnecessary else after `cycle` statement
    |
@@ -36,18 +35,17 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else'
 
-ℹ Safe fix
-22 22 |         cycle
-23 23 |       else if ((i - b) > 10) then
-24 24 |         cycle
-25    |-      else
-26    |-        capped_sub = capped_sub - b
-27 25 |       end if
-   26 |+
-   27 |+      capped_sub = capped_sub - b
-28 28 |     end do
-29 29 |   end function capped_sub
-30 30 |       
+22 |         cycle
+23 |       else if ((i - b) > 10) then
+24 |         cycle
+   -       else
+   -         capped_sub = capped_sub - b
+25 |       end if
+26 +
+27 +       capped_sub = capped_sub - b
+28 |     end do
+29 |   end function capped_sub
+30 |       
 
 ./resources/test/fixtures/style/S253.f90:38:9: S253 [*] Unnecessary else after `cycle` statement
    |
@@ -60,15 +58,14 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else'
 
-ℹ Safe fix
-36 36 |     label: do i = 1, a
-37 37 |       if ((a * b) > 100) then
-38 38 |         cycle label
-39    |-      else
-40    |-        capped_mult = capped_mult * b
-41 39 |       end if
-   40 |+
-   41 |+      capped_mult = capped_mult * b
-42 42 |     end do label
-43 43 |   end function capped_mult
-44 44 |
+36 |     label: do i = 1, a
+37 |       if ((a * b) > 100) then
+38 |         cycle label
+   -       else
+   -         capped_mult = capped_mult * b
+39 |       end if
+40 +
+41 +       capped_mult = capped_mult * b
+42 |     end do label
+43 |   end function capped_mult
+44 |

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-else-exit_S254.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-else-exit_S254.f90.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else-if'
 
-ℹ Safe fix
-20 20 |     do i = 1, a
-21 21 |       if ((i - b) < 0) then
-22 22 |         exit
-23    |-      else if ((i - b) > 10) then
-   23 |+      end if
-   24 |+      if ((i - b) > 10) then
-24 25 |         exit
-25 26 |       else
-26 27 |         capped_sub = capped_sub - b
+20 |     do i = 1, a
+21 |       if ((i - b) < 0) then
+22 |         exit
+   -       else if ((i - b) > 10) then
+23 +       end if
+24 +       if ((i - b) > 10) then
+25 |         exit
+26 |       else
+27 |         capped_sub = capped_sub - b
 
 ./resources/test/fixtures/style/S254.f90:24:9: S254 [*] Unnecessary else after `exit` statement
    |
@@ -36,18 +35,17 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else'
 
-ℹ Safe fix
-22 22 |         exit
-23 23 |       else if ((i - b) > 10) then
-24 24 |         exit
-25    |-      else
-26    |-        capped_sub = capped_sub - b
-27 25 |       end if
-   26 |+
-   27 |+      capped_sub = capped_sub - b
-28 28 |     end do
-29 29 |   end function capped_sub
-30 30 |       
+22 |         exit
+23 |       else if ((i - b) > 10) then
+24 |         exit
+   -       else
+   -         capped_sub = capped_sub - b
+25 |       end if
+26 +
+27 +       capped_sub = capped_sub - b
+28 |     end do
+29 |   end function capped_sub
+30 |       
 
 ./resources/test/fixtures/style/S254.f90:38:9: S254 [*] Unnecessary else after `exit` statement
    |
@@ -60,15 +58,14 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else'
 
-ℹ Safe fix
-36 36 |     label: do i = 1, a
-37 37 |       if ((a * b) > 100) then
-38 38 |         exit label
-39    |-      else
-40    |-        capped_mult = capped_mult * b
-41 39 |       end if
-   40 |+
-   41 |+      capped_mult = capped_mult * b
-42 42 |     end do label
-43 43 |   end function capped_mult
-44 44 |
+36 |     label: do i = 1, a
+37 |       if ((a * b) > 100) then
+38 |         exit label
+   -       else
+   -         capped_mult = capped_mult * b
+39 |       end if
+40 +
+41 +       capped_mult = capped_mult * b
+42 |     end do label
+43 |   end function capped_mult
+44 |

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-else-return_S252.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-else-return_S252.f90.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else-if'
 
-ℹ Safe fix
-17 17 |     if ((a - b) < 0) then
-18 18 |       capped_sub = 0
-19 19 |       return
-20    |-    else if ((a - b) > 10) then
-   20 |+    end if
-   21 |+    if ((a - b) > 10) then
-21 22 |       capped_sub = 10
-22 23 |       return
-23 24 |     ELSEIF (.false.) then
+17 |     if ((a - b) < 0) then
+18 |       capped_sub = 0
+19 |       return
+   -     else if ((a - b) > 10) then
+20 +     end if
+21 +     if ((a - b) > 10) then
+22 |       capped_sub = 10
+23 |       return
+24 |     ELSEIF (.false.) then
 
 ./resources/test/fixtures/style/S252.f90:22:7: S252 [*] Unnecessary else-if after `return` statement
    |
@@ -36,16 +35,15 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else-if'
 
-ℹ Safe fix
-20 20 |     else if ((a - b) > 10) then
-21 21 |       capped_sub = 10
-22 22 |       return
-23    |-    ELSEIF (.false.) then
-   23 |+    end if
-   24 |+    if (.false.) then
-24 25 |       capped_sub = -1
-25 26 |       return
-26 27 |     else
+20 |     else if ((a - b) > 10) then
+21 |       capped_sub = 10
+22 |       return
+   -     ELSEIF (.false.) then
+23 +     end if
+24 +     if (.false.) then
+25 |       capped_sub = -1
+26 |       return
+27 |     else
 
 ./resources/test/fixtures/style/S252.f90:25:7: S252 [*] Unnecessary else after `return` statement
    |
@@ -58,18 +56,17 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else'
 
-ℹ Safe fix
-23 23 |     ELSEIF (.false.) then
-24 24 |       capped_sub = -1
-25 25 |       return
-26    |-    else
-27    |-      capped_sub = a - b
-28 26 |     end if
-   27 |+
-   28 |+    capped_sub = a - b
-29 29 |   end function capped_sub
-30 30 | 
-31 31 |   integer function capped_mult(a, b)
+23 |     ELSEIF (.false.) then
+24 |       capped_sub = -1
+25 |       return
+   -     else
+   -       capped_sub = a - b
+26 |     end if
+27 +
+28 +     capped_sub = a - b
+29 |   end function capped_sub
+30 |
+31 |   integer function capped_mult(a, b)
 
 ./resources/test/fixtures/style/S252.f90:35:7: S252 [*] Unnecessary else after `return` statement
    |
@@ -82,24 +79,23 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else'
 
-ℹ Safe fix
-33 33 |     if ((a * b) > 100) then
-34 34 |       capped_mult = 100
-35 35 |       return
-36    |-    else  ! This comment should be moved onto next line
-37    |-      ! And some other bits that
-38    |-      ! should also be unindented
-   36 |+    end if
-   37 |+    ! This comment should be moved onto next line
-   38 |+    ! And some other bits that
-   39 |+    ! should also be unindented
-39 40 |  ! unindented comment shouldn't cause over-indentation
-40    |-      capped_mult = a * b
-41    |-    end if
-   41 |+    capped_mult = a * b
-42 42 |   end function capped_mult
-43 43 | 
-44 44 |   integer function capped_div(a, b)
+33 |     if ((a * b) > 100) then
+34 |       capped_mult = 100
+35 |       return
+   -     else  ! This comment should be moved onto next line
+   -       ! And some other bits that
+   -       ! should also be unindented
+36 +     end if
+37 +     ! This comment should be moved onto next line
+38 +     ! And some other bits that
+39 +     ! should also be unindented
+40 |  ! unindented comment shouldn't cause over-indentation
+   -       capped_mult = a * b
+   -     end if
+41 +     capped_mult = a * b
+42 |   end function capped_mult
+43 |
+44 |   integer function capped_div(a, b)
 
 ./resources/test/fixtures/style/S252.f90:68:7: S252 Unnecessary else after `return` statement
    |

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-else-stop_S255.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-else-stop_S255.f90.snap
@@ -14,16 +14,15 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else-if'
 
-ℹ Safe fix
-17 17 |     if ((a - b) < 0) then
-18 18 |       capped_sub = 0
-19 19 |       STOP
-20    |-    else if ((a - b) > 10) then
-   20 |+    end if
-   21 |+    if ((a - b) > 10) then
-21 22 |       capped_sub = 10
-22 23 |       stop 3
-23 24 |     else
+17 |     if ((a - b) < 0) then
+18 |       capped_sub = 0
+19 |       STOP
+   -     else if ((a - b) > 10) then
+20 +     end if
+21 +     if ((a - b) > 10) then
+22 |       capped_sub = 10
+23 |       stop 3
+24 |     else
 
 ./resources/test/fixtures/style/S255.f90:22:7: S255 [*] Unnecessary else after `stop` statement
    |
@@ -36,18 +35,17 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else'
 
-ℹ Safe fix
-20 20 |     else if ((a - b) > 10) then
-21 21 |       capped_sub = 10
-22 22 |       stop 3
-23    |-    else
-24    |-      capped_sub = a - b
-25 23 |     end if
-   24 |+
-   25 |+    capped_sub = a - b
-26 26 |   end function capped_sub
-27 27 | 
-28 28 |   integer function capped_mult(a, b)
+20 |     else if ((a - b) > 10) then
+21 |       capped_sub = 10
+22 |       stop 3
+   -     else
+   -       capped_sub = a - b
+23 |     end if
+24 +
+25 +     capped_sub = a - b
+26 |   end function capped_sub
+27 |
+28 |   integer function capped_mult(a, b)
 
 ./resources/test/fixtures/style/S255.f90:32:7: S255 [*] Unnecessary else after `error stop` statement
    |
@@ -60,15 +58,14 @@ snapshot_kind: text
    |
    = help: Remove unnecessary 'else'
 
-ℹ Safe fix
-30 30 |     if ((a * b) > 100) then
-31 31 |       capped_mult = 100
-32 32 |       error     stop 2
-33    |-    else
-34    |-      capped_mult = a * b
-35 33 |     end if
-   34 |+
-   35 |+    capped_mult = a * b
-36 36 |   end function capped_mult
-37 37 | 
-38 38 |   integer function capped_pow(a, b)
+30 |     if ((a * b) > 100) then
+31 |       capped_mult = 100
+32 |       error     stop 2
+   -     else
+   -       capped_mult = a * b
+33 |     end if
+34 +
+35 +     capped_mult = a * b
+36 |   end function capped_mult
+37 |
+38 |   integer function capped_pow(a, b)

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-implicit-none_S201.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-implicit-none_S201.f90.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S201.f90:5:5: S201 [*] 'implicit none' set on the enclosing module
   |
@@ -13,14 +14,13 @@ expression: diagnostics
   |
   = help: Remove unnecessary 'implicit none'
 
-ℹ Safe fix
-2 2 |   implicit none
-3 3 | contains
-4 4 |   integer function myfunc(x)
-5   |-    implicit none
-6 5 |     integer, intent(in) :: x
-7 6 |     myfunc = x * 2
-8 7 |   end function myfunc
+2 |   implicit none
+3 | contains
+4 |   integer function myfunc(x)
+  -     implicit none
+5 |     integer, intent(in) :: x
+6 |     myfunc = x * 2
+7 |   end function myfunc
 
 ./resources/test/fixtures/style/S201.f90:10:5: S201 [*] 'implicit none' set on the enclosing module
    |
@@ -33,14 +33,13 @@ expression: diagnostics
    |
    = help: Remove unnecessary 'implicit none'
 
-ℹ Safe fix
-7  7  |     myfunc = x * 2
-8  8  |   end function myfunc
-9  9  |   subroutine mysub(x)
-10    |-    implicit none (type)
-11 10 |     integer, intent(inout) :: x
-12 11 |     x = x * 2
-13 12 |   end subroutine mysub
+7  |     myfunc = x * 2
+8  |   end function myfunc
+9  |   subroutine mysub(x)
+   -     implicit none (type)
+10 |     integer, intent(inout) :: x
+11 |     x = x * 2
+12 |   end subroutine mysub
 
 ./resources/test/fixtures/style/S201.f90:23:5: S201 [*] 'implicit none' set on the enclosing program
    |
@@ -53,14 +52,13 @@ expression: diagnostics
    |
    = help: Remove unnecessary 'implicit none'
 
-ℹ Safe fix
-20 20 | 
-21 21 | contains
-22 22 |   integer function myfunc2(x)
-23    |-    implicit none
-24 23 |     integer, intent(in) :: x
-25 24 |     myfunc2 = x * 2
-26 25 |   end function myfunc2
+20 |
+21 | contains
+22 |   integer function myfunc2(x)
+   -     implicit none
+23 |     integer, intent(in) :: x
+24 |     myfunc2 = x * 2
+25 |   end function myfunc2
 
 ./resources/test/fixtures/style/S201.f90:28:5: S201 [*] 'implicit none' set on the enclosing program
    |
@@ -73,11 +71,10 @@ expression: diagnostics
    |
    = help: Remove unnecessary 'implicit none'
 
-ℹ Safe fix
-25 25 |     myfunc2 = x * 2
-26 26 |   end function myfunc2
-27 27 |   subroutine mysub2(x)
-28    |-    implicit none
-29 28 |     integer, intent(inout) :: x
-30 29 |     x = x * 2
-31 30 |   end subroutine mysub2
+25 |     myfunc2 = x * 2
+26 |   end function myfunc2
+27 |   subroutine mysub2(x)
+   -     implicit none
+28 |     integer, intent(inout) :: x
+29 |     x = x * 2
+30 |   end subroutine mysub2

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-semicolon_S081.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-semicolon_S081.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -12,12 +12,11 @@ snapshot_kind: text
   |
   = help: Remove this character
 
-ℹ Safe fix
-1 1 | module m
-2   |-  ;
-3 2 | end module m
-4 3 | 
-5 4 | 
+1 | module m
+  -   ;
+2 | end module m
+3 |
+4 |
 
 ./resources/test/fixtures/style/S081.f90:6:10: S081 [*] unnecessary semicolon
   |
@@ -28,15 +27,14 @@ snapshot_kind: text
   |
   = help: Remove this character
 
-ℹ Safe fix
-3 3 | end module m
-4 4 | 
-5 5 | 
-6   |-program p;
-  6 |+program p
-7 7 |   ;
-8 8 |   implicit none;
-9 9 |   integer :: i;
+3 | end module m
+4 |
+5 |
+  - program p;
+6 + program p
+7 |   ;
+8 |   implicit none;
+9 |   integer :: i;
 
 ./resources/test/fixtures/style/S081.f90:7:3: S081 [*] unnecessary semicolon
   |
@@ -48,14 +46,13 @@ snapshot_kind: text
   |
   = help: Remove this character
 
-ℹ Safe fix
-4 4 | 
-5 5 | 
-6 6 | program p;
-7   |-  ;
-8 7 |   implicit none;
-9 8 |   integer :: i;
-10 9 |   integer :: j;
+4 |
+5 |
+6 | program p;
+  -   ;
+7 |   implicit none;
+8 |   integer :: i;
+9 |   integer :: j;
 
 ./resources/test/fixtures/style/S081.f90:8:16: S081 [*] unnecessary semicolon
    |
@@ -68,15 +65,14 @@ snapshot_kind: text
    |
    = help: Remove this character
 
-ℹ Safe fix
-5 5 | 
-6 6 | program p;
-7 7 |   ;
-8   |-  implicit none;
-  8 |+  implicit none
-9 9 |   integer :: i;
-10 10 |   integer :: j;
-11 11 |   i = 1;; j = 2;
+5  |
+6  | program p;
+7  |   ;
+   -   implicit none;
+8  +   implicit none
+9  |   integer :: i;
+10 |   integer :: j;
+11 |   i = 1;; j = 2;
 
 ./resources/test/fixtures/style/S081.f90:9:15: S081 [*] unnecessary semicolon
    |
@@ -89,15 +85,14 @@ snapshot_kind: text
    |
    = help: Remove this character
 
-ℹ Safe fix
-6  6  | program p;
-7  7  |   ;
-8  8  |   implicit none;
-9     |-  integer :: i;
-   9  |+  integer :: i
-10 10 |   integer :: j;
-11 11 |   i = 1;; j = 2;
-12 12 |   i = i + j; write (*, *) i;;
+6  | program p;
+7  |   ;
+8  |   implicit none;
+   -   integer :: i;
+9  +   integer :: i
+10 |   integer :: j;
+11 |   i = 1;; j = 2;
+12 |   i = i + j; write (*, *) i;;
 
 ./resources/test/fixtures/style/S081.f90:10:15: S081 [*] unnecessary semicolon
    |
@@ -110,15 +105,14 @@ snapshot_kind: text
    |
    = help: Remove this character
 
-ℹ Safe fix
-7  7  |   ;
-8  8  |   implicit none;
-9  9  |   integer :: i;
-10    |-  integer :: j;
-   10 |+  integer :: j
-11 11 |   i = 1;; j = 2;
-12 12 |   i = i + j; write (*, *) i;;
-13 13 | end program p;
+7  |   ;
+8  |   implicit none;
+9  |   integer :: i;
+   -   integer :: j;
+10 +   integer :: j
+11 |   i = 1;; j = 2;
+12 |   i = i + j; write (*, *) i;;
+13 | end program p;
 
 ./resources/test/fixtures/style/S081.f90:11:9: S081 [*] unnecessary semicolon
    |
@@ -131,14 +125,13 @@ snapshot_kind: text
    |
    = help: Remove this character
 
-ℹ Safe fix
-8  8  |   implicit none;
-9  9  |   integer :: i;
-10 10 |   integer :: j;
-11    |-  i = 1;; j = 2;
-   11 |+  i = 1; j = 2;
-12 12 |   i = i + j; write (*, *) i;;
-13 13 | end program p;
+8  |   implicit none;
+9  |   integer :: i;
+10 |   integer :: j;
+   -   i = 1;; j = 2;
+11 +   i = 1; j = 2;
+12 |   i = i + j; write (*, *) i;;
+13 | end program p;
 
 ./resources/test/fixtures/style/S081.f90:11:16: S081 [*] unnecessary semicolon
    |
@@ -151,14 +144,13 @@ snapshot_kind: text
    |
    = help: Remove this character
 
-ℹ Safe fix
-8  8  |   implicit none;
-9  9  |   integer :: i;
-10 10 |   integer :: j;
-11    |-  i = 1;; j = 2;
-   11 |+  i = 1;; j = 2
-12 12 |   i = i + j; write (*, *) i;;
-13 13 | end program p;
+8  |   implicit none;
+9  |   integer :: i;
+10 |   integer :: j;
+   -   i = 1;; j = 2;
+11 +   i = 1;; j = 2
+12 |   i = i + j; write (*, *) i;;
+13 | end program p;
 
 ./resources/test/fixtures/style/S081.f90:12:29: S081 [*] unnecessary semicolon
    |
@@ -170,13 +162,12 @@ snapshot_kind: text
    |
    = help: Remove this character
 
-ℹ Safe fix
-9  9  |   integer :: i;
-10 10 |   integer :: j;
-11 11 |   i = 1;; j = 2;
-12    |-  i = i + j; write (*, *) i;;
-   12 |+  i = i + j; write (*, *) i;
-13 13 | end program p;
+9  |   integer :: i;
+10 |   integer :: j;
+11 |   i = 1;; j = 2;
+   -   i = i + j; write (*, *) i;;
+12 +   i = i + j; write (*, *) i;
+13 | end program p;
 
 ./resources/test/fixtures/style/S081.f90:13:14: S081 [*] unnecessary semicolon
    |
@@ -187,9 +178,8 @@ snapshot_kind: text
    |
    = help: Remove this character
 
-ℹ Safe fix
-10 10 |   integer :: j;
-11 11 |   i = 1;; j = 2;
-12 12 |   i = i + j; write (*, *) i;;
-13    |-end program p;
-   13 |+end program p
+10 |   integer :: j;
+11 |   i = 1;; j = 2;
+12 |   i = i + j; write (*, *) i;;
+   - end program p;
+13 + end program p

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-while-true_S301.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-while-true_S301.f90.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 ./resources/test/fixtures/style/S301.f90:88:12: S301 [*] Superfluous boolean literal '.true.' in 'do while' statement
    |
@@ -13,15 +14,14 @@ expression: diagnostics
    |
    = help: Remove 'while' statement
 
-ℹ Safe fix
-85 85 | 
-86 86 |     ! FAIL 1 -> standard.
-87 87 |     subroutine fail_1()
-88    |-        do while (.true.)
-   88 |+        do 
-89 89 |             x = x + 1
-90 90 |             if (x > 10) exit
-91 91 |         end do
+85 |
+86 |     ! FAIL 1 -> standard.
+87 |     subroutine fail_1()
+   -         do while (.true.)
+88 +         do 
+89 |             x = x + 1
+90 |             if (x > 10) exit
+91 |         end do
 
 ./resources/test/fixtures/style/S301.f90:96:12: S301 [*] Superfluous boolean literal '.true.' in 'do while' statement
    |
@@ -34,15 +34,14 @@ expression: diagnostics
    |
    = help: Remove 'while' statement
 
-ℹ Safe fix
-93 93 | 
-94 94 |     ! FAIL 2 -> case insensitive.
-95 95 |     subroutine fail_2()
-96    |-        do while (.TRUE.)
-   96 |+        do 
-97 97 |             x = x + 1
-98 98 |             if (x > 10) exit
-99 99 |         end do
+93 |
+94 |     ! FAIL 2 -> case insensitive.
+95 |     subroutine fail_2()
+   -         do while (.TRUE.)
+96 +         do 
+97 |             x = x + 1
+98 |             if (x > 10) exit
+99 |         end do
 
 ./resources/test/fixtures/style/S301.f90:104:12: S301 [*] Superfluous boolean literal '.true.' in 'do while' statement
     |
@@ -55,15 +54,14 @@ expression: diagnostics
     |
     = help: Remove 'while' statement
 
-ℹ Safe fix
-101 101 | 
-102 102 |     ! FAIL 3 -> extra whitespace.
-103 103 |     subroutine fail_3()
-104     |-        do while (  .true.  )
-    104 |+        do 
-105 105 |             x = x + 1
-106 106 |             if (x > 10) exit
-107 107 |         end do
+101 |
+102 |     ! FAIL 3 -> extra whitespace.
+103 |     subroutine fail_3()
+    -         do while (  .true.  )
+104 +         do 
+105 |             x = x + 1
+106 |             if (x > 10) exit
+107 |         end do
 
 ./resources/test/fixtures/style/S301.f90:112:20: S301 [*] Superfluous boolean literal '.true.' in 'do while' statement
     |
@@ -76,15 +74,14 @@ expression: diagnostics
     |
     = help: Remove 'while' statement
 
-ℹ Safe fix
-109 109 | 
-110 110 |     ! FAIL 4 -> do loop name.
-111 111 |     subroutine fail_4()
-112     |-        a_name: do while (.true.)
-    112 |+        a_name: do 
-113 113 |             x = x + 1
-114 114 |             if (x > 10) exit
-115 115 |         end do a_name
+109 |
+110 |     ! FAIL 4 -> do loop name.
+111 |     subroutine fail_4()
+    -         a_name: do while (.true.)
+112 +         a_name: do 
+113 |             x = x + 1
+114 |             if (x > 10) exit
+115 |         end do a_name
 
 ./resources/test/fixtures/style/S301.f90:120:12: S301 [*] Superfluous boolean literal '.true.' in 'do while' statement
     |
@@ -97,15 +94,14 @@ expression: diagnostics
     |
     = help: Remove 'while' statement
 
-ℹ Safe fix
-117 117 | 
-118 118 |     ! FAIL 5 -> with extra parentheses.
-119 119 |     subroutine fail_5()
-120     |-        do while ((.true.))
-    120 |+        do 
-121 121 |             x = x + 1
-122 122 |             if (x > 10) exit
-123 123 |         end do
+117 |
+118 |     ! FAIL 5 -> with extra parentheses.
+119 |     subroutine fail_5()
+    -         do while ((.true.))
+120 +         do 
+121 |             x = x + 1
+122 |             if (x > 10) exit
+123 |         end do
 
 ./resources/test/fixtures/style/S301.f90:128:12: S301 [*] Superfluous boolean literal '.true.' in 'do while' statement
     |
@@ -118,15 +114,14 @@ expression: diagnostics
     |
     = help: Remove 'while' statement
 
-ℹ Safe fix
-125 125 | 
-126 126 |     ! FAIL 6 -> with lots of extra parentheses.
-127 127 |     subroutine fail_6()
-128     |-        do while (((((((.true.)))))))
-    128 |+        do 
-129 129 |             x = x + 1
-130 130 |             if (x > 10) exit
-131 131 |         end do
+125 |
+126 |     ! FAIL 6 -> with lots of extra parentheses.
+127 |     subroutine fail_6()
+    -         do while (((((((.true.)))))))
+128 +         do 
+129 |             x = x + 1
+130 |             if (x > 10) exit
+131 |         end do
 
 ./resources/test/fixtures/style/S301.f90:136:12: S301 [*] Superfluous boolean literal '.true.' in 'do while' statement
     |
@@ -142,17 +137,16 @@ expression: diagnostics
     |
     = help: Remove 'while' statement
 
-ℹ Safe fix
-133 133 | 
-134 134 |     ! FAIL 7 -> line continuation in logical expression.
-135 135 |     subroutine fail_7()
-136     |-        do while (&
-137     |-                .true.&
-138     |-                )
-    136 |+        do 
-139 137 |             x = x + 1
-140 138 |             if (x > 10) some_logical = .false.
-141 139 |         end do
+133 |
+134 |     ! FAIL 7 -> line continuation in logical expression.
+135 |     subroutine fail_7()
+    -         do while (&
+    -                 .true.&
+    -                 )
+136 +         do 
+137 |             x = x + 1
+138 |             if (x > 10) some_logical = .false.
+139 |         end do
 
 ./resources/test/fixtures/style/S301.f90:146:12: S301 [*] Superfluous boolean literal '.true.' in 'do while' statement
     |
@@ -167,13 +161,12 @@ expression: diagnostics
     |
     = help: Remove 'while' statement
 
-ℹ Safe fix
-143 143 | 
-144 144 |     ! FAIL 8 -> line continuation between "while" and logical expression.
-145 145 |     subroutine fail_8()
-146     |-        do while &
-147     |-                (.true.)
-    146 |+        do 
-148 147 |             x = x + 1
-149 148 |             if (x > 10) some_logical = .false.
-150 149 |         end do
+143 |
+144 |     ! FAIL 8 -> line continuation between "while" and logical expression.
+145 |     subroutine fail_8()
+    -         do while &
+    -                 (.true.)
+146 +         do 
+147 |             x = x + 1
+148 |             if (x > 10) some_logical = .false.
+149 |         end do

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__trailing-whitespace_S101.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__trailing-whitespace_S101.f90.snap
@@ -1,5 +1,5 @@
 ---
-source: fortitude/src/rules/style/mod.rs
+source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
 snapshot_kind: text
 ---
@@ -12,12 +12,11 @@ snapshot_kind: text
   |
   = help: Remove trailing whitespace
 
-ℹ Safe fix
-1   |-program test  
-  1 |+program test
-2 2 |   implicit none
-3 3 |   integer :: a(3) = [ & 
-4 4 |     1, &
+  - program test  
+1 + program test
+2 |   implicit none
+3 |   integer :: a(3) = [ & 
+4 |     1, &
 
 ./resources/test/fixtures/style/S101.f90:3:24: S101 [*] trailing whitespace
   |
@@ -30,14 +29,13 @@ snapshot_kind: text
   |
   = help: Remove trailing whitespace
 
-ℹ Safe fix
-1 1 | program test  
-2 2 |   implicit none
-3   |-  integer :: a(3) = [ & 
-  3 |+  integer :: a(3) = [ &
-4 4 |     1, &
-5 5 |     2, &
-6 6 |     3 &
+1 | program test  
+2 |   implicit none
+  -   integer :: a(3) = [ & 
+3 +   integer :: a(3) = [ &
+4 |     1, &
+5 |     2, &
+6 |     3 &
 
 ./resources/test/fixtures/style/S101.f90:7:4: S101 [*] trailing whitespace
   |
@@ -50,14 +48,13 @@ snapshot_kind: text
   |
   = help: Remove trailing whitespace
 
-ℹ Safe fix
-4 4 |     1, &
-5 5 |     2, &
-6 6 |     3 &
-7   |-  ]    
-  7 |+  ]
-8 8 |    
-9 9 | end program test
+4 |     1, &
+5 |     2, &
+6 |     3 &
+  -   ]    
+7 +   ]
+8 |    
+9 | end program test
 
 ./resources/test/fixtures/style/S101.f90:8:1: S101 [*] trailing whitespace
   |
@@ -69,10 +66,9 @@ snapshot_kind: text
   |
   = help: Remove trailing whitespace
 
-ℹ Safe fix
-5 5 |     2, &
-6 6 |     3 &
-7 7 |   ]    
-8   |-   
-  8 |+
-9 9 | end program test
+5 |     2, &
+6 |     3 &
+7 |   ]    
+  -    
+8 +
+9 | end program test

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unnamed-end-statement_S061.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unnamed-end-statement_S061.f90.snap
@@ -14,15 +14,14 @@ snapshot_kind: text
   |
   = help: Write as 'end type mytype'.
 
-ℹ Safe fix
-3 3 |   type mytype
-4 4 |     integer :: x
-5 5 |     ! catch this
-6   |-  end type
-  6 |+  end type mytype
-7 7 | contains
-8 8 |   subroutine mysub1()
-9 9 |     write (*,*) 'hello world'
+3 |   type mytype
+4 |     integer :: x
+5 |     ! catch this
+  -   end type
+6 +   end type mytype
+7 | contains
+8 |   subroutine mysub1()
+9 |     write (*,*) 'hello world'
 
 ./resources/test/fixtures/style/S061.f90:11:3: S061 [*] end statement should be named.
    |
@@ -35,15 +34,14 @@ snapshot_kind: text
    |
    = help: Write as 'end subroutine mysub1'.
 
-ℹ Safe fix
-8  8  |   subroutine mysub1()
-9  9  |     write (*,*) 'hello world'
-10 10 |     ! catch this
-11    |-  end subroutine
-   11 |+  end subroutine mysub1
-12 12 |   subroutine mysub2()
-13 13 |     write (*,*) 'hello world'
-14 14 |     ! ignore this
+8  |   subroutine mysub1()
+9  |     write (*,*) 'hello world'
+10 |     ! catch this
+   -   end subroutine
+11 +   end subroutine mysub1
+12 |   subroutine mysub2()
+13 |     write (*,*) 'hello world'
+14 |     ! ignore this
 
 ./resources/test/fixtures/style/S061.f90:17:1: S061 [*] end statement should be named.
    |
@@ -56,15 +54,14 @@ snapshot_kind: text
    |
    = help: Write as 'end module mymod1'.
 
-ℹ Safe fix
-14 14 |     ! ignore this
-15 15 |   end subroutine mysub2
-16 16 |   ! catch this
-17    |-end
-   17 |+end module mymod1
-18 18 | module mymod2
-19 19 |   implicit none
-20 20 |   type mytype
+14 |     ! ignore this
+15 |   end subroutine mysub2
+16 |   ! catch this
+   - end
+17 + end module mymod1
+18 | module mymod2
+19 |   implicit none
+20 |   type mytype
 
 ./resources/test/fixtures/style/S061.f90:28:3: S061 [*] end statement should be named.
    |
@@ -77,15 +74,14 @@ snapshot_kind: text
    |
    = help: Write as 'end function myfunc1'.
 
-ℹ Safe fix
-25 25 |   integer function myfunc1()
-26 26 |     myfunc1 = 1
-27 27 |     ! catch this
-28    |-  end function
-   28 |+  end function myfunc1
-29 29 |   integer function myfunc2()
-30 30 |     myfunc2 = 1
-31 31 |     ! ignore this
+25 |   integer function myfunc1()
+26 |     myfunc1 = 1
+27 |     ! catch this
+   -   end function
+28 +   end function myfunc1
+29 |   integer function myfunc2()
+30 |     myfunc2 = 1
+31 |     ! ignore this
 
 ./resources/test/fixtures/style/S061.f90:34:1: S061 [*] end statement should be named.
    |
@@ -98,15 +94,14 @@ snapshot_kind: text
    |
    = help: Write as 'end module mymod2'.
 
-ℹ Safe fix
-31 31 |     ! ignore this
-32 32 |   end function myfunc2
-33 33 |   ! catch this
-34    |-end module
-   34 |+end module mymod2
-35 35 | module mymod3
-36 36 |   interface
-37 37 |     module function foo() result(x)
+31 |     ! ignore this
+32 |   end function myfunc2
+33 |   ! catch this
+   - end module
+34 + end module mymod2
+35 | module mymod3
+36 |   interface
+37 |     module function foo() result(x)
 
 ./resources/test/fixtures/style/S061.f90:56:3: S061 [*] end statement should be named.
    |
@@ -119,15 +114,14 @@ snapshot_kind: text
    |
    = help: Write as 'end procedure foo'.
 
-ℹ Safe fix
-53 53 |   module procedure foo
-54 54 |     x = 1
-55 55 |     ! catch this
-56    |-  end procedure
-   56 |+  end procedure foo
-57 57 |   ! catch this
-58 58 | end
-59 59 | submodule (mymod3) mysub2
+53 |   module procedure foo
+54 |     x = 1
+55 |     ! catch this
+   -   end procedure
+56 +   end procedure foo
+57 |   ! catch this
+58 | end
+59 | submodule (mymod3) mysub2
 
 ./resources/test/fixtures/style/S061.f90:58:1: S061 [*] end statement should be named.
    |
@@ -140,15 +134,14 @@ snapshot_kind: text
    |
    = help: Write as 'end submodule mysub1'.
 
-ℹ Safe fix
-55 55 |     ! catch this
-56 56 |   end procedure
-57 57 |   ! catch this
-58    |-end
-   58 |+end submodule mysub1
-59 59 | submodule (mymod3) mysub2
-60 60 | contains
-61 61 |   module procedure bar
+55 |     ! catch this
+56 |   end procedure
+57 |   ! catch this
+   - end
+58 + end submodule mysub1
+59 | submodule (mymod3) mysub2
+60 | contains
+61 |   module procedure bar
 
 ./resources/test/fixtures/style/S061.f90:66:1: S061 [*] end statement should be named.
    |
@@ -161,15 +154,14 @@ snapshot_kind: text
    |
    = help: Write as 'end submodule mysub2'.
 
-ℹ Safe fix
-63 63 |     ! ignore this
-64 64 |   end procedure bar
-65 65 |   ! catch this
-66    |-end submodule
-   66 |+end submodule mysub2
-67 67 | submodule (mymod3) mysub3
-68 68 | contains
-69 69 |   module procedure baz
+63 |     ! ignore this
+64 |   end procedure bar
+65 |   ! catch this
+   - end submodule
+66 + end submodule mysub2
+67 | submodule (mymod3) mysub3
+68 | contains
+69 |   module procedure baz
 
 ./resources/test/fixtures/style/S061.f90:79:1: S061 [*] end statement should be named.
    |
@@ -182,15 +174,14 @@ snapshot_kind: text
    |
    = help: Write as 'end program myprog'.
 
-ℹ Safe fix
-76 76 |   implicit none
-77 77 |   write (*,*) 'hello world'
-78 78 |   ! catch this
-79    |-end
-   79 |+end program myprog
-80 80 | 
-81 81 | ! uppercase versions, check preserve case
-82 82 | MODULE MYMOD1_UPPER
+76 |   implicit none
+77 |   write (*,*) 'hello world'
+78 |   ! catch this
+   - end
+79 + end program myprog
+80 |
+81 | ! uppercase versions, check preserve case
+82 | MODULE MYMOD1_UPPER
 
 ./resources/test/fixtures/style/S061.f90:87:3: S061 [*] end statement should be named.
    |
@@ -203,15 +194,14 @@ snapshot_kind: text
    |
    = help: Write as 'END TYPE MYTYPE'.
 
-ℹ Safe fix
-84 84 |   TYPE MYTYPE
-85 85 |     INTEGER :: X
-86 86 |     ! CATCH THIS
-87    |-  END TYPE
-   87 |+  END TYPE MYTYPE
-88 88 | CONTAINS
-89 89 |   SUBROUTINE MYSUB1()
-90 90 |     WRITE (*,*) 'HELLO WORLD'
+84 |   TYPE MYTYPE
+85 |     INTEGER :: X
+86 |     ! CATCH THIS
+   -   END TYPE
+87 +   END TYPE MYTYPE
+88 | CONTAINS
+89 |   SUBROUTINE MYSUB1()
+90 |     WRITE (*,*) 'HELLO WORLD'
 
 ./resources/test/fixtures/style/S061.f90:92:3: S061 [*] end statement should be named.
    |
@@ -224,15 +214,14 @@ snapshot_kind: text
    |
    = help: Write as 'END SUBROUTINE MYSUB1'.
 
-ℹ Safe fix
-89 89 |   SUBROUTINE MYSUB1()
-90 90 |     WRITE (*,*) 'HELLO WORLD'
-91 91 |     ! CATCH THIS
-92    |-  END SUBROUTINE
-   92 |+  END SUBROUTINE MYSUB1
-93 93 |   SUBROUTINE MYSUB2()
-94 94 |     WRITE (*,*) 'HELLO WORLD'
-95 95 |     ! IGNORE THIS
+89 |   SUBROUTINE MYSUB1()
+90 |     WRITE (*,*) 'HELLO WORLD'
+91 |     ! CATCH THIS
+   -   END SUBROUTINE
+92 +   END SUBROUTINE MYSUB1
+93 |   SUBROUTINE MYSUB2()
+94 |     WRITE (*,*) 'HELLO WORLD'
+95 |     ! IGNORE THIS
 
 ./resources/test/fixtures/style/S061.f90:98:1: S061 [*] end statement should be named.
     |
@@ -245,15 +234,14 @@ snapshot_kind: text
     |
     = help: Write as 'END MODULE MYMOD1_UPPER'.
 
-ℹ Safe fix
-95 95 |     ! IGNORE THIS
-96 96 |   END SUBROUTINE MYSUB2
-97 97 |   ! CATCH THIS
-98    |-END
-   98 |+END MODULE MYMOD1_UPPER
-99 99 | MODULE MYMOD2_UPPER
-100 100 |   IMPLICIT NONE
-101 101 |   TYPE MYTYPE
+95  |     ! IGNORE THIS
+96  |   END SUBROUTINE MYSUB2
+97  |   ! CATCH THIS
+    - END
+98  + END MODULE MYMOD1_UPPER
+99  | MODULE MYMOD2_UPPER
+100 |   IMPLICIT NONE
+101 |   TYPE MYTYPE
 
 ./resources/test/fixtures/style/S061.f90:109:3: S061 [*] end statement should be named.
     |
@@ -266,15 +254,14 @@ snapshot_kind: text
     |
     = help: Write as 'END FUNCTION MYFUNC1'.
 
-ℹ Safe fix
-106 106 |   INTEGER FUNCTION MYFUNC1()
-107 107 |     MYFUNC1 = 1
-108 108 |     ! CATCH THIS
-109     |-  END FUNCTION
-    109 |+  END FUNCTION MYFUNC1
-110 110 |   INTEGER FUNCTION MYFUNC2()
-111 111 |     MYFUNC2 = 1
-112 112 |     ! IGNORE THIS
+106 |   INTEGER FUNCTION MYFUNC1()
+107 |     MYFUNC1 = 1
+108 |     ! CATCH THIS
+    -   END FUNCTION
+109 +   END FUNCTION MYFUNC1
+110 |   INTEGER FUNCTION MYFUNC2()
+111 |     MYFUNC2 = 1
+112 |     ! IGNORE THIS
 
 ./resources/test/fixtures/style/S061.f90:115:1: S061 [*] end statement should be named.
     |
@@ -285,9 +272,8 @@ snapshot_kind: text
     |
     = help: Write as 'END MODULE MYMOD2_UPPER'.
 
-ℹ Safe fix
-112 112 |     ! IGNORE THIS
-113 113 |   END FUNCTION MYFUNC2
-114 114 |   ! CATCH THIS
-115     |-END MODULE
-    115 |+END MODULE MYMOD2_UPPER
+112 |     ! IGNORE THIS
+113 |   END FUNCTION MYFUNC2
+114 |   ! CATCH THIS
+    - END MODULE
+115 + END MODULE MYMOD2_UPPER

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unsorted-uses_S271.f90.snap
@@ -18,20 +18,19 @@ snapshot_kind: text
   |
   = help: Sort `use` statements
 
-ℹ Safe fix
-1 1 | module test_module
-2   |-	use module_z_with_tab, only: fun_z_with_tab
-  2 |+  use, intrinsic :: iso_fortran_env, ONLY: int32
-  3 |+    USE module_a, only: fun_a !! module_a inline comments
-3 4 |   use module_c, only: fun_c3, &
-4 5 |                       fun_c2, & !! fun_c2 comments
-5 6 |                       fun_c1
-6   |-  use, intrinsic :: iso_fortran_env, ONLY: int32
-7   |-    USE module_a, only: fun_a !! module_a inline comments
-  7 |+	use module_z_with_tab, only: fun_z_with_tab
-8 8 |   USE module_z, only: fun_z
-9 9 |   use module_no_only
-10 10 | 
+1  | module test_module
+   - 	use module_z_with_tab, only: fun_z_with_tab
+2  +   use, intrinsic :: iso_fortran_env, ONLY: int32
+3  +     USE module_a, only: fun_a !! module_a inline comments
+4  |   use module_c, only: fun_c3, &
+5  |                       fun_c2, & !! fun_c2 comments
+6  |                       fun_c1
+   -   use, intrinsic :: iso_fortran_env, ONLY: int32
+   -     USE module_a, only: fun_a !! module_a inline comments
+7  + 	use module_z_with_tab, only: fun_z_with_tab
+8  |   USE module_z, only: fun_z
+9  |   use module_no_only
+10 |
 
 ./resources/test/fixtures/style/S271.f90:13:3: S271 [*] `use` statements are not sorted
    |
@@ -46,17 +45,16 @@ snapshot_kind: text
    |
    = help: Sort `use` statements
 
-ℹ Safe fix
-10 10 | 
-11 11 |   use module_single, only: fun_single
-12 12 | 
-   13 |+  use, intrinsic :: iso_c_binding, only: fun_i
-13 14 |   use, intrinsic :: iso_fortran_env, only: real64
-14 15 |   use aa_non_intrinsic_module_d, only: fun_d
-15    |-  use, intrinsic :: iso_c_binding, only: fun_i
-16 16 | 
-17 17 |   implicit none (type, external)
-18 18 | 
+10 |
+11 |   use module_single, only: fun_single
+12 |
+13 +   use, intrinsic :: iso_c_binding, only: fun_i
+14 |   use, intrinsic :: iso_fortran_env, only: real64
+15 |   use aa_non_intrinsic_module_d, only: fun_d
+   -   use, intrinsic :: iso_c_binding, only: fun_i
+16 |
+17 |   implicit none (type, external)
+18 |
 
 ./resources/test/fixtures/style/S271.f90:22:5: S271 [*] `use` statements are not sorted
    |
@@ -71,20 +69,19 @@ snapshot_kind: text
    |
    = help: Sort `use` statements
 
-ℹ Safe fix
-19 19 |   private
-20 20 |   contains
-21 21 |   real function compute_something(x, y)
-   22 |+    use, intrinsic :: ieee_arithmetic, only: fun_a
-   23 |+    use, intrinsic :: iso_fortran_env, only: real64, int32
-   24 |+    use another_package, only: helper, util
-22 25 |     use custom_math, only: fun_m
-23    |-    use another_package, only: helper, util
-24    |-    use, intrinsic :: iso_fortran_env, only: real64, int32
-25    |-    use, intrinsic :: ieee_arithmetic, only: fun_a
-26 26 |     real(real64), intent(in) :: x, y
-27 27 | 
-28 28 |     compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)
+19 |   private
+20 |   contains
+21 |   real function compute_something(x, y)
+22 +     use, intrinsic :: ieee_arithmetic, only: fun_a
+23 +     use, intrinsic :: iso_fortran_env, only: real64, int32
+24 +     use another_package, only: helper, util
+25 |     use custom_math, only: fun_m
+   -     use another_package, only: helper, util
+   -     use, intrinsic :: iso_fortran_env, only: real64, int32
+   -     use, intrinsic :: ieee_arithmetic, only: fun_a
+26 |     real(real64), intent(in) :: x, y
+27 |
+28 |     compute_something = helper(x) + util(y) + real(ieee_max(x,y), real64)
 
 ./resources/test/fixtures/style/S271.f90:32:5: S271 [*] `use` statements are not sorted
    |
@@ -99,20 +96,19 @@ snapshot_kind: text
    |
    = help: Sort `use` statements
 
-ℹ Safe fix
-29 29 |   end function compute_something
-30 30 | 
-31 31 |   subroutine test_comments_as_separator()
-32    |-    !! fun_c is used for...
-33    |-    use module_c, only: fun_c
-34 32 |     use module_a, only: fun_a
-35 33 |     ! fun_b is used for...
-36 34 |     use module_b, only: fun_b
-   35 |+    !! fun_c is used for...
-   36 |+    use module_c, only: fun_c
-37 37 |   end subroutine test_comments_as_separator
-38 38 | 
-39 39 |   subroutine test_freeform()
+29 |   end function compute_something
+30 |
+31 |   subroutine test_comments_as_separator()
+   -     !! fun_c is used for...
+   -     use module_c, only: fun_c
+32 |     use module_a, only: fun_a
+33 |     ! fun_b is used for...
+34 |     use module_b, only: fun_b
+35 +     !! fun_c is used for...
+36 +     use module_c, only: fun_c
+37 |   end subroutine test_comments_as_separator
+38 |
+39 |   subroutine test_freeform()
 
 ./resources/test/fixtures/style/S271.f90:40:5: S271 [*] `use` statements are not sorted
    |
@@ -127,15 +123,14 @@ snapshot_kind: text
    |
    = help: Sort `use` statements
 
-ℹ Safe fix
-37 37 |   end subroutine test_comments_as_separator
-38 38 | 
-39 39 |   subroutine test_freeform()
-   40 |+    use module_a
-   41 |+    use module_e
-40 42 |     use module_f, only: fun_f
-41    |-    use module_a
-42 43 |     use module_z, only: fun_z; use module_b; use module_c, only: fun_c
-43    |-    use module_e
-44 44 |   end subroutine test_freeform
-45 45 | end module test_module
+37 |   end subroutine test_comments_as_separator
+38 |
+39 |   subroutine test_freeform()
+40 +     use module_a
+41 +     use module_e
+42 |     use module_f, only: fun_f
+   -     use module_a
+43 |     use module_z, only: fun_z; use module_b; use module_c, only: fun_c
+   -     use module_e
+44 |   end subroutine test_freeform
+45 | end module test_module

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__useless-return_S251.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__useless-return_S251.f90.snap
@@ -13,14 +13,13 @@ snapshot_kind: text
    |
    = help: remove `return` statement
 
-ℹ Safe fix
-8  8  |       return
-9  9  |     end if
-10 10 |     capped_add = a + b
-11    |-    return
-12 11 |   end function capped_add
-13 12 | 
-14 13 |   integer function capped_sub(a, b)
+8  |       return
+9  |     end if
+10 |     capped_add = a + b
+   -     return
+11 |   end function capped_add
+12 |
+13 |   integer function capped_sub(a, b)
 
 ./resources/test/fixtures/style/S251.f90:21:5: S251 [*] useless `return` statement`
    |
@@ -32,11 +31,10 @@ snapshot_kind: text
    |
    = help: remove `return` statement
 
-ℹ Safe fix
-18 18 |       return
-19 19 |     end if
-20 20 |     capped_sub = a - b
-21    |-    return
-22 21 |     ! but with comments
-23 22 | 
-24 23 |     ! and whitespace after
+18 |       return
+19 |     end if
+20 |     capped_sub = a - b
+   -     return
+21 |     ! but with comments
+22 |
+23 |     ! and whitespace after


### PR DESCRIPTION
Ruff's new diff style only includes a single line of column numbers, and is probably easier to read?

This is partly in advance of the incoming diagnostic changes, but also ruff now displays the diff in its normal output too.

Old format:

```text
ℹ Safe fix
22 22 |       "Hello world!"; end if
23 23 | 
24 24 |   ! Raise an error if the body is on a new line.
25    |-  if (condition) &
26    |-      print *, "Hello"
   25 |+  if (condition) then
   26 |+    print *, "Hello"
   27 |+  end if
27 28 |       print *, "World!"
28 29 | 
29 30 |   ! Misleading semicolons: the second statement in the body should be placed
```

new format:
```
22 |       "Hello world!"; end if
23 |
24 |   ! Raise an error if the body is on a new line.
   -   if (condition) &
   -       print *, "Hello"
25 +   if (condition) then
26 +     print *, "Hello"
27 +   end if
28 |       print *, "World!"
29 |
30 |   ! Misleading semicolons: the second statement in the body should be placed
```