### PR TITLE
Add new ReturnInProgram rule.

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/portability/PORT041.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/portability/PORT041.f90
@@ -1,0 +1,75 @@
+program test_pass_program
+
+    integer :: y = add_one(5)
+    integer :: z = 10
+
+    if (y == 6) stop  ! all OK.
+
+    do i=1,10
+        if (i > y) stop  ! all OK.
+    end do
+
+    call minus_one(z)
+
+    stop  ! all OK.
+
+contains
+
+    integer function add_one(value)
+        integer, intent(in) :: value
+        add_one = value + 1
+        return  ! all OK.
+    end function add_one
+
+    subroutine minus_one(value)
+        integer, intent(inout) :: value
+        value = value - 1
+        return  ! all OK.
+    end subroutine minus_one
+
+end program test_pass_program
+
+
+module test_pass_module
+contains
+
+    SUBROUTINE multiply_by_two(value)
+        integer, intent(inout) :: value
+        value = value * 2
+        return !  all OK.
+    end subroutine multiply_by_two
+
+end module test_pass_module
+
+! ****************************************** !
+
+program test_fail
+
+    integer :: y = add_one(5)
+    integer :: z = 10
+
+    if (y == 6) return  ! not OK.
+
+    do i=1,10
+        if (i > y) return  ! not OK.
+    end do
+
+    call minus_one(z)
+
+    return  ! not OK.
+
+contains
+
+    integer function add_one(inp)
+        integer, intent(in) :: inp
+        add_one = inp + 1
+        return  ! all OK.
+    end function add_one
+
+    subroutine minus_one(value)
+        integer, intent(inout) :: value
+        value = value - 1
+        return  ! all OK.
+    end subroutine minus_one
+
+end program test_fail

--- a/crates/fortitude_linter/src/rules/mod.rs
+++ b/crates/fortitude_linter/src/rules/mod.rs
@@ -129,6 +129,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Portability, "012") => (RuleGroup::Stable, Ast, Default, portability::literal_kinds::LiteralKindSuffix),
         (Portability, "021") => (RuleGroup::Stable, Ast, Default, portability::star_kinds::StarKind),
         (Portability, "031") => (RuleGroup::Stable, None, Default, portability::invalid_tab::InvalidTab),
+        (Portability, "041") => (RuleGroup::Preview, Ast, Optional, portability::return_in_program::ReturnInProgram),
 
         // style
         (Style, "001") => (RuleGroup::Stable, None, Default, style::line_length::LineTooLong),

--- a/crates/fortitude_linter/src/rules/portability/mod.rs
+++ b/crates/fortitude_linter/src/rules/portability/mod.rs
@@ -1,6 +1,7 @@
 pub mod invalid_tab;
 pub(crate) mod literal_kinds;
 pub(crate) mod non_portable_io_unit;
+pub mod return_in_program;
 pub(crate) mod star_kinds;
 
 #[cfg(test)]
@@ -23,6 +24,7 @@ mod tests {
     #[test_case(Rule::LiteralKindSuffix, Path::new("PORT012.f90"))]
     #[test_case(Rule::StarKind, Path::new("PORT021.f90"))]
     #[test_case(Rule::InvalidTab, Path::new("PORT031.f90"))]
+    #[test_case(Rule::ReturnInProgram, Path::new("PORT041.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/fortitude_linter/src/rules/portability/return_in_program.rs
+++ b/crates/fortitude_linter/src/rules/portability/return_in_program.rs
@@ -1,0 +1,68 @@
+use crate::ast::FortitudeNode;
+use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
+use crate::{AstRule, CheckContext};
+use fortitude_macros::ViolationMetadata;
+use ruff_macros::derive_message_formats;
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks for use of `return` statement inside a `program` body, as allowed by some compilers.
+/// Suggests to replace it with `stop`.
+///
+/// ## Why is this bad?
+/// It is non-standard and not portable.
+///
+/// ## Example
+/// ```f90
+/// program test
+///   return
+/// end program test
+/// ```
+///
+/// Use instead:
+/// ```f90
+/// program test
+///   stop
+/// end program test
+/// ```
+#[derive(ViolationMetadata)]
+pub(crate) struct ReturnInProgram;
+
+impl AlwaysFixableViolation for ReturnInProgram {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "'return' statement in program body".to_string()
+    }
+
+    fn fix_title(&self) -> String {
+        "Replace 'return' with 'stop'".to_string()
+    }
+}
+
+impl AstRule for ReturnInProgram {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        if !node
+            .child(0)?
+            .to_text(context.source_text())?
+            .eq_ignore_ascii_case("return")
+        {
+            return None;
+        }
+
+        for ancestor in node.ancestors() {
+            if matches!(
+                ancestor.kind(),
+                "function" | "subroutine" | "module" | "submodule" | "block_data"
+            ) {
+                return None;
+            }
+        }
+
+        let fix = Fix::safe_edit(node.edit_replacement(context.source_file(), "stop".to_string()));
+        some_vec!(context.create_diagnostic(Self {}, node).with_fix(fix))
+    }
+
+    fn entrypoints() -> Vec<&'static str> {
+        vec!["keyword_statement"]
+    }
+}

--- a/crates/fortitude_linter/src/rules/portability/snapshots/fortitude_linter__rules__portability__tests__return-in-program_PORT041.f90.snap
+++ b/crates/fortitude_linter/src/rules/portability/snapshots/fortitude_linter__rules__portability__tests__return-in-program_PORT041.f90.snap
@@ -1,0 +1,61 @@
+---
+source: crates/fortitude_linter/src/rules/portability/mod.rs
+expression: diagnostics
+---
+./resources/test/fixtures/portability/PORT041.f90:51:17: PORT041 [*] 'return' statement in program body
+   |
+49 |     integer :: z = 10
+50 |
+51 |     if (y == 6) return  ! not OK.
+   |                 ^^^^^^ PORT041
+52 |
+53 |     do i=1,10
+   |
+   = help: Replace 'return' with 'stop'
+
+48 |     integer :: y = add_one(5)
+49 |     integer :: z = 10
+50 |
+   -     if (y == 6) return  ! not OK.
+51 +     if (y == 6) stop  ! not OK.
+52 |
+53 |     do i=1,10
+54 |         if (i > y) return  ! not OK.
+
+./resources/test/fixtures/portability/PORT041.f90:54:20: PORT041 [*] 'return' statement in program body
+   |
+53 |     do i=1,10
+54 |         if (i > y) return  ! not OK.
+   |                    ^^^^^^ PORT041
+55 |     end do
+   |
+   = help: Replace 'return' with 'stop'
+
+51 |     if (y == 6) return  ! not OK.
+52 |
+53 |     do i=1,10
+   -         if (i > y) return  ! not OK.
+54 +         if (i > y) stop  ! not OK.
+55 |     end do
+56 |
+57 |     call minus_one(z)
+
+./resources/test/fixtures/portability/PORT041.f90:59:5: PORT041 [*] 'return' statement in program body
+   |
+57 |     call minus_one(z)
+58 |
+59 |     return  ! not OK.
+   |     ^^^^^^ PORT041
+60 |
+61 | contains
+   |
+   = help: Replace 'return' with 'stop'
+
+56 |
+57 |     call minus_one(z)
+58 |
+   -     return  ! not OK.
+59 +     stop  ! not OK.
+60 |
+61 | contains
+62 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -130,6 +130,7 @@
 | PORT012 | [literal-kind-suffix](rules/literal-kind-suffix.md) | '{literal}' has literal kind suffix '{suffix}' | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | PORT021 | [star-kind](rules/star-kind.md) | '{dtype}{size}' uses non-standard syntax | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | PORT031 | [invalid-tab](rules/invalid-tab.md) | Invalid tab character | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| PORT041 | [return-in-program](rules/return-in-program.md) | 'return' statement in program body | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 
 ### Fortitude (FORT)
 

--- a/docs/rules/return-in-program.md
+++ b/docs/rules/return-in-program.md
@@ -1,0 +1,25 @@
+# return-in-program (PORT041)
+Fix is always available.
+
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for use of `return` statement inside a `program` body, as allowed by some compilers.
+Suggests to replace it with `stop`.
+
+## Why is this bad?
+It is non-standard and not portable.
+
+## Example
+```f90
+program test
+  return
+end program test
+```
+
+Use instead:
+```f90
+program test
+  stop
+end program test
+```


### PR DESCRIPTION
@LiamPattinson @ZedThree

**Add new ReturnInProgram rule.**
- Checks if a `return` statement is inside the body of a `program`. If so, will recommend to replace the statement with `stop`.
- Put in "Portability" rule with number 041.
- Allows `return` statement inside `function`, `subroutine`, `module`, `submodule`, `block_data`. (Latter 3 I don't think are possible but added as safeguards (?))

Closes #548 