### PR TITLE
Add rule `shadowed-variable`

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C201_shadowed_variable.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C201_shadowed_variable.f90
@@ -1,0 +1,50 @@
+module my_mod
+
+  implicit none (type, external)
+  private
+
+  real, allocatable :: x(:)
+
+contains
+
+  subroutine initialise(n)
+    integer, intent(in) :: n
+    real, allocatable :: x(:)  ! This is a bug!
+
+    allocate(x(n))
+
+  end subroutine initialise
+
+  subroutine selection_sort(arr)
+    real, intent(inout) :: arr(:)
+    integer :: i
+
+    do i = 1, size(arr)
+      call helper(arr(i:size(arr)))
+    end do
+
+  contains
+
+    !! Finds minimum element of an array, swaps it with the start
+    subroutine helper(arr)
+      real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
+      real :: min_val
+      integer :: min_idx
+      integer :: i  ! Allowed: is a loop variable
+
+      min_val = arr(1)
+      min_idx = 1
+      do i = 1, size(arr)
+        if (arr(i) < min_val) then
+          min_val = arr(i)
+          min_idx = i
+        end if
+      end do
+      arr(min_idx) = arr(1)
+      arr(1) = min_val
+
+    end subroutine helper
+
+  end subroutine selection_sort
+
+end module my_mod

--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C201_shadowed_variable.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C201_shadowed_variable.f90
@@ -1,5 +1,7 @@
 module my_mod
 
+  use, intrinsic :: iso_fortran_env, only: real32
+
   implicit none (type, external)
   private
 
@@ -10,6 +12,7 @@ contains
   subroutine initialise(n)
     integer, intent(in) :: n
     real, allocatable :: x(:)  ! This is a bug!
+    real :: real32 ! This is a bug!
 
     allocate(x(n))
 

--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C201_shadowed_variable.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C201_shadowed_variable.f90
@@ -18,9 +18,9 @@ contains
 
   end subroutine initialise
 
-  subroutine selection_sort(arr)
-    use some_mod, only: x => y  ! This is a bug!
-    real, intent(inout) :: arr(:)
+  subroutine selection_sort(Arr)
+    use some_mod, only: X => y  ! This is a bug!
+    real, intent(inout) :: Arr(:)
     integer :: i
 
     do i = 1, size(arr)

--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C201_shadowed_variable.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C201_shadowed_variable.f90
@@ -19,6 +19,7 @@ contains
   end subroutine initialise
 
   subroutine selection_sort(arr)
+    use some_mod, only: x => y  ! This is a bug!
     real, intent(inout) :: arr(:)
     integer :: i
 

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -8,7 +8,8 @@ use crate::{ast::types::ProcedureKind, traits::HasNode};
 use super::{
     FortitudeNode,
     types::{
-        HasName, Module, Name, Procedure, Program, TypeDefinition, Variable, VariableDeclaration,
+        HasName, Module, Name, Procedure, Program, TypeDefinition, UseStatement, UsedItem,
+        Variable, VariableDeclaration,
     },
 };
 
@@ -39,6 +40,7 @@ pub enum Symbol<'a> {
     Type(TypeDefinition<'a>),
     Module(Module<'a>),
     Program(Program<'a>),
+    UsedItem(UsedItem<'a>),
 }
 
 impl<'a> Symbol<'a> {
@@ -49,6 +51,7 @@ impl<'a> Symbol<'a> {
             Self::Type(typedef) => typedef.name(),
             Self::Module(module) => module.name(),
             Self::Program(program) => program.name(),
+            Self::UsedItem(item) => item.name(),
         }
     }
 }
@@ -61,6 +64,7 @@ impl<'a> HasNode<'a> for Symbol<'a> {
             Self::Type(typedef) => typedef.node(),
             Self::Module(module) => module.node(),
             Self::Program(program) => program.node(),
+            Self::UsedItem(item) => item.node(),
         }
     }
 }
@@ -76,6 +80,7 @@ impl<'a> HasNode<'a> for Symbol<'a> {
 pub struct SymbolTable<'a> {
     inner: HashMap<String, Symbol<'a>>,
     decl_lines: Vec<Rc<VariableDeclaration<'a>>>,
+    use_statements: Vec<Rc<UseStatement<'a>>>,
 }
 
 impl<'a> SymbolTable<'a> {
@@ -104,6 +109,12 @@ impl<'a> SymbolTable<'a> {
                 }
             }
         }
+
+        scope
+            .named_children(&mut scope.walk())
+            .filter(|child| child.kind() == "use_statement")
+            .filter_map(|stmt| UseStatement::try_from_node(&stmt, src).ok())
+            .for_each(|stmt| new_table.insert_from_use_statement(stmt, src));
 
         scope
             .named_children(&mut scope.walk())
@@ -187,6 +198,22 @@ impl<'a> SymbolTable<'a> {
         self.decl_lines.push(decl);
     }
 
+    /// Insert all symbols found in a single use statement
+    pub fn insert_from_use_statement(&mut self, stmt: UseStatement<'a>, src: &str) {
+        let stmt = Rc::new(stmt);
+        if let Some(items) = stmt.included_items() {
+            for item in items.named_children(&mut items.walk()) {
+                // Other nodes such as comments can be found in the list
+                if let Some(item) = UsedItem::try_from_node(item, src, stmt.clone()) {
+                    let symbol = Symbol::UsedItem(item);
+                    let name = symbol.name().as_str().to_ascii_lowercase();
+                    self.inner.insert(name, symbol);
+                }
+            }
+        }
+        self.use_statements.push(stmt);
+    }
+
     /// Return the symbol with the given name if it exists
     pub fn get(&self, name: &str) -> Option<&Symbol<'_>> {
         self.inner.get(name)
@@ -195,6 +222,11 @@ impl<'a> SymbolTable<'a> {
     /// Iterator over the variable declaration lines
     pub fn iter_decl_lines(&self) -> impl Iterator<Item = &Rc<VariableDeclaration<'a>>> {
         self.decl_lines.iter()
+    }
+
+    /// Iterator over the use statements
+    pub fn iter_use_statements(&self) -> impl Iterator<Item = &Rc<UseStatement<'a>>> {
+        self.use_statements.iter()
     }
 
     /// Iterator over symbols in this scope
@@ -627,6 +659,85 @@ end program foo
     }
 
     #[test]
+    fn used_items() -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .context("Error loading Fortran grammar")?;
+
+        let code = r#"
+program foo
+  use, intrinsic :: iso_fortran_env, only: i8 => int8, real32
+  use :: my_module, only: my_subroutine
+  use another_module
+end program foo
+"#;
+        let tree = parser.parse(code, None).context("Failed to parse")?;
+        let root = tree.root_node().child(0).context("Missing child")?;
+
+        let mut symbol_table = SymbolTables::default();
+        symbol_table.push_table(SymbolTable::new(&root, code));
+
+        let i8 = symbol_table.get("i8");
+        assert!(i8.is_some());
+        let i8 = i8.unwrap();
+        assert!(i8.is_used_item());
+        assert!(i8.name().as_str() == "i8");
+        let Symbol::UsedItem(i8) = i8 else {
+            panic!("Expected i8 to be a UsedItem");
+        };
+        assert!(i8.alias_of().is_some());
+        let i8_alias_of = i8.alias_of().unwrap();
+        assert!(i8_alias_of.as_str() == "int8");
+        let i8_module = i8.module_name();
+        assert!(i8_module.as_str() == "iso_fortran_env");
+
+        let real32 = symbol_table.get("real32");
+        assert!(real32.is_some());
+        let real32 = real32.unwrap();
+        assert!(real32.is_used_item());
+        assert!(real32.name().as_str() == "real32");
+        let Symbol::UsedItem(real32) = real32 else {
+            panic!("Expected real32 to be a UsedItem");
+        };
+        assert!(real32.alias_of().is_none());
+        let real32_module = real32.module_name();
+        assert!(real32_module.as_str() == "iso_fortran_env");
+
+        let iso_fortran_env = real32.decl_statement();
+        assert!(iso_fortran_env.name().as_str() == "iso_fortran_env");
+        assert!(iso_fortran_env.is_intrinsic());
+        assert!(iso_fortran_env.has_colon());
+        assert!(iso_fortran_env.has_only());
+
+        let my_subroutine = symbol_table.get("my_subroutine");
+        assert!(my_subroutine.is_some());
+        let my_subroutine = my_subroutine.unwrap();
+        assert!(my_subroutine.is_used_item());
+        let Symbol::UsedItem(my_subroutine) = my_subroutine else {
+            panic!("Expected my_subroutine to be a UsedItem");
+        };
+        assert!(my_subroutine.alias_of().is_none());
+        let my_subroutine_module = my_subroutine.module_name();
+        assert!(my_subroutine_module.as_str() == "my_module");
+
+        let my_module = my_subroutine.decl_statement();
+        assert!(my_module.name().as_str() == "my_module");
+        assert!(!my_module.is_intrinsic());
+        assert!(my_module.has_colon());
+        assert!(my_module.has_only());
+
+        let symbol_table = symbol_table.pop_table().unwrap();
+        let another_module = symbol_table.iter_use_statements().last().unwrap();
+        assert!(another_module.name().as_str() == "another_module");
+        assert!(!another_module.is_intrinsic());
+        assert!(!another_module.has_colon());
+        assert!(!another_module.has_only());
+
+        Ok(())
+    }
+
+    #[test]
     fn all_symbols() -> Result<()> {
         let mut parser = Parser::new();
         parser
@@ -635,6 +746,7 @@ end program foo
 
         let code = r#"
 program foo
+  use :: some_module, only: p, q => r
   integer :: a, b
 contains
   integer function bar(x) result(y)
@@ -651,7 +763,7 @@ end program foo
         let symbol_table = SymbolTable::new(&root, code);
 
         let count = symbol_table.iter_symbols().count();
-        assert_eq!(count, 4);
+        assert_eq!(count, 6);
 
         Ok(())
     }

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, rc::Rc};
 
+use itertools::Itertools;
 use strum_macros::EnumIs;
 use tree_sitter::Node;
 
@@ -90,25 +91,26 @@ impl<'a> SymbolTable<'a> {
         let mut new_table = Self::default();
 
         // If this is a procedure, collect a list of dummy arg names
-        let mut dummy_vars = vec![];
-        let kind = scope.kind();
-        if matches!(kind, "function" | "subroutine") {
-            let stmt = scope
+        let dummy_vars = if matches!(scope.kind(), "function" | "subroutine") {
+            scope
                 .named_child(0)
-                .expect("First child must be function/subroutine statement");
-            if let Some(params) = stmt.child_by_field_name("parameters") {
-                for child in params.named_children(&mut params.walk()) {
-                    if child.kind() == "identifier" {
-                        dummy_vars.push(
+                .expect("First child must be function/subroutine statement")
+                .child_by_field_name("parameters")
+                .map_or(vec![], |params| {
+                    params
+                        .named_children(&mut params.walk())
+                        .filter(|child| child.kind() == "identifier")
+                        .map(|child| {
                             child
                                 .to_text(src)
                                 .unwrap_or("<unknown>")
-                                .to_ascii_lowercase(),
-                        );
-                    }
-                }
-            }
-        }
+                                .to_ascii_lowercase()
+                        })
+                        .collect_vec()
+                })
+        } else {
+            vec![]
+        };
 
         scope
             .named_children(&mut scope.walk())

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -198,8 +198,8 @@ impl<'a> SymbolTables<'a> {
         self.inner.push(table);
     }
 
-    pub fn pop_table(&mut self) {
-        self.inner.pop();
+    pub fn pop_table(&mut self) -> Option<SymbolTable<'a>> {
+        self.inner.pop()
     }
 
     /// Return the symbol with the given name if it exists and is a variable

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -84,22 +84,50 @@ impl<'a> SymbolTable<'a> {
     pub fn new(scope: &Node<'a>, src: &str) -> Self {
         let mut new_table = Self::default();
 
+        // If this is a procedure, collect a list of dummy arg names
+        let mut dummy_vars = vec![];
+        let kind = scope.kind();
+        if matches!(kind, "function" | "subroutine") {
+            let stmt = scope
+                .named_child(0)
+                .expect("First child must be function/subroutine statement");
+            if let Some(params) = stmt.child_by_field_name("parameters") {
+                for child in params.named_children(&mut params.walk()) {
+                    if child.kind() == "identifier" {
+                        dummy_vars.push(
+                            child
+                                .to_text(src)
+                                .unwrap_or("<unknown>")
+                                .to_ascii_lowercase(),
+                        );
+                    }
+                }
+            }
+        }
+
         scope
             .named_children(&mut scope.walk())
             .filter(|child| child.kind() == "variable_declaration")
             .filter_map(|decl| VariableDeclaration::try_from_node(&decl, src).ok())
-            .for_each(|line| new_table.insert_from_decl_line(line));
+            .for_each(|line| new_table.insert_from_decl_line(line, &dummy_vars));
 
         // The `function` statement itself _may_ also be the declaration line if
         // it has a type as a procedure attribute. If it doesn't, then it will
         // either have an explicit decl line, which is handled above, or it's
         // implicitly typed, which we don't currently handle here at all
-        if scope.is_named() && scope.kind() == "function" {
+        if scope.kind() == "function" {
             let stmt = scope
                 .child(0)
                 .expect("`function` must have `function_statement` as zeroth child");
             if let Ok(decl) = VariableDeclaration::try_from_fn_stmt(&stmt, src) {
-                new_table.insert_from_decl_line(decl);
+                let name = decl
+                    .names()
+                    .first()
+                    .expect("Function must have a name")
+                    .name()
+                    .as_str()
+                    .to_ascii_lowercase();
+                new_table.insert_from_decl_line(decl, &[name]);
             }
         }
 
@@ -146,13 +174,14 @@ impl<'a> SymbolTable<'a> {
     }
 
     /// Insert all symbols found in a single variable declaration statement
-    pub fn insert_from_decl_line(&mut self, decl: VariableDeclaration<'a>) {
+    pub fn insert_from_decl_line(&mut self, decl: VariableDeclaration<'a>, dummy_vars: &[String]) {
         let decl = Rc::new(decl);
         for name in decl.names().iter() {
             let name_lower = name.name().as_str().to_ascii_lowercase();
+            let is_dummy_var = dummy_vars.contains(&name_lower);
             self.inner.insert(
                 name_lower,
-                Symbol::Variable(Variable::new(name.clone(), decl.clone())),
+                Symbol::Variable(Variable::new(name.clone(), is_dummy_var, decl.clone())),
             );
         }
         self.decl_lines.push(decl);
@@ -450,12 +479,14 @@ end subroutine foo
         let x = symbol_table.get_var("x");
         assert!(x.is_some());
         let x = x.unwrap();
+        assert!(x.is_dummy_var());
         assert!(x.attributes().iter().any(|attr| attr.kind().is_dimension()));
         assert!(x.has_attribute(AttributeKind::Intent(Intent::In)));
 
         let y = symbol_table.get_var("y");
         assert!(y.is_some());
         let y = y.unwrap();
+        assert!(y.is_dummy_var());
         let y_dim = y
             .attributes()
             .iter()
@@ -493,6 +524,7 @@ end function foo
         let foo = symbol_table.get_var("foo");
         assert!(foo.is_some());
         let foo = foo.unwrap();
+        assert!(!foo.is_dummy_var());
         assert!(foo.has_attribute(AttributeKind::Allocatable));
         assert!(
             foo.attributes()
@@ -524,6 +556,7 @@ end function foo
         let foo = symbol_table.get_var("foo");
         assert!(foo.is_some());
         let foo = foo.unwrap();
+        assert!(foo.is_dummy_var());
         assert!(foo.type_().is_intrinsic());
 
         Ok(())
@@ -550,6 +583,7 @@ end function foo
         let y = symbol_table.get_var("y");
         assert!(y.is_some());
         let y = y.unwrap();
+        assert!(y.is_dummy_var());
         assert!(y.type_().is_intrinsic());
 
         Ok(())

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -511,13 +511,22 @@ pub fn get_init_node_of_declarator<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
 #[derive(Clone, Debug)]
 pub struct Variable<'a> {
     name: NameDecl<'a>,
+    is_dummy_var: bool,
     /// Reference to the statement in which the variable is declared
     decl: Rc<VariableDeclaration<'a>>,
 }
 
 impl<'a> Variable<'a> {
-    pub fn new(name: NameDecl<'a>, decl: Rc<VariableDeclaration<'a>>) -> Self {
-        Self { name, decl }
+    pub fn new(name: NameDecl<'a>, is_dummy_var: bool, decl: Rc<VariableDeclaration<'a>>) -> Self {
+        Self {
+            name,
+            is_dummy_var,
+            decl,
+        }
+    }
+
+    pub fn is_dummy_var(&self) -> bool {
+        self.is_dummy_var
     }
 
     pub fn decl(&self) -> &NameDecl<'a> {

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -880,6 +880,7 @@ impl<'a> UseStatement<'a> {
             }
             if child.kind() == "::" {
                 has_colon = true;
+                break;
             }
         }
 

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -474,7 +474,7 @@ impl<'a> VariableDeclaration<'a> {
 /// declarator node, and not, say, the initialiser
 pub fn get_name_node_of_declarator<'a>(node: &Node<'a>) -> Node<'a> {
     match node.kind() {
-        "identifier" | "method_name" | "type_name" | "name" => *node,
+        "identifier" | "method_name" | "type_name" | "module_name" | "local_name" | "name" => *node,
         "sized_declarator" => node
             .named_child(0)
             .expect("sized_declarator should have named child"),
@@ -490,6 +490,9 @@ pub fn get_name_node_of_declarator<'a>(node: &Node<'a>) -> Node<'a> {
                     .expect("init/pointer_init/data_declarator should have left-hand side"),
             )
         }
+        "use_alias" => node
+            .child_with_name("local_name")
+            .expect("use_alias should have local_name child"),
         _ => unreachable!("unexpected node type in declarator ({node:?})"),
     }
 }
@@ -840,5 +843,129 @@ impl<'a> Program<'a> {
         let name = Name::from_node(&name_node, src);
 
         Ok(Self { name, node: *node })
+    }
+}
+
+/// A use statament line
+#[derive(Clone, Debug, HasName, HasNode)]
+pub struct UseStatement<'a> {
+    intrinsic: bool,
+    has_only: bool,
+    has_colon: bool,
+    name: Name<'a>,
+    node: Node<'a>,
+}
+
+impl<'a> UseStatement<'a> {
+    /// Create from `use_statement` node
+    pub fn try_from_node(node: &Node<'a>, src: &str) -> Result<Self> {
+        if node.kind() != "use_statement" {
+            return Err(anyhow!("wrong node type"));
+        }
+
+        let name = Name::from_node(
+            &node
+                .child_with_name("module_name")
+                .context("expected module_name in 'use_statement'")?,
+            src,
+        );
+
+        let has_only = node.child_with_name("included_items").is_some();
+
+        let mut intrinsic = false;
+        let mut has_colon = false;
+        for child in node.children(&mut node.walk()) {
+            if child.kind() == "intrinsic" {
+                intrinsic = true;
+            }
+            if child.kind() == "::" {
+                has_colon = true;
+            }
+        }
+
+        Ok(Self {
+            intrinsic,
+            has_only,
+            has_colon,
+            name,
+            node: *node,
+        })
+    }
+
+    pub fn included_items(&self) -> Option<Node<'a>> {
+        self.node.child_with_name("included_items")
+    }
+
+    pub fn is_intrinsic(&self) -> bool {
+        self.intrinsic
+    }
+
+    pub fn has_only(&self) -> bool {
+        self.has_only
+    }
+
+    pub fn has_colon(&self) -> bool {
+        self.has_colon
+    }
+}
+
+/// A single Fortran variable
+#[derive(Clone, Debug, HasName)]
+pub struct UsedItem<'a> {
+    name: Name<'a>,
+    alias_of: Option<Name<'a>>,
+    /// Reference to the statement in which the variable is used
+    decl: Rc<UseStatement<'a>>,
+}
+
+impl<'a> UsedItem<'a> {
+    pub fn try_from_node(node: Node<'a>, src: &str, decl: Rc<UseStatement<'a>>) -> Option<Self> {
+        if node.kind() == "identifier" {
+            let name = Name::from_node(&node, src);
+            Some(Self {
+                name,
+                alias_of: None,
+                decl,
+            })
+        } else if node.kind() == "use_alias" {
+            let name = Name::from_node(
+                &node
+                    .child_with_name("local_name")
+                    .expect("use_alias should have local_name child"),
+                src,
+            );
+            let alias_of = Name::from_node(
+                &node
+                    .child_with_name("identifier")
+                    .expect("use_alias should have identifier child"),
+                src,
+            );
+            Some(Self {
+                name,
+                alias_of: Some(alias_of),
+                decl,
+            })
+        } else {
+            // Can include comments etc
+            None
+        }
+    }
+
+    pub fn alias_of(&self) -> Option<&Name<'a>> {
+        self.alias_of.as_ref()
+    }
+
+    pub fn decl_statement(&'a self) -> &'a UseStatement<'a> {
+        self.decl.as_ref()
+    }
+
+    pub fn module_name(&self) -> &Name<'a> {
+        &self.decl.name
+    }
+}
+
+impl<'a> HasNode<'a> for UsedItem<'a> {
+    fn node(&self) -> &Node<'a> {
+        self.name.node()
     }
 }

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -299,7 +299,7 @@ pub(crate) fn check_path(
             violations.push(context.create_diagnostic(SyntaxError {}, node));
         }
 
-        if BEGIN_SCOPE_NODES.contains(&node.kind()) {
+        if node.is_named() && BEGIN_SCOPE_NODES.contains(&node.kind()) {
             let new_table = SymbolTable::new(&node, file.source_text());
 
             // Check for keyword reuse in this scope

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -33,6 +33,7 @@ use ast::FortitudeNode;
 use diagnostics::{Diagnostic, Diagnostics, FixMap, Violation};
 use fix::{FixResult, fix_file};
 use locator::Locator;
+use rules::correctness::shadowed_variable::check_shadowed_variables;
 use rules::correctness::split_escaped_quote::SplitEscapedQuote;
 use rules::error::invalid_character::check_invalid_character;
 use rules::error::syntax_error::SyntaxError;
@@ -304,6 +305,11 @@ pub(crate) fn check_path(
             // Check for keyword reuse in this scope
             if context.rules.enabled(Rule::KeywordReuse) {
                 violations.extend(check_keyword_reuse(&context, &new_table));
+            }
+
+            // Check for shadowed variables in this scope
+            if context.rules.enabled(Rule::ShadowedVariable) {
+                violations.extend(check_shadowed_variables(&context, &new_table))
             }
 
             // Run rules over variable declarations without needing to reparse

--- a/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
+++ b/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
@@ -108,7 +108,7 @@ impl AstRule for MissingExitOrCycleLabel {
 /// ```
 ///
 /// ## Settings
-/// See [allow-unnested-loops](../settings.md#check_exit-unlabelled-loops_allow-unnested-loops)
+/// See [check.exit-unlabelled-loops](../settings.md#checkexit-unlabelled-loops)
 #[derive(ViolationMetadata)]
 pub(crate) struct ExitOrCycleInUnlabelledLoop {
     name: String,

--- a/crates/fortitude_linter/src/rules/correctness/mod.rs
+++ b/crates/fortitude_linter/src/rules/correctness/mod.rs
@@ -240,8 +240,8 @@ mod tests {
         let snapshot = format!("{}_strict_{}", rule_code.as_ref(), path.to_string_lossy());
         let settings = CheckSettings {
             shadowed_variables: shadowed_variable::settings::Settings {
-                allow: vec!["array".to_string(), "x".to_string()],
                 strict: true,
+                ..shadowed_variable::settings::Settings::default()
             },
             ..CheckSettings::for_rule(rule_code)
         };

--- a/crates/fortitude_linter/src/rules/correctness/mod.rs
+++ b/crates/fortitude_linter/src/rules/correctness/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod magic_numbers;
 pub(crate) mod missing_io_specifier;
 pub(crate) mod nonportable_shortcircuit_inquiry;
 pub(crate) mod select_default;
-pub(crate) mod shadowed_variable;
+pub mod shadowed_variable;
 pub(crate) mod split_escaped_quote;
 pub(crate) mod trailing_backslash;
 pub(crate) mod unreachable_statement;
@@ -35,7 +35,7 @@ mod tests {
 
     use crate::apply_common_filters;
     use crate::registry::Rule;
-    use crate::rules::correctness::{exit_labels, use_statements};
+    use crate::rules::correctness::{exit_labels, shadowed_variable, use_statements};
     use crate::settings::{CheckSettings, FortranStandard};
     use crate::test::test_path;
 
@@ -208,6 +208,46 @@ mod tests {
         let snapshot = "c151_fix_multiple_inline_if";
         apply_common_filters!();
         assert_snapshot!(snapshot, fixed);
+        Ok(())
+    }
+
+    #[test]
+    fn c201_shadowed_variable_whitelist() -> Result<()> {
+        let rule_code = Rule::ShadowedVariable;
+        let path = Path::new("C201_shadowed_variable.f90");
+        let snapshot = format!(
+            "{}_whitelist_{}",
+            rule_code.as_ref(),
+            path.to_string_lossy()
+        );
+        let settings = CheckSettings {
+            shadowed_variables: shadowed_variable::settings::Settings {
+                allow: vec!["array".to_string(), "x".to_string()],
+                strict: false,
+            },
+            ..CheckSettings::for_rule(rule_code)
+        };
+        let diagnostics = test_path(Path::new("correctness").join(path).as_path(), &settings)?;
+        apply_common_filters!();
+        assert_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn c201_shadowed_variable_strict() -> Result<()> {
+        let rule_code = Rule::ShadowedVariable;
+        let path = Path::new("C201_shadowed_variable.f90");
+        let snapshot = format!("{}_strict_{}", rule_code.as_ref(), path.to_string_lossy());
+        let settings = CheckSettings {
+            shadowed_variables: shadowed_variable::settings::Settings {
+                allow: vec!["array".to_string(), "x".to_string()],
+                strict: true,
+            },
+            ..CheckSettings::for_rule(rule_code)
+        };
+        let diagnostics = test_path(Path::new("correctness").join(path).as_path(), &settings)?;
+        apply_common_filters!();
+        assert_snapshot!(snapshot, diagnostics);
         Ok(())
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/mod.rs
+++ b/crates/fortitude_linter/src/rules/correctness/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod magic_numbers;
 pub(crate) mod missing_io_specifier;
 pub(crate) mod nonportable_shortcircuit_inquiry;
 pub(crate) mod select_default;
+pub(crate) mod shadowed_variable;
 pub(crate) mod split_escaped_quote;
 pub(crate) mod trailing_backslash;
 pub(crate) mod unreachable_statement;
@@ -71,6 +72,7 @@ mod tests {
     #[test_case(Rule::MultipleAllocationsWithStat, Path::new("C182.f90"))]
     #[test_case(Rule::StatWithoutMessage, Path::new("C183.f90"))]
     #[test_case(Rule::UnreachableStatement, Path::new("C191.f90"))]
+    #[test_case(Rule::ShadowedVariable, Path::new("C201_shadowed_variable.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
+++ b/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
@@ -13,19 +13,18 @@ use ruff_macros::derive_message_formats;
 /// variable is being referenced in a given context. Shadowing may be
 /// unintentional, which is a common source of bugs.
 ///
-/// There are contexts in which shadowing is acceptable. For instance, if a
+/// There are contexts in which shadowing may be acceptable. For instance, if a
 /// procedure dummy argument has the same name as a module variable, this
 /// indicates that the programmer likely intends to use the dummy argument to
-/// reference the module variable. However, shadowing a module-scoped variable
-/// with a local variable is generally considered poor practice.
+/// reference the module variable.  If you want to also capture dummy arguments,
+/// the setting `check.shadowed-variables.strict` can be used to toggle this
+/// behaviour.
 ///
 /// It is also very common to reuse loop variables such as `i`, `j`, and `k` or
-/// error flags such as `err` in different scopes. Fortitude will ignore
-/// integers with common names. The setting `check.shadowed-variables.allow` can
-/// be used to add further variables to the whitelist.
-///
-/// The setting `check.shadowed-variables.strict` can be used to disallow
-/// shadowing of variables in all contexts, including dummy arguments.
+/// error flags such as `err` in different scopes. By default, Fortitude will
+/// ignore variables with common names. The setting
+/// `check.shadowed-variables.allow` can be used to modify which variables are
+/// allowed to be shadowed.
 ///
 /// ## Examples
 ///
@@ -62,7 +61,7 @@ use ruff_macros::derive_message_formats;
 ///       real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
 ///       real :: min_val
 ///       integer :: min_idx
-///       integer :: i  ! Allowed: is a loop variable
+///       integer :: i  ! Allowed: is a common loop variable
 ///
 ///       min_val = arr(1)
 ///       min_idx = 1

--- a/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
+++ b/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
@@ -17,16 +17,20 @@ use ruff_macros::derive_message_formats;
 /// variable is being referenced in a given context. Shadowing may be
 /// unintentional, which is a common source of bugs.
 ///
-/// There are contexts in which shadowing is acceptable. For instance,
-/// if a procedure dummy argument has the same name as a module variable, this is acceptable,
-/// this indicates that the programmer likely intends to use the dummy argument
-/// in preference to the module variable. However, shadowing a module variable
+/// There are contexts in which shadowing is acceptable. For instance, if a
+/// procedure dummy argument has the same name as a module variable, this
+/// indicates that the programmer likely intends to use the dummy argument to
+/// reference the module variable. However, shadowing a module-scoped variable
 /// with a local variable is generally considered poor practice.
 ///
-/// It is also very common to reuse loop variables such as `i`, `j`, and `k` or error
-/// flags such as `err` in different scopes. Fortitude will ignore integers with common
-/// names. The setting `shadowed-variables.allow` can be used to add further variables
-/// to the whitelist.
+/// It is also very common to reuse loop variables such as `i`, `j`, and `k` or
+/// error flags such as `err` in different scopes. Fortitude will ignore
+/// integers with common names. The setting `check.shadowed-variables.allow` can
+/// be used to add further variables to the whitelist.
+///
+/// The setting `check.shadowed-variables.strict` can be used to disallow
+/// shadowing of variables in all contexts, including dummy arguments, loop
+/// variables, error flags, and variables added to the whitelist.
 ///
 /// ## Examples
 ///
@@ -81,6 +85,10 @@ use ruff_macros::derive_message_formats;
 ///   end subroutine selection_sort
 ///
 /// end module my_mod
+/// ```
+///
+/// ## Settings
+/// See [check.shadowed-variables](../settings.md#checkshadowed-variables)
 #[derive(ViolationMetadata)]
 pub struct ShadowedVariable {
     name: String,
@@ -115,8 +123,10 @@ pub(crate) fn check_shadowed_variables(
     context: &CheckContext,
     symbols: &SymbolTable,
 ) -> Vec<Diagnostic> {
+    let allow = &context.settings().shadowed_variables.allow;
+    let strict = &context.settings().shadowed_variables.strict;
     // Check the names of all variables declared in the current scope
-    symbols
+    let mut diagnostics = symbols
         .iter()
         // Only check variables
         .filter_map(|(name, symbol)| {
@@ -126,8 +136,10 @@ pub(crate) fn check_shadowed_variables(
                 None
             }
         })
-        // Filter allowed integers and dummy variables
-        .filter(|(_, var)| !is_allowed_integer(var) && !var.is_dummy_var())
+        // Filter allowed integers, dummy variables, and allowed names
+        .filter(|(name, var)| {
+            *strict || (!is_allowed_integer(var) && !var.is_dummy_var() && !allow.contains(name))
+        })
         // Create diagnostic if var found in a higher scope
         .filter_map(|(name, var)| {
             if context.symbol_table().get_var(name).is_some() {
@@ -141,5 +153,30 @@ pub(crate) fn check_shadowed_variables(
                 None
             }
         })
-        .collect_vec()
+        .collect_vec();
+    diagnostics.sort();
+    diagnostics
+}
+
+pub mod settings {
+    use crate::display_settings;
+    use ruff_macros::CacheKey;
+    use std::fmt::Display;
+
+    #[derive(Debug, Default, Clone, CacheKey)]
+    pub struct Settings {
+        pub allow: Vec<String>,
+        pub strict: bool,
+    }
+
+    impl Display for Settings {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            display_settings! {
+                formatter = f,
+                namespace = "check.shadowed-variables",
+                fields = [self.allow | array, self.strict]
+            }
+            Ok(())
+        }
+    }
 }

--- a/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
+++ b/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
@@ -126,8 +126,8 @@ pub(crate) fn check_shadowed_variables(
                 None
             }
         })
-        // Filter allowed integers
-        .filter(|(_, var)| !is_allowed_integer(var))
+        // Filter allowed integers and dummy variables
+        .filter(|(_, var)| !is_allowed_integer(var) && !var.is_dummy_var())
         // Create diagnostic if var found in a higher scope
         .filter_map(|(name, var)| {
             if context.symbol_table().get_var(name).is_some() {

--- a/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
+++ b/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
@@ -1,0 +1,125 @@
+use crate::CheckContext;
+use crate::ast::symbol_table::{Symbol, SymbolTable};
+use crate::ast::types::HasName;
+use crate::diagnostics::{Diagnostic, FixAvailability, Violation};
+use fortitude_macros::ViolationMetadata;
+use itertools::Itertools;
+use ruff_macros::derive_message_formats;
+
+/// ## What it does
+/// Checks for variables that shadow those in a higher scope.
+///
+/// ## Why is this bad?
+/// Shadowing variables can lead to confusion, as it can be unclear which
+/// variable is being referenced in a given context. Shadowing may be
+/// unintentional, which is a common source of bugs.
+///
+/// There are contexts in which shadowing is acceptable. For instance,
+/// if a procedure dummy argument has the same name as a module variable, this is acceptable,
+/// this indicates that the programmer likely intends to use the dummy argument
+/// in preference to the module variable. However, shadowing a module variable
+/// with a local variable is generally considered poor practice.
+///
+/// It is also very common to reuse loop variables such as `i`, `j`, and `k` or error
+/// flags such as `err` in different scopes. Fortitude will ignore integers with common
+/// names. The setting `shadowed-variables.allow` can be used to add further variables
+/// to the whitelist.
+///
+/// ## Examples
+///
+/// ```f90
+/// module my_mod
+///
+///   implicit none (type, external)
+///   private
+///
+///   real, allocatable :: x(:)
+///
+/// contains
+///
+///   subroutine initialise(n)
+///     integer, intent(in) :: n
+///     real, allocatable :: x(:)  ! This is a bug!
+///
+///     allocate(x(n))
+///
+///   end subroutine initialise
+///
+///   subroutine selection_sort(arr)
+///     real, intent(inout) :: arr(:)
+///     integer :: i
+///
+///     do i = 1, size(arr)
+///       call helper(arr(i:size(arr)))
+///     end do
+///
+///   contains
+///
+///     !! Finds minimum element of an array, swaps it with the start
+///     subroutine helper(arr)
+///       real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
+///       real :: min_val
+///       integer :: min_idx
+///       integer :: i  ! Allowed: is a loop variable
+///
+///       min_val = arr(1)
+///       min_idx = 1
+///       do i = 1, size(arr)
+///         if (arr(i) < min_val) then
+///           min_val = arr(i)
+///           min_idx = i
+///         end if
+///       end do
+///       arr(min_idx) = arr(1)
+///       arr(1) = min_val
+///
+///     end subroutine helper
+///
+///   end subroutine selection_sort
+///
+/// end module my_mod
+#[derive(ViolationMetadata)]
+pub struct ShadowedVariable {
+    name: String,
+}
+
+// const ALLOWED_INTS: &[&'static str] = &[
+//     "i", "j", "k", "ii", "jj", "kk", "idx", "index", "err", "ierr", "ioerr", "stat", "iostat",
+//     "status",
+// ];
+
+impl Violation for ShadowedVariable {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let name = &self.name;
+        // TODO: Use new diagnostic annotations to point to higher scope variable
+        format!("Variable `{name}` shadows variable in a higher scope")
+    }
+}
+
+/// Check the symbol table for any variables that also exist at a higher scope.
+pub(crate) fn check_shadowed_variables(
+    context: &CheckContext,
+    symbols: &SymbolTable,
+) -> Vec<Diagnostic> {
+    // Check the names of all variables declared in the current scope
+    symbols
+        .iter()
+        .filter_map(|(name, symbol)| {
+            if let Symbol::Variable(symbol) = symbol
+                && let Some(_) = context.symbol_table().get_var(name)
+            {
+                Some(context.create_diagnostic(
+                    ShadowedVariable {
+                        name: name.to_string(),
+                    },
+                    symbol.name(),
+                ))
+            } else {
+                None
+            }
+        })
+        .collect_vec()
+}

--- a/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
+++ b/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
@@ -140,7 +140,7 @@ pub(crate) fn check_shadowed_variables(
             }
             if let Symbol::Variable(var) = var {
                 return !is_allowed_integer(var) && !var.is_dummy_var();
-            } 
+            }
             true
         })
         // Create diagnostic if var found in a higher scope

--- a/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
+++ b/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
@@ -142,7 +142,9 @@ pub(crate) fn check_shadowed_variables(
         })
         // Create diagnostic if var found in a higher scope
         .filter_map(|(name, var)| {
-            if context.symbol_table().get_var(name).is_some() {
+            if let Some(parent) = context.symbol_table().get(name)
+                && (parent.is_variable() || parent.is_used_item())
+            {
                 Some(context.create_diagnostic(
                     ShadowedVariable {
                         name: name.to_string(),

--- a/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
+++ b/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
@@ -1,6 +1,9 @@
 use crate::CheckContext;
-use crate::ast::symbol_table::{Symbol, SymbolTable};
 use crate::ast::types::HasName;
+use crate::ast::{
+    symbol_table::{Symbol, SymbolTable},
+    types::Variable,
+};
 use crate::diagnostics::{Diagnostic, FixAvailability, Violation};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
@@ -83,10 +86,18 @@ pub struct ShadowedVariable {
     name: String,
 }
 
-// const ALLOWED_INTS: &[&'static str] = &[
-//     "i", "j", "k", "ii", "jj", "kk", "idx", "index", "err", "ierr", "ioerr", "stat", "iostat",
-//     "status",
-// ];
+const ALLOWED_INTEGERS: &[&str] = &[
+    "i", "j", "k", "ii", "jj", "kk", "idx", "index", "err", "ierr", "ioerr", "stat", "iostat",
+    "status",
+];
+
+fn is_allowed_integer(var: &Variable) -> bool {
+    let t = var.type_();
+    let name = var.name().as_str().to_ascii_lowercase();
+    t.is_intrinsic()
+        && t.as_str().eq_ignore_ascii_case("integer")
+        && ALLOWED_INTEGERS.contains(&name.as_str())
+}
 
 impl Violation for ShadowedVariable {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
@@ -107,15 +118,24 @@ pub(crate) fn check_shadowed_variables(
     // Check the names of all variables declared in the current scope
     symbols
         .iter()
+        // Only check variables
         .filter_map(|(name, symbol)| {
-            if let Symbol::Variable(symbol) = symbol
-                && let Some(_) = context.symbol_table().get_var(name)
-            {
+            if let Symbol::Variable(var) = symbol {
+                Some((name, var))
+            } else {
+                None
+            }
+        })
+        // Filter allowed integers
+        .filter(|(_, var)| !is_allowed_integer(var))
+        // Create diagnostic if var found in a higher scope
+        .filter_map(|(name, var)| {
+            if context.symbol_table().get_var(name).is_some() {
                 Some(context.create_diagnostic(
                     ShadowedVariable {
                         name: name.to_string(),
                     },
-                    symbol.name(),
+                    var.name(),
                 ))
             } else {
                 None

--- a/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
+++ b/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
@@ -1,9 +1,5 @@
 use crate::CheckContext;
-use crate::ast::types::HasName;
-use crate::ast::{
-    symbol_table::{Symbol, SymbolTable},
-    types::Variable,
-};
+use crate::ast::symbol_table::{Symbol, SymbolTable};
 use crate::diagnostics::{Diagnostic, FixAvailability, Violation};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
@@ -29,8 +25,7 @@ use ruff_macros::derive_message_formats;
 /// be used to add further variables to the whitelist.
 ///
 /// The setting `check.shadowed-variables.strict` can be used to disallow
-/// shadowing of variables in all contexts, including dummy arguments, loop
-/// variables, error flags, and variables added to the whitelist.
+/// shadowing of variables in all contexts, including dummy arguments.
 ///
 /// ## Examples
 ///
@@ -94,19 +89,6 @@ pub struct ShadowedVariable {
     name: String,
 }
 
-const ALLOWED_INTEGERS: &[&str] = &[
-    "i", "j", "k", "ii", "jj", "kk", "idx", "index", "err", "ierr", "ioerr", "stat", "iostat",
-    "status",
-];
-
-fn is_allowed_integer(var: &Variable) -> bool {
-    let t = var.type_();
-    let name = var.name().as_str().to_ascii_lowercase();
-    t.is_intrinsic()
-        && t.as_str().eq_ignore_ascii_case("integer")
-        && ALLOWED_INTEGERS.contains(&name.as_str())
-}
-
 impl Violation for ShadowedVariable {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 
@@ -130,16 +112,13 @@ pub(crate) fn check_shadowed_variables(
         .iter()
         // Only check variables and used items
         .filter(|(_, symbol)| symbol.is_variable() || symbol.is_used_item())
-        // Filter allowed integers, dummy variables, and allowed names
+        // Filter dummy variables and allowed names
         .filter(|(name, var)| {
-            if *strict {
-                return true;
-            }
             if allow.contains(name) {
                 return false;
             }
             if let Symbol::Variable(var) = var {
-                return !is_allowed_integer(var) && !var.is_dummy_var();
+                return *strict || !var.is_dummy_var();
             }
             true
         })
@@ -168,10 +147,24 @@ pub mod settings {
     use ruff_macros::CacheKey;
     use std::fmt::Display;
 
-    #[derive(Debug, Default, Clone, CacheKey)]
+    #[derive(Debug, Clone, CacheKey)]
     pub struct Settings {
         pub allow: Vec<String>,
         pub strict: bool,
+    }
+
+    const DEFAULT_ALLOWED: &[&str] = &[
+        "i", "j", "k", "l", "m", "n", "ii", "jj", "kk", "ll", "mm", "nn", "idx", "index", "err",
+        "ierr", "ioerr", "ios", "info", "stat", "iostat", "istat", "status",
+    ];
+
+    impl Default for Settings {
+        fn default() -> Self {
+            Self {
+                allow: DEFAULT_ALLOWED.iter().map(|s| s.to_string()).collect(),
+                strict: false,
+            }
+        }
     }
 
     impl Display for Settings {

--- a/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
+++ b/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
@@ -125,20 +125,23 @@ pub(crate) fn check_shadowed_variables(
 ) -> Vec<Diagnostic> {
     let allow = &context.settings().shadowed_variables.allow;
     let strict = &context.settings().shadowed_variables.strict;
-    // Check the names of all variables declared in the current scope
+    // Check the names of all variables and used items declared in the current scope
     let mut diagnostics = symbols
         .iter()
-        // Only check variables
-        .filter_map(|(name, symbol)| {
-            if let Symbol::Variable(var) = symbol {
-                Some((name, var))
-            } else {
-                None
-            }
-        })
+        // Only check variables and used items
+        .filter(|(_, symbol)| symbol.is_variable() || symbol.is_used_item())
         // Filter allowed integers, dummy variables, and allowed names
         .filter(|(name, var)| {
-            *strict || (!is_allowed_integer(var) && !var.is_dummy_var() && !allow.contains(name))
+            if *strict {
+                return true;
+            }
+            if allow.contains(name) {
+                return false;
+            }
+            if let Symbol::Variable(var) = var {
+                return !is_allowed_integer(var) && !var.is_dummy_var();
+            } 
+            true
         })
         // Create diagnostic if var found in a higher scope
         .filter_map(|(name, var)| {

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
@@ -2,12 +2,21 @@
 source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 ---
-./resources/test/fixtures/correctness/C201_shadowed_variable.f90:12:26: C201 Variable `x` shadows variable in a higher scope
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:14:26: C201 Variable `x` shadows variable in a higher scope
    |
-10 |   subroutine initialise(n)
-11 |     integer, intent(in) :: n
-12 |     real, allocatable :: x(:)  ! This is a bug!
+12 |   subroutine initialise(n)
+13 |     integer, intent(in) :: n
+14 |     real, allocatable :: x(:)  ! This is a bug!
    |                          ^ C201
-13 |
-14 |     allocate(x(n))
+15 |     real :: real32 ! This is a bug!
+   |
+
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:15:13: C201 Variable `real32` shadows variable in a higher scope
+   |
+13 |     integer, intent(in) :: n
+14 |     real, allocatable :: x(:)  ! This is a bug!
+15 |     real :: real32 ! This is a bug!
+   |             ^^^^^^ C201
+16 |
+17 |     allocate(x(n))
    |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
@@ -23,9 +23,9 @@ expression: diagnostics
 
 ./resources/test/fixtures/correctness/C201_shadowed_variable.f90:22:25: C201 Variable `x` shadows variable in a higher scope
    |
-21 |   subroutine selection_sort(arr)
-22 |     use some_mod, only: x => y  ! This is a bug!
+21 |   subroutine selection_sort(Arr)
+22 |     use some_mod, only: X => y  ! This is a bug!
    |                         ^ C201
-23 |     real, intent(inout) :: arr(:)
+23 |     real, intent(inout) :: Arr(:)
 24 |     integer :: i
    |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
@@ -11,13 +11,3 @@ expression: diagnostics
 13 |
 14 |     allocate(x(n))
    |
-
-./resources/test/fixtures/correctness/C201_shadowed_variable.f90:30:30: C201 Variable `arr` shadows variable in a higher scope
-   |
-28 |     !! Finds minimum element of an array, swaps it with the start
-29 |     subroutine helper(arr)
-30 |       real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
-   |                              ^^^ C201
-31 |       real :: min_val
-32 |       integer :: min_idx
-   |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
@@ -20,3 +20,12 @@ expression: diagnostics
 16 |
 17 |     allocate(x(n))
    |
+
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:22:25: C201 Variable `x` shadows variable in a higher scope
+   |
+21 |   subroutine selection_sort(arr)
+22 |     use some_mod, only: x => y  ! This is a bug!
+   |                         ^ C201
+23 |     real, intent(inout) :: arr(:)
+24 |     integer :: i
+   |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
@@ -12,16 +12,6 @@ expression: diagnostics
 14 |     allocate(x(n))
    |
 
-./resources/test/fixtures/correctness/C201_shadowed_variable.f90:33:18: C201 Variable `i` shadows variable in a higher scope
-   |
-31 |       real :: min_val
-32 |       integer :: min_idx
-33 |       integer :: i  ! Allowed: is a loop variable
-   |                  ^ C201
-34 |
-35 |       min_val = arr(1)
-   |
-
 ./resources/test/fixtures/correctness/C201_shadowed_variable.f90:30:30: C201 Variable `arr` shadows variable in a higher scope
    |
 28 |     !! Finds minimum element of an array, swaps it with the start

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_C201_shadowed_variable.f90.snap
@@ -1,0 +1,33 @@
+---
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
+expression: diagnostics
+---
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:12:26: C201 Variable `x` shadows variable in a higher scope
+   |
+10 |   subroutine initialise(n)
+11 |     integer, intent(in) :: n
+12 |     real, allocatable :: x(:)  ! This is a bug!
+   |                          ^ C201
+13 |
+14 |     allocate(x(n))
+   |
+
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:33:18: C201 Variable `i` shadows variable in a higher scope
+   |
+31 |       real :: min_val
+32 |       integer :: min_idx
+33 |       integer :: i  ! Allowed: is a loop variable
+   |                  ^ C201
+34 |
+35 |       min_val = arr(1)
+   |
+
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:30:30: C201 Variable `arr` shadows variable in a higher scope
+   |
+28 |     !! Finds minimum element of an array, swaps it with the start
+29 |     subroutine helper(arr)
+30 |       real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
+   |                              ^^^ C201
+31 |       real :: min_val
+32 |       integer :: min_idx
+   |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_strict_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_strict_C201_shadowed_variable.f90.snap
@@ -21,22 +21,31 @@ expression: diagnostics
 17 |     allocate(x(n))
    |
 
-./resources/test/fixtures/correctness/C201_shadowed_variable.f90:33:30: C201 Variable `arr` shadows variable in a higher scope
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:22:25: C201 Variable `x` shadows variable in a higher scope
    |
-31 |     !! Finds minimum element of an array, swaps it with the start
-32 |     subroutine helper(arr)
-33 |       real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
-   |                              ^^^ C201
-34 |       real :: min_val
-35 |       integer :: min_idx
+21 |   subroutine selection_sort(arr)
+22 |     use some_mod, only: x => y  ! This is a bug!
+   |                         ^ C201
+23 |     real, intent(inout) :: arr(:)
+24 |     integer :: i
    |
 
-./resources/test/fixtures/correctness/C201_shadowed_variable.f90:36:18: C201 Variable `i` shadows variable in a higher scope
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:34:30: C201 Variable `arr` shadows variable in a higher scope
    |
-34 |       real :: min_val
-35 |       integer :: min_idx
-36 |       integer :: i  ! Allowed: is a loop variable
+32 |     !! Finds minimum element of an array, swaps it with the start
+33 |     subroutine helper(arr)
+34 |       real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
+   |                              ^^^ C201
+35 |       real :: min_val
+36 |       integer :: min_idx
+   |
+
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:37:18: C201 Variable `i` shadows variable in a higher scope
+   |
+35 |       real :: min_val
+36 |       integer :: min_idx
+37 |       integer :: i  ! Allowed: is a loop variable
    |                  ^ C201
-37 |
-38 |       min_val = arr(1)
+38 |
+39 |       min_val = arr(1)
    |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_strict_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_strict_C201_shadowed_variable.f90.snap
@@ -39,13 +39,3 @@ expression: diagnostics
 35 |       real :: min_val
 36 |       integer :: min_idx
    |
-
-./resources/test/fixtures/correctness/C201_shadowed_variable.f90:37:18: C201 Variable `i` shadows variable in a higher scope
-   |
-35 |       real :: min_val
-36 |       integer :: min_idx
-37 |       integer :: i  ! Allowed: is a loop variable
-   |                  ^ C201
-38 |
-39 |       min_val = arr(1)
-   |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_strict_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_strict_C201_shadowed_variable.f90.snap
@@ -2,32 +2,41 @@
 source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 ---
-./resources/test/fixtures/correctness/C201_shadowed_variable.f90:12:26: C201 Variable `x` shadows variable in a higher scope
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:14:26: C201 Variable `x` shadows variable in a higher scope
    |
-10 |   subroutine initialise(n)
-11 |     integer, intent(in) :: n
-12 |     real, allocatable :: x(:)  ! This is a bug!
+12 |   subroutine initialise(n)
+13 |     integer, intent(in) :: n
+14 |     real, allocatable :: x(:)  ! This is a bug!
    |                          ^ C201
-13 |
-14 |     allocate(x(n))
+15 |     real :: real32 ! This is a bug!
    |
 
-./resources/test/fixtures/correctness/C201_shadowed_variable.f90:30:30: C201 Variable `arr` shadows variable in a higher scope
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:15:13: C201 Variable `real32` shadows variable in a higher scope
    |
-28 |     !! Finds minimum element of an array, swaps it with the start
-29 |     subroutine helper(arr)
-30 |       real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
+13 |     integer, intent(in) :: n
+14 |     real, allocatable :: x(:)  ! This is a bug!
+15 |     real :: real32 ! This is a bug!
+   |             ^^^^^^ C201
+16 |
+17 |     allocate(x(n))
+   |
+
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:33:30: C201 Variable `arr` shadows variable in a higher scope
+   |
+31 |     !! Finds minimum element of an array, swaps it with the start
+32 |     subroutine helper(arr)
+33 |       real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
    |                              ^^^ C201
-31 |       real :: min_val
-32 |       integer :: min_idx
+34 |       real :: min_val
+35 |       integer :: min_idx
    |
 
-./resources/test/fixtures/correctness/C201_shadowed_variable.f90:33:18: C201 Variable `i` shadows variable in a higher scope
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:36:18: C201 Variable `i` shadows variable in a higher scope
    |
-31 |       real :: min_val
-32 |       integer :: min_idx
-33 |       integer :: i  ! Allowed: is a loop variable
+34 |       real :: min_val
+35 |       integer :: min_idx
+36 |       integer :: i  ! Allowed: is a loop variable
    |                  ^ C201
-34 |
-35 |       min_val = arr(1)
+37 |
+38 |       min_val = arr(1)
    |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_strict_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_strict_C201_shadowed_variable.f90.snap
@@ -23,10 +23,10 @@ expression: diagnostics
 
 ./resources/test/fixtures/correctness/C201_shadowed_variable.f90:22:25: C201 Variable `x` shadows variable in a higher scope
    |
-21 |   subroutine selection_sort(arr)
-22 |     use some_mod, only: x => y  ! This is a bug!
+21 |   subroutine selection_sort(Arr)
+22 |     use some_mod, only: X => y  ! This is a bug!
    |                         ^ C201
-23 |     real, intent(inout) :: arr(:)
+23 |     real, intent(inout) :: Arr(:)
 24 |     integer :: i
    |
 

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_strict_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_strict_C201_shadowed_variable.f90.snap
@@ -1,0 +1,33 @@
+---
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
+expression: diagnostics
+---
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:12:26: C201 Variable `x` shadows variable in a higher scope
+   |
+10 |   subroutine initialise(n)
+11 |     integer, intent(in) :: n
+12 |     real, allocatable :: x(:)  ! This is a bug!
+   |                          ^ C201
+13 |
+14 |     allocate(x(n))
+   |
+
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:30:30: C201 Variable `arr` shadows variable in a higher scope
+   |
+28 |     !! Finds minimum element of an array, swaps it with the start
+29 |     subroutine helper(arr)
+30 |       real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
+   |                              ^^^ C201
+31 |       real :: min_val
+32 |       integer :: min_idx
+   |
+
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:33:18: C201 Variable `i` shadows variable in a higher scope
+   |
+31 |       real :: min_val
+32 |       integer :: min_idx
+33 |       integer :: i  ! Allowed: is a loop variable
+   |                  ^ C201
+34 |
+35 |       min_val = arr(1)
+   |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_whitelist_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_whitelist_C201_shadowed_variable.f90.snap
@@ -2,4 +2,12 @@
 source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
 ---
-
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:15:13: C201 Variable `real32` shadows variable in a higher scope
+   |
+13 |     integer, intent(in) :: n
+14 |     real, allocatable :: x(:)  ! This is a bug!
+15 |     real :: real32 ! This is a bug!
+   |             ^^^^^^ C201
+16 |
+17 |     allocate(x(n))
+   |

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_whitelist_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_whitelist_C201_shadowed_variable.f90.snap
@@ -1,0 +1,5 @@
+---
+source: crates/fortitude_linter/src/rules/correctness/mod.rs
+expression: diagnostics
+---
+

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_whitelist_C201_shadowed_variable.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__shadowed-variable_whitelist_C201_shadowed_variable.f90.snap
@@ -11,3 +11,13 @@ expression: diagnostics
 16 |
 17 |     allocate(x(n))
    |
+
+./resources/test/fixtures/correctness/C201_shadowed_variable.f90:37:18: C201 Variable `i` shadows variable in a higher scope
+   |
+35 |       real :: min_val
+36 |       integer :: min_idx
+37 |       integer :: i  ! Allowed: is a loop variable
+   |                  ^ C201
+38 |
+39 |       min_val = arr(1)
+   |

--- a/crates/fortitude_linter/src/rules/correctness/use_statements.rs
+++ b/crates/fortitude_linter/src/rules/correctness/use_statements.rs
@@ -29,8 +29,8 @@ use tree_sitter::Node;
 /// code have come from, and avoids introducing many unneeded components to your
 /// local scope.
 ///
-/// ## Options
-/// - `check.use-statements.allow-bare-use`
+/// ## Settings
+/// See [check.use-statements](../settings.md#checkuse-statements)
 #[derive(ViolationMetadata)]
 pub(crate) struct UseAll {}
 

--- a/crates/fortitude_linter/src/rules/mod.rs
+++ b/crates/fortitude_linter/src/rules/mod.rs
@@ -112,6 +112,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Correctness, "182") => (RuleGroup::Stable, Ast, Default, correctness::error_handling::MultipleAllocationsWithStat),
         (Correctness, "183") => (RuleGroup::Stable, Ast, Optional, correctness::error_handling::StatWithoutMessage),
         (Correctness, "191") => (RuleGroup::Stable, Ast, Default, correctness::unreachable_statement::UnreachableStatement),
+        (Correctness, "201") => (RuleGroup::Preview, None, Optional, correctness::shadowed_variable::ShadowedVariable),
 
         // modernisation
         (Modernisation, "001") => (RuleGroup::Stable, Ast, Optional, modernisation::double_precision::DoublePrecision),

--- a/crates/fortitude_linter/src/rules/style/keywords.rs
+++ b/crates/fortitude_linter/src/rules/style/keywords.rs
@@ -496,7 +496,7 @@ pub(crate) fn check_keyword_reuse(
             ));
         }
     }
-    diagnostics.sort_by(|a, b| a.range().ordering(b.range()));
+    diagnostics.sort();
     diagnostics
 }
 

--- a/crates/fortitude_linter/src/settings.rs
+++ b/crates/fortitude_linter/src/settings.rs
@@ -19,7 +19,7 @@ use crate::fs::{EXCLUDE_BUILTINS, FilePatternSet, INCLUDE};
 use crate::registry::Rule;
 use crate::rule_selector::{CompiledPerFileIgnoreList, PreviewOptions, RuleSelector};
 use crate::rule_table::RuleTable;
-use crate::rules::correctness::{exit_labels, use_statements};
+use crate::rules::correctness::{exit_labels, shadowed_variable, use_statements};
 use crate::rules::portability::{self, invalid_tab};
 use crate::rules::style::{complexity, inconsistent_dimension, keywords, line_length, strings};
 
@@ -73,6 +73,7 @@ pub struct CheckSettings {
 
     // Individual rule settings
     pub exit_unlabelled_loops: exit_labels::settings::Settings,
+    pub shadowed_variables: shadowed_variable::settings::Settings,
     pub incorrect_keyword_case: keywords::settings_keyword_case::Settings,
     pub keyword_whitespace: keywords::settings::Settings,
     pub strings: strings::settings::Settings,
@@ -109,6 +110,7 @@ impl CheckSettings {
             progress_bar: ProgressBar::default(),
             preview: PreviewMode::default(),
             exit_unlabelled_loops: exit_labels::settings::Settings::default(),
+            shadowed_variables: shadowed_variable::settings::Settings::default(),
             incorrect_keyword_case: keywords::settings_keyword_case::Settings::default(),
             keyword_whitespace: keywords::settings::Settings::default(),
             strings: strings::settings::Settings::default(),
@@ -162,6 +164,7 @@ impl fmt::Display for CheckSettings {
             namespace = "check",
             fields = [
                 self.exit_unlabelled_loops | nested,
+                self.shadowed_variables | nested,
                 self.incorrect_keyword_case | nested,
                 self.keyword_whitespace | nested,
                 self.strings | nested,

--- a/crates/fortitude_workspace/src/configuration.rs
+++ b/crates/fortitude_workspace/src/configuration.rs
@@ -1,7 +1,7 @@
 use crate::options::{
     ComplexityOptions, ExitUnlabelledLoopOptions, InconsistentDimensionOptions,
     IncorrectKeywordCaseOptions, InvalidTabOptions, KeywordWhitespaceOptions, LineTooLongOptions,
-    Options, PortabilityOptions, StringOptions, UseStatementsOptions,
+    Options, PortabilityOptions, ShadowedVariableOptions, StringOptions, UseStatementsOptions,
 };
 use fortitude_linter::fs::{
     EXCLUDE_BUILTINS, FORTRAN_EXTS, FilePattern, FilePatternSet, GlobPath, INCLUDE,
@@ -249,6 +249,7 @@ pub struct Configuration {
 
     // Individual rules
     pub exit_unlabelled_loops: Option<ExitUnlabelledLoopOptions>,
+    pub shadowed_variables: Option<ShadowedVariableOptions>,
     pub incorrect_keyword_case: Option<IncorrectKeywordCaseOptions>,
     pub keyword_whitespace: Option<KeywordWhitespaceOptions>,
     pub strings: Option<StringOptions>,
@@ -328,6 +329,7 @@ impl Configuration {
 
             // Individual rules
             exit_unlabelled_loops: check.exit_unlabelled_loops,
+            shadowed_variables: check.shadowed_variables,
             incorrect_keyword_case: check.incorrect_keyword_case,
             keyword_whitespace: check.keyword_whitespace,
             strings: check.strings,
@@ -388,6 +390,10 @@ impl Configuration {
                 exit_unlabelled_loops: self
                     .exit_unlabelled_loops
                     .map(ExitUnlabelledLoopOptions::into_settings)
+                    .unwrap_or_default(),
+                shadowed_variables: self
+                    .shadowed_variables
+                    .map(ShadowedVariableOptions::into_settings)
                     .unwrap_or_default(),
                 incorrect_keyword_case: self
                     .incorrect_keyword_case
@@ -490,6 +496,7 @@ impl Configuration {
             force_exclude: self.force_exclude.or(config.force_exclude),
             respect_gitignore: self.respect_gitignore.or(config.respect_gitignore),
             exit_unlabelled_loops: self.exit_unlabelled_loops.or(config.exit_unlabelled_loops),
+            shadowed_variables: self.shadowed_variables.or(config.shadowed_variables),
             incorrect_keyword_case: self
                 .incorrect_keyword_case
                 .or(config.incorrect_keyword_case),

--- a/crates/fortitude_workspace/src/options.rs
+++ b/crates/fortitude_workspace/src/options.rs
@@ -12,7 +12,7 @@ use fortitude_linter::{
     line_width::IndentWidth,
     rule_selector::RuleSelector,
     rules::{
-        correctness::{exit_labels, use_statements},
+        correctness::{exit_labels, shadowed_variable, use_statements},
         portability::{self, invalid_tab},
         style::{
             complexity,
@@ -379,6 +379,10 @@ pub struct CheckOptions {
     #[option_group]
     pub exit_unlabelled_loops: Option<ExitUnlabelledLoopOptions>,
 
+    /// Options for the `shadowed-variable` rule
+    #[option_group]
+    pub shadowed_variables: Option<ShadowedVariableOptions>,
+
     /// Options for the `incorrect-keyword-case` rule
     #[option_group]
     pub incorrect_keyword_case: Option<IncorrectKeywordCaseOptions>,
@@ -444,6 +448,37 @@ impl ExitUnlabelledLoopOptions {
     pub fn into_settings(self) -> exit_labels::settings::Settings {
         exit_labels::settings::Settings {
             allow_unnested_loops: self.allow_unnested_loops.unwrap_or_default(),
+        }
+    }
+}
+
+/// Options for the `shadowed-variable` rule
+#[derive(
+    Clone, Debug, PartialEq, Eq, Default, OptionsMetadata, CombineOptions, Serialize, Deserialize,
+)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct ShadowedVariableOptions {
+    /// A list of variable names that are allowed to be shadowed. By default,
+    /// common loop variables and error flags are allowed to be shadowed.
+    /// Variables in this list will be ignored in addition to the default list.
+    #[option(
+        default = "[]",
+        value_type = "list[str]",
+        example = r#"allow = ["array", "x"]"#
+    )]
+    pub allow: Option<Vec<String>>,
+
+    /// Strict mode will flag any shadowed variable, including dummy arguments,
+    /// loop variables, error flags, and variables in the allow list.
+    #[option(default = "false", value_type = "bool", example = "strict = true")]
+    pub strict: Option<bool>,
+}
+
+impl ShadowedVariableOptions {
+    pub fn into_settings(self) -> shadowed_variable::settings::Settings {
+        shadowed_variable::settings::Settings {
+            allow: self.allow.unwrap_or_default(),
+            strict: self.strict.unwrap_or_default(),
         }
     }
 }

--- a/crates/fortitude_workspace/src/options.rs
+++ b/crates/fortitude_workspace/src/options.rs
@@ -460,7 +460,6 @@ impl ExitUnlabelledLoopOptions {
 pub struct ShadowedVariableOptions {
     /// A list of variable names that are allowed to be shadowed. By default,
     /// common loop variables and error flags are allowed to be shadowed.
-    /// Variables in this list will be ignored in addition to the default list.
     #[option(
         default = r#"["i", "j", "k", "l", "m", "n", "ii", "jj", "kk", "ll", "mm", "nn", "idx", "index", "err", "ierr", "ioerr", "ios", "info", "stat", "iostat", "istat", "status"]"#,
         value_type = "list[str]",
@@ -468,7 +467,7 @@ pub struct ShadowedVariableOptions {
     )]
     pub allow: Option<Vec<String>>,
 
-    /// Strict mode will also include dummy arguments.
+    /// Strict mode will also check dummy arguments for violations
     #[option(default = "false", value_type = "bool", example = "strict = true")]
     pub strict: Option<bool>,
 }

--- a/crates/fortitude_workspace/src/options.rs
+++ b/crates/fortitude_workspace/src/options.rs
@@ -462,14 +462,13 @@ pub struct ShadowedVariableOptions {
     /// common loop variables and error flags are allowed to be shadowed.
     /// Variables in this list will be ignored in addition to the default list.
     #[option(
-        default = "[]",
+        default = r#"["i", "j", "k", "l", "m", "n", "ii", "jj", "kk", "ll", "mm", "nn", "idx", "index", "err", "ierr", "ioerr", "ios", "info", "stat", "iostat", "istat", "status"]"#,
         value_type = "list[str]",
         example = r#"allow = ["array", "x"]"#
     )]
     pub allow: Option<Vec<String>>,
 
-    /// Strict mode will flag any shadowed variable, including dummy arguments,
-    /// loop variables, error flags, and variables in the allow list.
+    /// Strict mode will also include dummy arguments.
     #[option(default = "false", value_type = "bool", example = "strict = true")]
     pub strict: Option<bool>,
 }

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -47,6 +47,7 @@
 | C182 | [multiple-allocations-with-stat](rules/multiple-allocations-with-stat.md) | 'stat' parameter used with multiple {allocations}. | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | C183 | [stat-without-message](rules/stat-without-message.md) | '{stat}' used without '{errmsg}'. | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 | C191 | [unreachable-statement](rules/unreachable-statement.md) | code following `{}` is unreachable | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
+| C201 | [shadowed-variable](rules/shadowed-variable.md) | Variable `{name}` shadows variable in a higher scope | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix not available' style='opacity: 0.1' aria-hidden='true'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 
 ### Obsolescent (OB)
 

--- a/docs/rules/exit-or-cycle-in-unlabelled-loop.md
+++ b/docs/rules/exit-or-cycle-in-unlabelled-loop.md
@@ -26,4 +26,4 @@ end do
 ```
 
 ## Settings
-See [allow-unnested-loops](../settings.md#check_exit-unlabelled-loops_allow-unnested-loops)
+See [check.exit-unlabelled-loops](../settings.md#checkexit-unlabelled-loops)

--- a/docs/rules/shadowed-variable.md
+++ b/docs/rules/shadowed-variable.md
@@ -9,16 +9,20 @@ Shadowing variables can lead to confusion, as it can be unclear which
 variable is being referenced in a given context. Shadowing may be
 unintentional, which is a common source of bugs.
 
-There are contexts in which shadowing is acceptable. For instance,
-if a procedure dummy argument has the same name as a module variable, this is acceptable,
-this indicates that the programmer likely intends to use the dummy argument
-in preference to the module variable. However, shadowing a module variable
+There are contexts in which shadowing is acceptable. For instance, if a
+procedure dummy argument has the same name as a module variable, this
+indicates that the programmer likely intends to use the dummy argument to
+reference the module variable. However, shadowing a module-scoped variable
 with a local variable is generally considered poor practice.
 
-It is also very common to reuse loop variables such as `i`, `j`, and `k` or error
-flags such as `err` in different scopes. Fortitude will ignore integers with common
-names. The setting `shadowed-variables.allow` can be used to add further variables
-to the whitelist.
+It is also very common to reuse loop variables such as `i`, `j`, and `k` or
+error flags such as `err` in different scopes. Fortitude will ignore
+integers with common names. The setting `check.shadowed-variables.allow` can
+be used to add further variables to the whitelist.
+
+The setting `check.shadowed-variables.strict` can be used to disallow
+shadowing of variables in all contexts, including dummy arguments, loop
+variables, error flags, and variables added to the whitelist.
 
 ## Examples
 
@@ -73,3 +77,7 @@ contains
   end subroutine selection_sort
 
 end module my_mod
+```
+
+## Settings
+See [check.shadowed-variables](../settings.md#checkshadowed-variables)

--- a/docs/rules/shadowed-variable.md
+++ b/docs/rules/shadowed-variable.md
@@ -21,8 +21,7 @@ integers with common names. The setting `check.shadowed-variables.allow` can
 be used to add further variables to the whitelist.
 
 The setting `check.shadowed-variables.strict` can be used to disallow
-shadowing of variables in all contexts, including dummy arguments, loop
-variables, error flags, and variables added to the whitelist.
+shadowing of variables in all contexts, including dummy arguments.
 
 ## Examples
 

--- a/docs/rules/shadowed-variable.md
+++ b/docs/rules/shadowed-variable.md
@@ -1,0 +1,75 @@
+# shadowed-variable (C201)
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for variables that shadow those in a higher scope.
+
+## Why is this bad?
+Shadowing variables can lead to confusion, as it can be unclear which
+variable is being referenced in a given context. Shadowing may be
+unintentional, which is a common source of bugs.
+
+There are contexts in which shadowing is acceptable. For instance,
+if a procedure dummy argument has the same name as a module variable, this is acceptable,
+this indicates that the programmer likely intends to use the dummy argument
+in preference to the module variable. However, shadowing a module variable
+with a local variable is generally considered poor practice.
+
+It is also very common to reuse loop variables such as `i`, `j`, and `k` or error
+flags such as `err` in different scopes. Fortitude will ignore integers with common
+names. The setting `shadowed-variables.allow` can be used to add further variables
+to the whitelist.
+
+## Examples
+
+```f90
+module my_mod
+
+  implicit none (type, external)
+  private
+
+  real, allocatable :: x(:)
+
+contains
+
+  subroutine initialise(n)
+    integer, intent(in) :: n
+    real, allocatable :: x(:)  ! This is a bug!
+
+    allocate(x(n))
+
+  end subroutine initialise
+
+  subroutine selection_sort(arr)
+    real, intent(inout) :: arr(:)
+    integer :: i
+
+    do i = 1, size(arr)
+      call helper(arr(i:size(arr)))
+    end do
+
+  contains
+
+    !! Finds minimum element of an array, swaps it with the start
+    subroutine helper(arr)
+      real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
+      real :: min_val
+      integer :: min_idx
+      integer :: i  ! Allowed: is a loop variable
+
+      min_val = arr(1)
+      min_idx = 1
+      do i = 1, size(arr)
+        if (arr(i) < min_val) then
+          min_val = arr(i)
+          min_idx = i
+        end if
+      end do
+      arr(min_idx) = arr(1)
+      arr(1) = min_val
+
+    end subroutine helper
+
+  end subroutine selection_sort
+
+end module my_mod

--- a/docs/rules/shadowed-variable.md
+++ b/docs/rules/shadowed-variable.md
@@ -9,19 +9,18 @@ Shadowing variables can lead to confusion, as it can be unclear which
 variable is being referenced in a given context. Shadowing may be
 unintentional, which is a common source of bugs.
 
-There are contexts in which shadowing is acceptable. For instance, if a
+There are contexts in which shadowing may be acceptable. For instance, if a
 procedure dummy argument has the same name as a module variable, this
 indicates that the programmer likely intends to use the dummy argument to
-reference the module variable. However, shadowing a module-scoped variable
-with a local variable is generally considered poor practice.
+reference the module variable.  If you want to also capture dummy arguments,
+the setting `check.shadowed-variables.strict` can be used to toggle this
+behaviour.
 
 It is also very common to reuse loop variables such as `i`, `j`, and `k` or
-error flags such as `err` in different scopes. Fortitude will ignore
-integers with common names. The setting `check.shadowed-variables.allow` can
-be used to add further variables to the whitelist.
-
-The setting `check.shadowed-variables.strict` can be used to disallow
-shadowing of variables in all contexts, including dummy arguments.
+error flags such as `err` in different scopes. By default, Fortitude will
+ignore variables with common names. The setting
+`check.shadowed-variables.allow` can be used to modify which variables are
+allowed to be shadowed.
 
 ## Examples
 
@@ -58,7 +57,7 @@ contains
       real, intent(inout) :: arr(:) ! Allowed: is a dummy arg
       real :: min_val
       integer :: min_idx
-      integer :: i  ! Allowed: is a loop variable
+      integer :: i  ! Allowed: is a common loop variable
 
       min_val = arr(1)
       min_idx = 1

--- a/docs/rules/use-all.md
+++ b/docs/rules/use-all.md
@@ -21,9 +21,5 @@ This makes it easier for programmers to understand where the symbols in your
 code have come from, and avoids introducing many unneeded components to your
 local scope.
 
-## Options
-- [`check.use-statements.allow-bare-use`][check.use-statements.allow-bare-use]
-
-
-[check.use-statements.allow-bare-use]: ../settings.md#check_use-statements_allow-bare-use
-
+## Settings
+See [check.use-statements](../settings.md#checkuse-statements)

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1287,6 +1287,77 @@ wish to switch this to `true` -- but see also
 
 ---
 
+### `check.shadowed-variables`
+
+Options for the `shadowed-variable` rule
+
+#### [`allow`](#check_shadowed-variables_allow) {: #check_shadowed-variables_allow }
+<span id="allow"></span>
+
+A list of variable names that are allowed to be shadowed. By default,
+common loop variables and error flags are allowed to be shadowed.
+Variables in this list will be ignored in addition to the default list.
+
+**Default value**: `[]`
+
+**Type**: `list[str]`
+
+**Example usage**:
+
+=== "`fpm.toml`"
+
+    ```toml
+    [extra.fortitude.check.shadowed-variables]
+    allow = ["array", "x"]
+    ```
+=== "`fortitude.toml` or `.fortitude.toml`"
+
+    ```toml
+    [check.shadowed-variables]
+    allow = ["array", "x"]
+    ```
+=== "`pyproject.toml`"
+
+    ```toml
+    [tool.fortitude.check.shadowed-variables]
+    allow = ["array", "x"]
+    ```
+
+---
+
+#### [`strict`](#check_shadowed-variables_strict) {: #check_shadowed-variables_strict }
+<span id="strict"></span>
+
+Strict mode will flag any shadowed variable, including dummy arguments,
+loop variables, error flags, and variables in the allow list.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+=== "`fpm.toml`"
+
+    ```toml
+    [extra.fortitude.check.shadowed-variables]
+    strict = true
+    ```
+=== "`fortitude.toml` or `.fortitude.toml`"
+
+    ```toml
+    [check.shadowed-variables]
+    strict = true
+    ```
+=== "`pyproject.toml`"
+
+    ```toml
+    [tool.fortitude.check.shadowed-variables]
+    strict = true
+    ```
+
+---
+
 ### `check.strings`
 
 Options for the string literal rules

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1296,7 +1296,6 @@ Options for the `shadowed-variable` rule
 
 A list of variable names that are allowed to be shadowed. By default,
 common loop variables and error flags are allowed to be shadowed.
-Variables in this list will be ignored in addition to the default list.
 
 **Default value**: `["i", "j", "k", "l", "m", "n", "ii", "jj", "kk", "ll", "mm", "nn", "idx", "index", "err", "ierr", "ioerr", "ios", "info", "stat", "iostat", "istat", "status"]`
 
@@ -1328,7 +1327,7 @@ Variables in this list will be ignored in addition to the default list.
 #### [`strict`](#check_shadowed-variables_strict) {: #check_shadowed-variables_strict }
 <span id="strict"></span>
 
-Strict mode will also include dummy arguments.
+Strict mode will also check dummy arguments for violations
 
 **Default value**: `false`
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1298,7 +1298,7 @@ A list of variable names that are allowed to be shadowed. By default,
 common loop variables and error flags are allowed to be shadowed.
 Variables in this list will be ignored in addition to the default list.
 
-**Default value**: `[]`
+**Default value**: `["i", "j", "k", "l", "m", "n", "ii", "jj", "kk", "ll", "mm", "nn", "idx", "index", "err", "ierr", "ioerr", "ios", "info", "stat", "iostat", "istat", "status"]`
 
 **Type**: `list[str]`
 
@@ -1328,8 +1328,7 @@ Variables in this list will be ignored in addition to the default list.
 #### [`strict`](#check_shadowed-variables_strict) {: #check_shadowed-variables_strict }
 <span id="strict"></span>
 
-Strict mode will flag any shadowed variable, including dummy arguments,
-loop variables, error flags, and variables in the allow list.
+Strict mode will also include dummy arguments.
 
 **Default value**: `false`
 


### PR DESCRIPTION
Closes https://github.com/PlasmaFAIR/fortitude/issues/672

Also upgrades some AST stuff along the way.

TODO:

- [x] Better testing, try uppercase vs lowercase and more obscure scenarios. 
- [x] Expand list of 'allowed integers', I've certainly missed a few.
- [x] Capture `use`'d variables in `SymbolTable` and check those.
  - We'll need to capture aliases too
- [x] Perhaps we should also check against non-variables in higher scopes?
- [x] Add user option:

```toml
[check.shadowed_variables]
allow = ["foo", "bar"]
```