### PR TITLE
Add `.gitattributes` file to enforce specific line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+
+crates/fortitude_linter/resources/test/fixtures/style/S101_crlf.f90 text eol=crlf
+
+*.md.snap linguist-language=Markdown

--- a/crates/fortitude_linter/resources/test/fixtures/style/S101_crlf.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/style/S101_crlf.f90
@@ -1,0 +1,9 @@
+program test  
+  implicit none
+  integer :: a(3) = [ & 
+    1, &
+    2, &
+    3 &
+  ]    
+   
+end program test

--- a/crates/fortitude_linter/src/rules/style/mod.rs
+++ b/crates/fortitude_linter/src/rules/style/mod.rs
@@ -42,6 +42,7 @@ mod tests {
     #[test_case(Rule::SuperfluousSemicolon, Path::new("S081.f90"))]
     #[test_case(Rule::MultipleStatementsPerLine, Path::new("S082.f90"))]
     #[test_case(Rule::TrailingWhitespace, Path::new("S101.f90"))]
+    #[test_case(Rule::TrailingWhitespace, Path::new("S101_crlf.f90"))]
     #[test_case(Rule::IncorrectSpaceBeforeComment, Path::new("S102.f90"))]
     #[test_case(Rule::IncorrectSpaceAroundDoubleColon, Path::new("S103.f90"))]
     #[test_case(Rule::IncorrectSpaceBetweenBrackets, Path::new("S104.f90"))]

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__trailing-whitespace_S101_crlf.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__trailing-whitespace_S101_crlf.f90.snap
@@ -1,0 +1,74 @@
+---
+source: crates/fortitude_linter/src/rules/style/mod.rs
+expression: diagnostics
+snapshot_kind: text
+---
+./resources/test/fixtures/style/S101_crlf.f90:1:13: S101 [*] trailing whitespace
+  |
+1 | program test  
+  |             ^^ S101
+2 |   implicit none
+3 |   integer :: a(3) = [ & 
+  |
+  = help: Remove trailing whitespace
+
+  - program test  
+1 + program test
+2 |   implicit none
+3 |   integer :: a(3) = [ & 
+4 |     1, &
+
+./resources/test/fixtures/style/S101_crlf.f90:3:24: S101 [*] trailing whitespace
+  |
+1 | program test  
+2 |   implicit none
+3 |   integer :: a(3) = [ & 
+  |                        ^ S101
+4 |     1, &
+5 |     2, &
+  |
+  = help: Remove trailing whitespace
+
+1 | program test  
+2 |   implicit none
+  -   integer :: a(3) = [ & 
+3 +   integer :: a(3) = [ &
+4 |     1, &
+5 |     2, &
+6 |     3 &
+
+./resources/test/fixtures/style/S101_crlf.f90:7:4: S101 [*] trailing whitespace
+  |
+5 |     2, &
+6 |     3 &
+7 |   ]    
+  |    ^^^^ S101
+8 |    
+9 | end program test
+  |
+  = help: Remove trailing whitespace
+
+4 |     1, &
+5 |     2, &
+6 |     3 &
+  -   ]    
+7 +   ]
+8 |    
+9 | end program test
+
+./resources/test/fixtures/style/S101_crlf.f90:8:1: S101 [*] trailing whitespace
+  |
+6 |     3 &
+7 |   ]    
+8 |    
+  | ^^^ S101
+9 | end program test
+  |
+  = help: Remove trailing whitespace
+
+5 |     2, &
+6 |     3 &
+7 |   ]    
+  -    
+8 +
+9 | end program test


### PR DESCRIPTION
Also add test for `crlf` (Windows) line endings for `trailing-whitespace`, allows us to check Windows line endings work even on Linux

Closes #661