### PR TITLE
Compile time checking of node names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,8 @@ dependencies = [
  "quote",
  "regex",
  "syn",
+ "tree-sitter",
+ "tree-sitter-fortran",
 ]
 
 [[package]]

--- a/crates/fortitude_linter/src/ast.rs
+++ b/crates/fortitude_linter/src/ast.rs
@@ -6,6 +6,7 @@ use crate::{
     whitespace::{has_leading_content, has_trailing_content},
 };
 use anyhow::{Result, anyhow};
+use fortitude_macros::{kind, kw};
 use itertools::Itertools;
 use ruff_source_file::{LineRanges, SourceFile};
 use ruff_text_size::{TextRange, TextSize};
@@ -508,28 +509,28 @@ pub enum ControlFlow {
 
 impl ControlFlow {
     pub fn maybe_from(value: &Node, src: &str) -> Option<Self> {
-        if value.kind() != "keyword_statement" {
+        if value.kind_id() != kind!("keyword_statement") {
             return None;
         }
-        match value.child(0)?.to_text(src)?.to_ascii_lowercase().as_str() {
-            "continue" => Some(Self::Continue),
-            "cycle" => Some(Self::Cycle),
-            "exit" => Some(Self::Exit),
-            "return" => Some(Self::Return),
-            "stop" => Some(Self::Stop),
-            "error" => Some(Self::Stop),
+        match value.child(0)?.kind_id() {
+            kw!("continue") => Some(Self::Continue),
+            kw!("cycle") => Some(Self::Cycle),
+            kw!("exit") => Some(Self::Exit),
+            kw!("return") => Some(Self::Return),
+            kw!("stop") => Some(Self::Stop),
+            kw!("error") => Some(Self::Stop),
             keyword => Self::parse_goto(keyword, value, src),
         }
     }
 
-    fn parse_goto(keyword: &str, value: &Node, src: &str) -> Option<Self> {
-        if !matches!(keyword, "go" | "goto") {
+    fn parse_goto(keyword: u16, value: &Node, src: &str) -> Option<Self> {
+        if !matches!(keyword, kw!("go") | kw!("goto")) {
             return None;
         }
 
         // We expect either `go to N` or `goto N`.
         // Don't bother with assigned or computed gotos for now
-        let expected_ref_index = if keyword == "go" { 2 } else { 1 };
+        let expected_ref_index = if keyword == kw!("go") { 2 } else { 1 };
         if value.child_count() > expected_ref_index + 1 {
             return None;
         }

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, rc::Rc};
 
+use fortitude_macros::kind;
 use itertools::Itertools;
 use strum_macros::EnumIs;
 use tree_sitter::Node;
@@ -128,7 +129,7 @@ impl<'a> SymbolTable<'a> {
         // it has a type as a procedure attribute. If it doesn't, then it will
         // either have an explicit decl line, which is handled above, or it's
         // implicitly typed, which we don't currently handle here at all
-        if scope.kind() == "function" {
+        if scope.kind_id() == kind!("function") {
             let stmt = scope
                 .child(0)
                 .expect("`function` must have `function_statement` as zeroth child");
@@ -148,8 +149,10 @@ impl<'a> SymbolTable<'a> {
         if let Some(procs) = scope.child_with_name("internal_procedures") {
             procs
                 .named_children(&mut procs.walk())
-                .filter_map(|proc| match proc.kind() {
-                    "function" | "subroutine" => Procedure::try_from_node(&proc, src).ok(),
+                .filter_map(|proc| match proc.kind_id() {
+                    kind!("function") | kind!("subroutine") => {
+                        Procedure::try_from_node(&proc, src).ok()
+                    }
                     _ => None,
                 })
                 .for_each(|proc| {

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -4,9 +4,8 @@ use std::{rc::Rc, str::FromStr};
 
 use anyhow::{Context, Result, anyhow};
 use bitflags::bitflags;
-use fortitude_macros::{HasName, HasNode};
+use fortitude_macros::{HasName, HasNode, kind, kw};
 use itertools::Itertools;
-use ruff_source_file::SourceFile;
 use strum_macros::{Display, EnumIs, EnumString, IntoStaticStr};
 use tree_sitter::Node;
 
@@ -594,23 +593,26 @@ pub(crate) struct ImplicitStatement<'a> {
 }
 
 impl<'a> ImplicitStatement<'a> {
-    pub fn try_from_node(node: Node<'a>, src: &SourceFile) -> Option<Self> {
+    pub fn try_from_node(node: Node<'a>) -> Option<Self> {
         if node.kind() != "implicit_statement" {
             return None;
         }
-        let text = node.to_text(src.source_text()).map(|t| t.to_lowercase())?;
         let mut none_type = ImplicitNoneType::empty();
-        if !text.contains("none") {
+        let ids = node
+            .descendants()
+            .map(|child| child.kind_id())
+            .collect_vec();
+        if !ids.contains(&kind!("none")) {
             return Some(Self { node, none_type });
         }
-        if text.contains("type") {
+        if ids.contains(&kw!("type")) {
             none_type |= ImplicitNoneType::TYPE;
         }
-        if text.contains("external") {
+        if ids.contains(&kw!("external")) {
             none_type |= ImplicitNoneType::EXTERNAL;
         }
         // If the (type, external) part is missing, then 'type' is implied
-        if !text.contains("type") && !text.contains("external") {
+        if !ids.contains(&kw!("type")) && !ids.contains(&kw!("external")) {
             none_type = ImplicitNoneType::TYPE;
         }
         Some(Self { node, none_type })
@@ -618,13 +620,17 @@ impl<'a> ImplicitStatement<'a> {
 
     /// Determine the implicit typing scheme of a
     /// program/module/submodule/function/subroutine node.
-    pub fn try_from_scope(node: &'a Node, src: &SourceFile) -> Option<Self> {
+    pub fn try_from_scope(node: &'a Node) -> Option<Self> {
         if matches!(
-            node.kind(),
-            "module" | "submodule" | "program" | "function" | "subroutine"
+            node.kind_id(),
+            kind!("module")
+                | kind!("submodule")
+                | kind!("program")
+                | kind!("function")
+                | kind!("subroutine")
         ) {
             if let Some(child) = node.child_with_name("implicit_statement") {
-                return ImplicitStatement::try_from_node(child, src);
+                return ImplicitStatement::try_from_node(child);
             }
             return None;
         }
@@ -668,8 +674,8 @@ pub struct ProcedureAttribute<'a> {
 }
 
 impl<'a> ProcedureAttribute<'a> {
-    pub fn try_from_node(node: Node<'a>, src: &str) -> Result<Self> {
-        let kind = ProcedureAttributeKind::from_str(node.to_text(src).context("expected text")?)?;
+    pub fn try_from_node(node: Node<'a>) -> Result<Self> {
+        let kind = ProcedureAttributeKind::from_str(node.kind())?;
         Ok(Self { kind, node })
     }
 
@@ -713,8 +719,8 @@ impl<'a> Procedure<'a> {
 
         let attributes: Result<Vec<_>> = stmt
             .named_children(&mut stmt.walk())
-            .filter(|attr| attr.kind() == "procedure_qualifier")
-            .map(|attr| ProcedureAttribute::try_from_node(attr, src))
+            .filter(|attr| attr.kind_id() == kind!("procedure_qualifier"))
+            .map(ProcedureAttribute::try_from_node)
             .collect();
         let attributes = attributes?;
 

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -1,3 +1,4 @@
+use fortitude_macros::kind;
 use line_filter::FilterSet;
 use ruff_text_size::Ranged;
 pub use rule_selector::RuleSelector;
@@ -332,8 +333,10 @@ pub(crate) fn check_path(
             Rule::SuperfluousElseCycle,
             Rule::SuperfluousElseExit,
             Rule::SuperfluousElseStop,
-        ]) && matches!(node.kind(), "keyword_statement" | "stop_statement")
-            && let Some(violation) = check_superfluous_returns(&context, &node)
+        ]) && matches!(
+            node.kind_id(),
+            kind!("keyword_statement") | kind!("stop_statement")
+        ) && let Some(violation) = check_superfluous_returns(&context, &node)
         {
             violations.push(violation);
         }

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -74,7 +74,7 @@ pub trait AstRule {
     fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>>;
 
     /// Return list of tree-sitter node types on which a rule should trigger.
-    fn entrypoints() -> Vec<&'static str>;
+    fn entrypoints() -> Vec<u16>;
 }
 
 pub struct CheckContext<'a> {
@@ -338,7 +338,7 @@ pub(crate) fn check_path(
             violations.push(violation);
         }
 
-        if let Some(rules) = context.rules.ast_entrypoints().get(node.kind()) {
+        if let Some(rules) = context.rules.ast_entrypoints().get(&node.kind_id()) {
             for rule in rules {
                 if let Some(violation) = rule.check(&context, &node) {
                     violations.extend(violation);

--- a/crates/fortitude_linter/src/rule_table.rs
+++ b/crates/fortitude_linter/src/rule_table.rs
@@ -20,7 +20,7 @@ pub struct RuleTable {
     enabled: RuleSet,
     should_fix: RuleSet,
     #[cache_key(ignore)]
-    ast_entrypoints: OnceLock<BTreeMap<&'static str, Vec<AstRuleEnum>>>,
+    ast_entrypoints: OnceLock<BTreeMap<u16, Vec<AstRuleEnum>>>,
 }
 
 impl RuleTable {
@@ -79,9 +79,9 @@ impl RuleTable {
 
     /// Return a mapping of AST entrypoints to lists of the rules and codes that
     /// operate on them.
-    pub fn ast_entrypoints(&self) -> &BTreeMap<&'static str, Vec<AstRuleEnum>> {
+    pub fn ast_entrypoints(&self) -> &BTreeMap<u16, Vec<AstRuleEnum>> {
         self.ast_entrypoints.get_or_init(|| {
-            let mut map: BTreeMap<&'static str, Vec<_>> = BTreeMap::new();
+            let mut map: BTreeMap<u16, Vec<_>> = BTreeMap::new();
 
             self.iter_enabled()
                 .filter_map(|rule| TryFrom::try_from(rule).ok())

--- a/crates/fortitude_linter/src/rules/correctness/accessibility_statements.rs
+++ b/crates/fortitude_linter/src/rules/correctness/accessibility_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -63,8 +63,8 @@ impl AstRule for MissingAccessibilityStatement {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["module_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["module_statement"]
     }
 }
 
@@ -105,7 +105,7 @@ impl AstRule for DefaultPublicAccessibility {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["public_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["public_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/assumed_size.rs
+++ b/crates/fortitude_linter/src/rules/correctness/assumed_size.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::settings::FortranStandard;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
@@ -107,8 +107,8 @@ impl AstRule for AssumedSize {
         Some(all_decls)
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["assumed_size"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["assumed_size"]
     }
 }
 
@@ -249,7 +249,7 @@ impl AstRule for AssumedSizeCharacterIntent {
         Some(all_decls)
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["assumed_size"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["assumed_size"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/conditionals.rs
+++ b/crates/fortitude_linter/src/rules/correctness/conditionals.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_source_file::{LineEnding, SourceFile, find_newline};
@@ -96,8 +96,8 @@ impl AstRule for MisleadingInlineIfSemicolon {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["if_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["if_statement"]
     }
 }
 
@@ -169,8 +169,8 @@ impl AstRule for MisleadingInlineIfContinuation {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["if_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["if_statement"]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/correctness/derived_default_init.rs
+++ b/crates/fortitude_linter/src/rules/correctness/derived_default_init.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Edit, Fix, Violation};
 use crate::settings::FortranStandard;
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -124,7 +124,7 @@ impl AstRule for MissingDefaultPointerInitalisation {
         Some(violations)
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["variable_declaration"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["variable_declaration"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/error_handling.rs
+++ b/crates/fortitude_linter/src/rules/correctness/error_handling.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use anyhow::{Context, Result, anyhow};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
@@ -204,8 +204,8 @@ impl AstRule for UncheckedStat {
         ))
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec![
+    fn entrypoints() -> Vec<u16> {
+        kind_ids![
             "allocate_statement",
             "deallocate_statement",
             "open_statement",
@@ -369,8 +369,8 @@ impl AstRule for MultipleAllocationsWithStat {
         some_vec!(context.create_diagnostic(Self { alloc_type }, stat_node))
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["allocate_statement", "deallocate_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["allocate_statement", "deallocate_statement"]
     }
 }
 
@@ -439,8 +439,8 @@ impl AstRule for StatWithoutMessage {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec![
+    fn entrypoints() -> Vec<u16> {
+        kind_ids![
             "allocate_statement",
             "deallocate_statement",
             "open_statement",

--- a/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
+++ b/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
@@ -4,7 +4,7 @@ use crate::diagnostics::{
 };
 use crate::traits::TextRanged;
 use crate::{AstRule, CheckContext, kind_ids};
-use fortitude_macros::ViolationMetadata;
+use fortitude_macros::{ViolationMetadata, kind, kw};
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
 
@@ -53,10 +53,11 @@ impl AstRule for MissingExitOrCycleLabel {
 
         let violations: Vec<Diagnostic> = node
             .named_descendants_except(["do_loop"])
-            .filter(|node| node.kind() == "keyword_statement")
-            .map(|stmt| (stmt, stmt.to_text(src).unwrap_or_default().to_lowercase()))
-            .filter(|(_, name)| name == "exit" || name == "cycle")
-            .map(|(stmt, name)| {
+            .filter(|node| node.kind_id() == kind!("keyword_statement"))
+            .filter_map(|node| node.child(0))
+            .filter(|child| matches!(child.kind_id(), kw!("exit") | kw!("cycle")))
+            .filter(|child| child.next_named_sibling().is_none())
+            .map(|stmt| {
                 let label_with_space = format!(" {label}");
                 let edit = Edit::insertion(label_with_space, stmt.end_textsize());
                 let fix = Fix::unsafe_edit(edit);
@@ -64,7 +65,7 @@ impl AstRule for MissingExitOrCycleLabel {
                 context
                     .create_diagnostic(
                         Self {
-                            name: name.to_string(),
+                            name: stmt.kind().to_string(),
                             label: label.to_string(),
                         },
                         stmt,
@@ -133,7 +134,7 @@ impl AstRule for ExitOrCycleInUnlabelledLoop {
 
         let parent_loop = node
             .ancestors()
-            .filter(|ancestor| ancestor.kind() == "do_loop")
+            .filter(|ancestor| ancestor.kind_id() == kind!("do_loop"))
             .nth(0)?;
 
         // Immediate parent loop has a label, but we don't want to warn here, because
@@ -154,7 +155,7 @@ impl AstRule for ExitOrCycleInUnlabelledLoop {
         {
             parent_loop
                 .ancestors()
-                .filter(|ancestor| ancestor.kind() == "do_loop")
+                .filter(|ancestor| ancestor.kind_id() == kind!("do_loop"))
                 .nth(0)?;
         }
 

--- a/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
+++ b/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
@@ -3,7 +3,7 @@ use crate::diagnostics::{
     AlwaysFixableViolation, Diagnostic, Edit, Fix, FixAvailability, Violation,
 };
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -76,8 +76,8 @@ impl AstRule for MissingExitOrCycleLabel {
         Some(violations)
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["do_loop"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["do_loop"]
     }
 }
 
@@ -161,8 +161,8 @@ impl AstRule for ExitOrCycleInUnlabelledLoop {
         some_vec!(context.create_diagnostic(Self { name }, node))
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["keyword_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["keyword_statement"]
     }
 }
 
@@ -255,8 +255,8 @@ impl AstRule for MissingEndLabel {
         Some(vec![violation])
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec![
+    fn entrypoints() -> Vec<u16> {
+        kind_ids![
             "associate_statement",
             "block_construct",
             "coarray_critical_statement",

--- a/crates/fortitude_linter/src/rules/correctness/external.rs
+++ b/crates/fortitude_linter/src/rules/correctness/external.rs
@@ -3,7 +3,7 @@ use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
 
-use crate::{AstRule, CheckContext, ast::FortitudeNode};
+use crate::{AstRule, CheckContext, ast::FortitudeNode, kind_ids};
 
 /// ## What does it do?
 /// Checks for procedures declared with just `external`
@@ -49,8 +49,8 @@ impl AstRule for ExternalProcedure {
         some_vec!(context.create_diagnostic(Self { name }, node))
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["variable_modification"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["variable_modification"]
     }
 }
 
@@ -87,7 +87,7 @@ impl AstRule for ProcedureNotInModule {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["function", "subroutine"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["function", "subroutine"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/implicit_kinds.rs
+++ b/crates/fortitude_linter/src/rules/correctness/implicit_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -73,7 +73,7 @@ impl AstRule for ImplicitRealKind {
         some_vec![context.create_diagnostic(ImplicitRealKind { dtype }, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["intrinsic_type"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["intrinsic_type"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
+++ b/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
@@ -3,7 +3,7 @@ use crate::ast::{FortitudeNode, types::ImplicitStatement};
 use crate::diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use crate::settings::FortranStandard;
 use crate::traits::{HasNode, TextRanged};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_source_file::SourceFile;
@@ -187,8 +187,8 @@ impl AstRule for ImplicitTyping {
         ]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["module", "submodule", "program", "subroutine", "function"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["module", "submodule", "program", "subroutine", "function"]
     }
 }
 
@@ -238,8 +238,8 @@ impl AstRule for InterfaceImplicitTyping {
         ]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["function", "subroutine"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["function", "subroutine"]
     }
 }
 
@@ -300,7 +300,7 @@ impl AstRule for ImplicitExternalProcedures {
         )
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["implicit_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["implicit_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
+++ b/crates/fortitude_linter/src/rules/correctness/implicit_typing.rs
@@ -4,7 +4,7 @@ use crate::diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use crate::settings::FortranStandard;
 use crate::traits::{HasNode, TextRanged};
 use crate::{AstRule, CheckContext, kind_ids};
-use fortitude_macros::ViolationMetadata;
+use fortitude_macros::{ViolationMetadata, kw};
 use ruff_macros::derive_message_formats;
 use ruff_source_file::SourceFile;
 use tree_sitter::Node;
@@ -46,16 +46,16 @@ fn replace_with_implicit_none(node: &Node, src: &SourceFile) -> Edit {
 
 /// Assuming we have `implicit none (external)` for some cursed reason, adds
 /// `type` to it to make it `implicit none (type, external)`.
-fn add_type_to_implicit_none(node: &Node, src: &SourceFile) -> Option<Edit> {
+fn add_type_to_implicit_none(node: &Node) -> Option<Edit> {
     node.children(&mut node.walk())
-        .find(|child| child.to_text(src.source_text()).unwrap().to_lowercase() == "external")
+        .find(|child| child.kind_id() == kw!("external"))
         .map(|external_node| Edit::insertion("type, ".to_string(), external_node.start_textsize()))
 }
 
 // Add `(external)` to `implicit none (type)` or `(type, external)` to `implicit none`.
-fn add_external_to_implicit_none(node: &Node, src: &SourceFile) -> Edit {
+fn add_external_to_implicit_none(node: &Node) -> Edit {
     node.children(&mut node.walk())
-        .find(|child| child.to_text(src.source_text()).unwrap().to_lowercase() == "type")
+        .find(|child| child.kind_id() == kw!("type"))
         .map_or_else(
             || Edit::insertion(" (type, external)".to_string(), node.end_textsize()),
             |type_node| Edit::insertion(", external".to_string(), type_node.end_textsize()),
@@ -87,7 +87,7 @@ impl ImplicitTypingEdit {
     /// Called on the scope that should contain an `implicit none` statement.
     /// Returns an edit if a violation is found, otherwise returns `None`.
     fn try_from_scope(node: &Node, src: &SourceFile) -> Option<Self> {
-        match ImplicitStatement::try_from_scope(node, src) {
+        match ImplicitStatement::try_from_scope(node) {
             Some(stmt) => {
                 if stmt.is_implicit_none_type() {
                     // This is sufficient for these rules.
@@ -99,7 +99,7 @@ impl ImplicitTypingEdit {
                     // technically correct but probably a mistake, so we want to
                     // fix it to `implicit none (type, external)`.
                     let error_type = ImplicitTypingErrorType::ExternalWithoutType;
-                    let edit = add_type_to_implicit_none(stmt.node(), src)?;
+                    let edit = add_type_to_implicit_none(stmt.node())?;
                     return Some(Self { edit, error_type });
                 }
                 // If we get here, then there is an implicit statement but it's
@@ -278,7 +278,7 @@ impl AstRule for ImplicitExternalProcedures {
             return None;
         }
 
-        let stmt = ImplicitStatement::try_from_node(*node, context.source_file())?;
+        let stmt = ImplicitStatement::try_from_node(*node)?;
 
         if stmt.is_implicit_none_external() {
             // If `external` is already present, then it's correct.
@@ -292,7 +292,7 @@ impl AstRule for ImplicitExternalProcedures {
 
         // If we get here, it's either `implicit none` or `implicit none
         // (type)`, so we want to add `external` to it.
-        let edit = add_external_to_implicit_none(stmt.node(), context.source_file());
+        let edit = add_external_to_implicit_none(stmt.node());
         some_vec!(
             context
                 .create_diagnostic(Self {}, node)

--- a/crates/fortitude_linter/src/rules/correctness/init_decls.rs
+++ b/crates/fortitude_linter/src/rules/correctness/init_decls.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::ast::types::{AttributeKind, get_name_node_of_declarator};
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -97,8 +97,8 @@ impl AstRule for InitialisationInDeclaration {
         some_vec![context.create_diagnostic(Self { name }, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["init_declarator"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["init_declarator"]
     }
 }
 
@@ -223,7 +223,7 @@ impl AstRule for PointerInitialisationInDeclaration {
         some_vec![context.create_diagnostic(Self { name }, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["pointer_init_declarator"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["pointer_init_declarator"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/intent.rs
+++ b/crates/fortitude_linter/src/rules/correctness/intent.rs
@@ -3,7 +3,7 @@ use crate::ast::{FortitudeNode, types::HasName};
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::settings::FortranStandard;
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
@@ -91,7 +91,7 @@ impl AstRule for MissingIntent {
         )
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["function_statement", "subroutine_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["function_statement", "subroutine_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/kind_suffixes.rs
+++ b/crates/fortitude_linter/src/rules/correctness/kind_suffixes.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use lazy_regex::regex_is_match;
 use ruff_macros::derive_message_formats;
@@ -123,7 +123,7 @@ impl AstRule for NoRealSuffix {
         some_vec![context.create_diagnostic(NoRealSuffix { literal }, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["number_literal"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["number_literal"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/magic_numbers.rs
+++ b/crates/fortitude_linter/src/rules/correctness/magic_numbers.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::rules::utilities::literal_as_io_unit;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
@@ -95,8 +95,8 @@ impl AstRule for MagicNumberInArraySize {
         Some(violations)
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["sized_declarator", "type_qualifier"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["sized_declarator", "type_qualifier"]
     }
 }
 
@@ -153,8 +153,8 @@ impl AstRule for MagicIoUnit {
         some_vec!(context.create_diagnostic(Self { value }, unit))
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec![
+    fn entrypoints() -> Vec<u16> {
+        kind_ids![
             "read_statement",
             "write_statement",
             "open_statement",

--- a/crates/fortitude_linter/src/rules/correctness/missing_io_specifier.rs
+++ b/crates/fortitude_linter/src/rules/correctness/missing_io_specifier.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -35,7 +35,7 @@ impl AstRule for MissingActionSpecifier {
         some_vec![context.create_diagnostic(Self {}, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["open_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["open_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/nonportable_shortcircuit_inquiry.rs
+++ b/crates/fortitude_linter/src/rules/correctness/nonportable_shortcircuit_inquiry.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
@@ -130,8 +130,8 @@ impl AstRule for NonportableShortcircuitInquiry {
         Some(violations)
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["if_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["if_statement"]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/correctness/select_default.rs
+++ b/crates/fortitude_linter/src/rules/correctness/select_default.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -91,7 +91,7 @@ impl AstRule for MissingDefaultCase {
         }
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["select_case_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["select_case_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/trailing_backslash.rs
+++ b/crates/fortitude_linter/src/rules/correctness/trailing_backslash.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use lazy_regex::regex;
 use ruff_macros::derive_message_formats;
@@ -67,7 +67,7 @@ impl AstRule for TrailingBackslash {
         some_vec!(context.create_diagnostic(Self {}, range))
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["comment"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["comment"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/unreachable_statement.rs
+++ b/crates/fortitude_linter/src/rules/correctness/unreachable_statement.rs
@@ -1,6 +1,6 @@
 use crate::ast::{FortitudeNode, types::BlockExit};
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -82,7 +82,7 @@ impl AstRule for UnreachableStatement {
         }
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["keyword_statement", "stop_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["keyword_statement", "stop_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/use_statements.rs
+++ b/crates/fortitude_linter/src/rules/correctness/use_statements.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Edit, Fix, Violation};
 use crate::settings::FortranStandard;
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -57,8 +57,8 @@ impl AstRule for UseAll {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["use_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["use_statement"]
     }
 }
 
@@ -141,8 +141,8 @@ impl AstRule for MissingIntrinsic {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["use_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["use_statement"]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/error/syntax_error.rs
+++ b/crates/fortitude_linter/src/rules/error/syntax_error.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 
 use ruff_macros::derive_message_formats;
@@ -30,7 +30,7 @@ impl AstRule for SyntaxError {
         some_vec![context.create_diagnostic(Self {}, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["ERROR"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["ERROR"]
     }
 }

--- a/crates/fortitude_linter/src/rules/mod.rs
+++ b/crates/fortitude_linter/src/rules/mod.rs
@@ -53,6 +53,41 @@ impl PartialEq<&str> for NoqaCode {
     }
 }
 
+/// Use `kind_ids!` in `AstRule::entrypoints` to convert a `Vec` of string
+/// literals into a `Vec` of compiletime kind IDs. For unnamed keywords, append
+/// ``| kw`` to the literal.
+///
+/// # Example
+/// ```
+/// use fortitude_linter::kind_ids;
+/// use fortitude_macros::{kind, kw};
+///
+/// fn main() {
+///     let ids = kind_ids![
+///         "function",
+///         "end" | kw
+///     ];
+///     let expected = vec![kind!("function"), kw!("end")];
+///     assert_eq!(ids, expected);
+/// }
+/// ```
+#[macro_export]
+macro_rules! kind_ids {
+    ($($kinds:literal $(| $modifier:tt)?),* $(,)?) => {
+        vec![
+            $(
+                kind_ids!(@kind $kinds $(| $modifier)?),
+            )*
+        ]
+    };
+    (@kind $kind:literal) => {
+        fortitude_macros::kind!($kind)
+    };
+    (@kind $kind:literal | kw) => {
+        fortitude_macros::kw!($kind)
+    };
+}
+
 #[derive(Debug, Copy, Clone)]
 pub enum RuleGroup {
     /// The rule is stable.

--- a/crates/fortitude_linter/src/rules/modernisation/double_precision.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/double_precision.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use lazy_regex::regex_captures;
 use ruff_macros::derive_message_formats;
@@ -70,8 +70,8 @@ impl AstRule for DoublePrecision {
         some_vec![context.create_diagnostic(DoublePrecision::try_new(txt)?, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["intrinsic_type"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["intrinsic_type"]
     }
 }
 
@@ -165,7 +165,7 @@ impl AstRule for DoublePrecisionLiteral {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["number_literal"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["number_literal"]
     }
 }

--- a/crates/fortitude_linter/src/rules/modernisation/include_statement.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/include_statement.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_text_size::TextRange;
@@ -42,7 +42,7 @@ impl AstRule for IncludeStatement {
         some_vec![context.create_diagnostic(IncludeStatement {}, range)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["include_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["include_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/modernisation/mpi.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/mpi.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -97,7 +97,7 @@ impl AstRule for OldMPIModule {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["use_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["use_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/modernisation/old_style_array_literal.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/old_style_array_literal.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -45,7 +45,7 @@ impl AstRule for OldStyleArrayLiteral {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["array_literal"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["array_literal"]
     }
 }

--- a/crates/fortitude_linter/src/rules/modernisation/out_of_line_attribute.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/out_of_line_attribute.rs
@@ -5,7 +5,7 @@ use crate::fix::edits::{
     add_attribute_to_var_decl, remove_from_comma_sep_stmt, remove_variable_decl,
 };
 use crate::traits::{HasNode, TextRanged};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 
 use anyhow::{Context, Result};
 use fortitude_macros::ViolationMetadata;
@@ -276,8 +276,8 @@ impl AstRule for OutOfLineAttribute {
                 .collect_vec(),
         )
     }
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["parameter_statement", "variable_modification"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["parameter_statement", "variable_modification"]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/modernisation/relational_operators.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/relational_operators.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
@@ -62,7 +62,7 @@ impl AstRule for DeprecatedRelationalOperator {
         ]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["relational_expression"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["relational_expression"]
     }
 }

--- a/crates/fortitude_linter/src/rules/modernisation/save.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/save.rs
@@ -3,7 +3,8 @@ use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 
 use crate::{
-    AstRule, CheckContext, ast::FortitudeNode, settings::FortranStandard, traits::TextRanged,
+    AstRule, CheckContext, ast::FortitudeNode, kind_ids, settings::FortranStandard,
+    traits::TextRanged,
 };
 
 /// ## What it does
@@ -112,7 +113,7 @@ impl AstRule for SuperfluousSave {
         }
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["module", "submodule", "variable_declaration"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["module", "submodule", "variable_declaration"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/arithmetic_if.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/arithmetic_if.rs
@@ -1,7 +1,7 @@
 use crate::ast::{ControlFlow, ControlFlowNode, FortitudeNode};
 use crate::diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use itertools::Itertools;
 use log::debug;
@@ -354,7 +354,7 @@ impl AstRule for ArithmeticIf {
         some_vec![diagnostic]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["arithmetic_if_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["arithmetic_if_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/block_data_construct.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/block_data_construct.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::settings::FortranStandard;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
@@ -37,7 +37,7 @@ impl AstRule for BlockDataConstruct {
         some_vec![context.create_diagnostic(BlockDataConstruct {}, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["block_data_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["block_data_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/common_blocks.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/common_blocks.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -78,7 +78,7 @@ impl AstRule for CommonBlock {
         some_vec![context.create_diagnostic(CommonBlock {}, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["common_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["common_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/computed_goto.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/computed_goto.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -92,7 +92,7 @@ impl AstRule for ComputedGoTo {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["keyword_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["keyword_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/deprecated_character_syntax.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/deprecated_character_syntax.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -85,7 +85,7 @@ impl AstRule for DeprecatedCharacterSyntax {
         ]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["intrinsic_type"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["intrinsic_type"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/entry_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/entry_statement.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -35,7 +35,7 @@ impl AstRule for EntryStatement {
         some_vec![context.create_diagnostic(EntryStatement {}, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["entry_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["entry_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/equivalence_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/equivalence_statement.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::settings::FortranStandard;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -45,7 +45,7 @@ impl AstRule for EquivalenceStatement {
         some_vec![context.create_diagnostic(EquivalenceStatement {}, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["equivalence_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["equivalence_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/forall_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/forall_statement.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::settings::FortranStandard;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -61,7 +61,7 @@ impl AstRule for ForallStatement {
         some_vec![context.create_diagnostic(ForallStatement {}, node.child(0)?)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["forall_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["forall_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/mpi.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/mpi.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use std::path::Path;
@@ -120,7 +120,7 @@ impl AstRule for DeprecatedMPIInclude {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["include_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["include_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/non_block_do.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/non_block_do.rs
@@ -2,7 +2,7 @@ use crate::ast::{ControlFlow, ControlFlowNode, FortitudeNode};
 use crate::diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use crate::traits::TextRanged;
 use crate::{AstRule, CheckContext, kind_ids};
-use fortitude_macros::ViolationMetadata;
+use fortitude_macros::{ViolationMetadata, kind, kw};
 use log::debug;
 use ruff_macros::derive_message_formats;
 use ruff_source_file::SourceFile;
@@ -180,9 +180,10 @@ impl AstRule for BadDoTermination {
 
         let src = context.source_text();
 
-        match end_action.kind() {
-            "end" | "enddo" => (),
-            "keyword_statement" if ControlFlow::maybe_from(&end_action, src)?.is_continue() => (),
+        match end_action.kind_id() {
+            kw!("end") | kw!("enddo") => {}
+            kind!("keyword_statement")
+                if ControlFlow::maybe_from(&end_action, src)?.is_continue() => {}
             _ => {
                 let mut diagnostic = context.create_diagnostic(Self {}, end_action);
                 if let Some(fix) =

--- a/crates/fortitude_linter/src/rules/obsolescent/non_block_do.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/non_block_do.rs
@@ -1,7 +1,7 @@
 use crate::ast::{ControlFlow, ControlFlowNode, FortitudeNode};
 use crate::diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use log::debug;
 use ruff_macros::derive_message_formats;
@@ -61,8 +61,8 @@ impl AstRule for LabelledDoLoop {
         some_vec![diagnostic]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["do_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["do_statement"]
     }
 }
 
@@ -127,8 +127,8 @@ impl AstRule for SharedDoTermination {
         some_vec![diagnostic]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["do_label_virtual"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["do_label_virtual"]
     }
 }
 
@@ -198,8 +198,8 @@ impl AstRule for BadDoTermination {
         Some(diagnostics)
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["end_do_label_loop_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["end_do_label_loop_statement"]
     }
 }
 
@@ -273,8 +273,8 @@ impl AstRule for GotoEndDo {
         some_vec!(diagnostic)
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["keyword_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["keyword_statement"]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/obsolescent/openmp.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/openmp.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use std::path::Path;
@@ -46,7 +46,7 @@ impl AstRule for DeprecatedOmpInclude {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["include_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["include_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/pause_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/pause_statement.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Fix, Violation};
 use crate::{AstRule, CheckContext, kind_ids};
-use fortitude_macros::ViolationMetadata;
+use fortitude_macros::{ViolationMetadata, kw};
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
 
@@ -32,12 +32,7 @@ impl Violation for PauseStatement {
 
 impl AstRule for PauseStatement {
     fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
-        if node
-            .child(0)?
-            .to_text(context.source_text())?
-            .to_lowercase()
-            != "pause"
-        {
+        if node.child(0)?.kind_id() != kw!("pause") {
             return None;
         }
 

--- a/crates/fortitude_linter/src/rules/obsolescent/pause_statement.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/pause_statement.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Fix, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -51,7 +51,7 @@ impl AstRule for PauseStatement {
         ]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["file_position_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["file_position_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/specific_names.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/specific_names.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Fix, Violation};
 use crate::rules::utilities;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -110,7 +110,7 @@ impl AstRule for SpecificName {
         ]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["call_expression"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["call_expression"]
     }
 }

--- a/crates/fortitude_linter/src/rules/obsolescent/statement_functions.rs
+++ b/crates/fortitude_linter/src/rules/obsolescent/statement_functions.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -51,7 +51,7 @@ impl AstRule for StatementFunction {
         some_vec![context.create_diagnostic(StatementFunction {}, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["statement_function"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids![]
     }
 }

--- a/crates/fortitude_linter/src/rules/portability/literal_kinds.rs
+++ b/crates/fortitude_linter/src/rules/portability/literal_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{FortitudeNode, dtype_is_plain_number};
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use lazy_regex::regex_is_match;
 use ruff_macros::derive_message_formats;
@@ -117,8 +117,8 @@ impl AstRule for LiteralKind {
         some_vec![context.create_diagnostic(Self { dtype, literal }, literal_node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["intrinsic_type"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["intrinsic_type"]
     }
 }
 
@@ -198,7 +198,7 @@ impl AstRule for LiteralKindSuffix {
         some_vec![context.create_diagnostic(Self { literal, suffix }, kind)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["number_literal"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["number_literal"]
     }
 }

--- a/crates/fortitude_linter/src/rules/portability/non_portable_io_unit.rs
+++ b/crates/fortitude_linter/src/rules/portability/non_portable_io_unit.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::rules::utilities::literal_as_io_unit;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -87,7 +87,7 @@ impl AstRule for NonPortableIoUnit {
         ))
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["read_statement", "write_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["read_statement", "write_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/portability/return_in_program.rs
+++ b/crates/fortitude_linter/src/rules/portability/return_in_program.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -62,7 +62,7 @@ impl AstRule for ReturnInProgram {
         some_vec!(context.create_diagnostic(Self {}, node).with_fix(fix))
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["keyword_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["keyword_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/portability/star_kinds.rs
+++ b/crates/fortitude_linter/src/rules/portability/star_kinds.rs
@@ -1,6 +1,6 @@
 use crate::ast::{FortitudeNode, dtype_is_plain_number, strip_line_breaks};
 use crate::diagnostics::{Diagnostic, Fix, FixAvailability, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -73,7 +73,7 @@ impl AstRule for StarKind {
         ]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["intrinsic_type"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["intrinsic_type"]
     }
 }

--- a/crates/fortitude_linter/src/rules/style/complexity.rs
+++ b/crates/fortitude_linter/src/rules/style/complexity.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_text_size::TextRange;
@@ -122,8 +122,8 @@ impl AstRule for TooComplex {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["program", "function", "subroutine"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["program", "function", "subroutine"]
     }
 }
 
@@ -288,8 +288,8 @@ impl AstRule for TooManyArguments {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["function", "subroutine"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["function", "subroutine"]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/style/double_colon_in_decl.rs
+++ b/crates/fortitude_linter/src/rules/style/double_colon_in_decl.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -41,7 +41,7 @@ impl AstRule for MissingDoubleColon {
         }
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["variable_declaration"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["variable_declaration"]
     }
 }

--- a/crates/fortitude_linter/src/rules/style/end_statements.rs
+++ b/crates/fortitude_linter/src/rules/style/end_statements.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -105,8 +105,8 @@ impl AstRule for UnnamedEndStatement {
         ]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec![
+    fn entrypoints() -> Vec<u16> {
+        kind_ids![
             "end_module_statement",
             "end_submodule_statement",
             "end_program_statement",

--- a/crates/fortitude_linter/src/rules/style/file_contents.rs
+++ b/crates/fortitude_linter/src/rules/style/file_contents.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -36,8 +36,8 @@ impl AstRule for MultipleModules {
         Some(violations)
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["translation_unit"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["translation_unit"]
     }
 }
 
@@ -82,7 +82,7 @@ impl AstRule for ProgramWithModule {
         Some(violations)
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["translation_unit"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["translation_unit"]
     }
 }

--- a/crates/fortitude_linter/src/rules/style/functions.rs
+++ b/crates/fortitude_linter/src/rules/style/functions.rs
@@ -1,6 +1,6 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -88,7 +88,7 @@ impl AstRule for FunctionMissingResult {
         some_vec![context.create_diagnostic(Self {}, node)]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["function_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["function_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/style/implicit_none.rs
+++ b/crates/fortitude_linter/src/rules/style/implicit_none.rs
@@ -1,7 +1,7 @@
 /// Defines rules that raise errors if implicit typing is in use.
 use crate::ast::{FortitudeNode, types::ImplicitStatement};
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -81,7 +81,7 @@ impl AstRule for SuperfluousImplicitNone {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["implicit_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["implicit_statement"]
     }
 }

--- a/crates/fortitude_linter/src/rules/style/implicit_none.rs
+++ b/crates/fortitude_linter/src/rules/style/implicit_none.rs
@@ -32,7 +32,7 @@ impl AlwaysFixableViolation for SuperfluousImplicitNone {
 impl AstRule for SuperfluousImplicitNone {
     fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
         let src = context.source_file();
-        let stmt = ImplicitStatement::try_from_node(*node, src)?;
+        let stmt = ImplicitStatement::try_from_node(*node)?;
         // If this isn't an `implicit none` statement, then we don't care about it.
         if stmt.is_not_implicit_none() {
             return None;
@@ -47,7 +47,7 @@ impl AstRule for SuperfluousImplicitNone {
                         break;
                     }
                     "module" | "submodule" | "program" | "function" | "subroutine" => {
-                        match ImplicitStatement::try_from_scope(&ancestor, src) {
+                        match ImplicitStatement::try_from_scope(&ancestor) {
                             None => {
                                 // If the ancestor doesn't have any `implicit` statement, then
                                 // keep searching up the tree for a higher-level entity with

--- a/crates/fortitude_linter/src/rules/style/keywords.rs
+++ b/crates/fortitude_linter/src/rules/style/keywords.rs
@@ -5,8 +5,9 @@ use crate::diagnostics::{
 };
 use crate::stylist::ToCapitalisation;
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
+use itertools::Itertools;
 use ruff_macros::derive_message_formats;
 use ruff_text_size::{TextRange, TextSize};
 use std::str::FromStr;
@@ -141,8 +142,8 @@ impl AstRule for KeywordsMissingSpace {
         )
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec![
+    fn entrypoints() -> Vec<u16> {
+        kind_ids![
             "elseif_clause",
             "elsewhere_clause",
             "end_associate_statement",
@@ -163,7 +164,7 @@ impl AstRule for KeywordsMissingSpace {
             "end_subroutine_statement",
             "end_type_statement",
             "end_where_statement",
-            "inout",
+            "inout" | kw,
             "intrinsic_type",    // double precision and double complex
             "keyword_statement", // goto
             "select_case_statement",
@@ -265,9 +266,9 @@ impl AstRule for KeywordHasWhitespace {
         some_vec!(context.create_diagnostic(violation, first_child))
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec![
-            "in",
+    fn entrypoints() -> Vec<u16> {
+        kind_ids![
+            "in" | kw,
             "keyword_statement", // goto
         ]
     }
@@ -405,8 +406,15 @@ impl AstRule for IncorrectKeywordCase {
         )
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        tree_sitter_fortran::KEYWORDS.to_vec()
+    fn entrypoints() -> Vec<u16> {
+        let language: tree_sitter::Language = tree_sitter_fortran::LANGUAGE.into();
+        // TODO(peter): make this compiletime
+        tree_sitter_fortran::KEYWORDS
+            .iter()
+            .map(|kw| language.id_for_node_kind(kw, false))
+            // these two are named
+            .chain(kind_ids!["none", "default"])
+            .collect_vec()
     }
 }
 
@@ -523,7 +531,7 @@ impl AstRule for KeywordReuse {
 
     /// Entry point only on `block_label_start_expression`, as other cases of
     /// keyword reuse should be caught by `check_keyword_reuse`.
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["block_label_start_expression"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["block_label_start_expression"]
     }
 }

--- a/crates/fortitude_linter/src/rules/style/literals.rs
+++ b/crates/fortitude_linter/src/rules/style/literals.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_text_size::TextSize;
@@ -90,7 +90,7 @@ impl AstRule for BareDecimal {
         ]
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["number_literal"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["number_literal"]
     }
 }

--- a/crates/fortitude_linter/src/rules/style/semicolons.rs
+++ b/crates/fortitude_linter/src/rules/style/semicolons.rs
@@ -5,7 +5,7 @@ use ruff_text_size::TextSize;
 use tree_sitter::Node;
 
 use crate::ast::FortitudeNode;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 
 fn semicolon_is_superfluous(node: &Node) -> bool {
     let line_number = node.start_position().row;
@@ -85,8 +85,8 @@ impl AstRule for SuperfluousSemicolon {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec![";"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids![";" | kw]
     }
 }
 
@@ -134,7 +134,7 @@ impl AstRule for MultipleStatementsPerLine {
         )
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec![";"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids![";" | kw]
     }
 }

--- a/crates/fortitude_linter/src/rules/style/strings.rs
+++ b/crates/fortitude_linter/src/rules/style/strings.rs
@@ -9,7 +9,7 @@ use tree_sitter::Node;
 use crate::ast::FortitudeNode;
 use crate::stylist::Quote;
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 
 /// ## What does it do?
 /// Catches use of single- or double-quoted strings, depending on the value of
@@ -109,8 +109,8 @@ impl AstRule for BadQuoteString {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["string_literal"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["string_literal"]
     }
 }
 
@@ -187,8 +187,8 @@ impl AstRule for AvoidableEscapedQuote {
         )
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["string_literal"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["string_literal"]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/style/superfluous_while_true.rs
+++ b/crates/fortitude_linter/src/rules/style/superfluous_while_true.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
 use crate::fix::edits::delete_stmt_part;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -67,8 +67,8 @@ impl AstRule for SuperfluousWhileTrue {
         some_vec!(context.create_diagnostic(Self {}, node).with_fix(fix))
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["while_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["while_statement"]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/style/use_statement.rs
+++ b/crates/fortitude_linter/src/rules/style/use_statement.rs
@@ -2,7 +2,7 @@ use crate::ast::FortitudeNode;
 use crate::diagnostics::{AlwaysFixableViolation, Diagnostic};
 use crate::diagnostics::{Edit, Fix};
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
 use ruff_source_file::{LineRanges, SourceFile};
@@ -104,8 +104,8 @@ impl AstRule for UnsortedUses {
         }
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["module", "submodule", "program", "subroutine", "function"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["module", "submodule", "program", "subroutine", "function"]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/style/useless_return.rs
+++ b/crates/fortitude_linter/src/rules/style/useless_return.rs
@@ -6,7 +6,7 @@ use crate::fix::edits::redent;
 use crate::stylist::ToCapitalisation;
 use crate::traits::TextRanged;
 use crate::{AstRule, CheckContext, kind_ids};
-use fortitude_macros::ViolationMetadata;
+use fortitude_macros::{ViolationMetadata, kind};
 use log::debug;
 use ruff_macros::derive_message_formats;
 use ruff_text_size::TextRange;
@@ -61,17 +61,12 @@ impl AlwaysFixableViolation for UselessReturn {
 
 impl AstRule for UselessReturn {
     fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
-        let _ = context;
-        if !node
-            .to_text(context.source_text())?
-            .eq_ignore_ascii_case("return")
-        {
-            return None;
-        }
-        let sibling = node.next_non_comment_sibling();
+        let sibling = node.parent()?.next_non_comment_sibling()?;
         if !matches!(
-            sibling?.kind(),
-            "end_function_statement" | "end_subroutine_statement" | "internal_procedures"
+            sibling.kind_id(),
+            kind!("end_function_statement")
+                | kind!("end_subroutine_statement")
+                | kind!("internal_procedures")
         ) {
             return None;
         }
@@ -84,7 +79,7 @@ impl AstRule for UselessReturn {
     }
 
     fn entrypoints() -> Vec<u16> {
-        kind_ids!["keyword_statement"]
+        kind_ids!["return" | kw]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/style/useless_return.rs
+++ b/crates/fortitude_linter/src/rules/style/useless_return.rs
@@ -5,7 +5,7 @@ use crate::diagnostics::{
 use crate::fix::edits::redent;
 use crate::stylist::ToCapitalisation;
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::ViolationMetadata;
 use log::debug;
 use ruff_macros::derive_message_formats;
@@ -83,8 +83,8 @@ impl AstRule for UselessReturn {
         )
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["keyword_statement"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["keyword_statement"]
     }
 }
 

--- a/crates/fortitude_linter/src/rules/style/whitespace.rs
+++ b/crates/fortitude_linter/src/rules/style/whitespace.rs
@@ -8,7 +8,7 @@ use tree_sitter::Node;
 
 use crate::ast::FortitudeNode;
 use crate::traits::TextRanged;
-use crate::{AstRule, CheckContext};
+use crate::{AstRule, CheckContext, kind_ids};
 
 /// ## What does it do?
 /// Checks for trailing whitespace.
@@ -165,8 +165,8 @@ impl AstRule for IncorrectSpaceBeforeComment {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["comment"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["comment"]
     }
 }
 
@@ -231,8 +231,8 @@ impl AstRule for IncorrectSpaceAroundDoubleColon {
         None
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["::"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["::" | kw]
     }
 }
 
@@ -326,7 +326,7 @@ impl AstRule for IncorrectSpaceBetweenBrackets {
         )
     }
 
-    fn entrypoints() -> Vec<&'static str> {
-        vec!["(", "[", ")", "]"]
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["(" | kw, "[" | kw, ")" | kw, "]" | kw]
     }
 }

--- a/crates/fortitude_macros/Cargo.toml
+++ b/crates/fortitude_macros/Cargo.toml
@@ -12,3 +12,5 @@ quote = "1.0.37"
 syn = "2.0.86"
 itertools = { workspace = true }
 regex = { workspace = true }
+tree-sitter = { workspace = true }
+tree-sitter-fortran = { workspace = true }

--- a/crates/fortitude_macros/src/lib.rs
+++ b/crates/fortitude_macros/src/lib.rs
@@ -8,7 +8,9 @@ mod rule_namespace;
 mod violation_metadata;
 
 use proc_macro::TokenStream;
-use syn::{DeriveInput, Error, ItemFn, parse_macro_input};
+use quote::{quote, quote_spanned};
+use syn::{DeriveInput, Error, ItemFn, LitStr, parse_macro_input};
+use tree_sitter::Language;
 
 #[proc_macro_derive(ViolationMetadata, attributes(violation_metadata))]
 pub fn derive_violation_metadata(item: TokenStream) -> TokenStream {
@@ -52,4 +54,66 @@ pub fn derive_has_name(input: TokenStream) -> TokenStream {
     has_name::derive_impl(input)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
+}
+
+fn id_for_node_kind(token_stream: TokenStream, named: bool) -> TokenStream {
+    let string_literal: LitStr = parse_macro_input!(token_stream);
+
+    // Get the string value and calculate its length
+    let requested_kind = string_literal.value();
+
+    let language: Language = tree_sitter_fortran::LANGUAGE.into();
+    let found_id = language.id_for_node_kind(&requested_kind, named);
+
+    if found_id != 0 {
+        quote! {
+            #found_id
+        }
+    } else {
+        quote_spanned!(
+            string_literal.span() =>
+            compile_error!("This is not a valid node kind in the tree-sitter-fortran grammar")
+        )
+    }
+    .into()
+}
+
+/// Given a string literal of a named node, return the corresponding tree-sitter
+/// kind_id
+#[proc_macro]
+pub fn kind(token_stream: TokenStream) -> TokenStream {
+    id_for_node_kind(token_stream, true)
+}
+
+/// Given a string literal of an unnamed node (that is, a keyword), return the
+/// corresponding tree-sitter kind_id
+#[proc_macro]
+pub fn kw(token_stream: TokenStream) -> TokenStream {
+    id_for_node_kind(token_stream, false)
+}
+
+/// Given a string literal of a field name, return the corresponding tree-sitter
+/// field_id
+#[proc_macro]
+pub fn field(token_stream: TokenStream) -> TokenStream {
+    let string_literal: LitStr = parse_macro_input!(token_stream);
+
+    // Get the string value and calculate its length
+    let requested_keyword = string_literal.value();
+
+    let language: Language = tree_sitter_fortran::LANGUAGE.into();
+    let found_id = language.field_id_for_name(&requested_keyword);
+
+    if let Some(found_id) = found_id {
+        let id_number: u16 = found_id.into();
+        quote! {
+            std::num::NonZeroU16::new(#id_number).unwrap()
+        }
+    } else {
+        quote_spanned!(
+            string_literal.span() =>
+            compile_error!("This is not a valid field in the tree-sitter-fortran grammar")
+        )
+    }
+    .into()
 }

--- a/crates/fortitude_macros/src/map_codes.rs
+++ b/crates/fortitude_macros/src/map_codes.rs
@@ -480,7 +480,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
         use std::path::Path;
         use ruff_source_file::SourceFile;
         use tree_sitter::Node;
-        use crate::{AstRule, CheckContext};
+        use crate::{AstRule, CheckContext, kind_ids};
         use crate::diagnostics::{Diagnostic, Violation};
 
         #[derive(
@@ -567,7 +567,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a RuleMeta>) -> TokenStream 
                 }
             }
 
-            pub fn entrypoints(&self) -> Vec<&'static str> {
+            pub fn entrypoints(&self) -> Vec<u16> {
                 match self {
                     #ast_rule_entrypoint_match_arms
                 }

--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -78,7 +78,7 @@ def main(*, name: str, prefix: str, code: str, category: str) -> None:
         fp.write(
             f"""\
 use crate::ast::FortitudeNode;
-use crate::{{AstRule, CheckContext}};
+use crate::{{AstRule, CheckContext, kind_ids}};
 use crate::diagnostics::{{Diagnostic, Edit, Fix, FixAvailability, Violation}};
 use fortitude_macros::ViolationMetadata;
 use ruff_macros::derive_message_formats;
@@ -112,8 +112,8 @@ impl AstRule for {name} {{
         None
     }}
 
-    fn entrypoints() -> Vec<&'static str> {{
-        vec![]
+    fn entrypoints() -> Vec<u16> {{
+        kind_ids![]
     }}
 }}
 """,


### PR DESCRIPTION
Currently we rely on `Node::kind()` and string comparisons. There's a couple of instances where we need to distinguish between named and unnamed nodes with the same kind (the named `function` node is the whole function, whereas the unnamed `function` is just the keyword). 

This PR lets us start switching to using `Node::kind_id() -> u16`. Unfortunately, tree-sitter doesn't auto-generate any kind of mapping. There is a runtime function, `Language::id_for_node_kind()` that does this, but it would be quite messy to use it everywhere, plus we can't use it in e.g. `match` expressions (because it's not a constant).

This PR provides three proc macros, `kind!()`, `kw!()`, `field!()`, which do this look-up at compile-time, so we get compile-time checking of node names, plus the ability to use them in constant expressions. There may even be some performance benefit to not doing string comparisons everywhere.

We can also use these to avoid case-insensitive comparisons:

```diff
     node.children(&mut node.walk())
-        .find(|child| child.to_text(src.source_text()).unwrap().to_lowercase() == "external")
+        .find(|child| child.kind_id() == kw!("external"))
```

I've made a few changes like this to give a feel of how ergonomic these macros are to use.

The biggest change is for `AstRule::entrypoints()` to return `Vec<u16>`, using a macro `kind_ids![]` to make this simple. Use `"node_name" | kw` to get an unnamed node:

```rust
kind_ids![
    "function",          // named node
    "function" | kw,     // unnamed node, such as a keyword
    "math_expression",
    "+" | kw,
    "end_program_statement",
    "end" | kw,
];
```

