### PR TITLE
Add new unary-following-arithmetic rule.

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/portability/PORT051.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/portability/PORT051.f90
@@ -1,0 +1,98 @@
+module test_unary_following_arithmetic
+
+    implicit none(type, external)
+
+    interface operator(.plus.)
+        module procedure plus
+    end interface
+
+    interface operator(.minus.)
+        module procedure minus
+    end interface
+
+    interface operator(.negate.)
+        module procedure negate
+    end interface
+
+contains
+
+    ! user-defined binary function (math_expression)
+    integer function plus(lhs, rhs)
+        implicit none(type, external)
+        integer, intent(in) :: lhs, rhs
+        plus = lhs + rhs
+    end function plus
+
+    ! user-defined binary function (math_expression)
+    integer function minus(lhs, rhs)
+        implicit none(type, external)
+        integer, intent(in) :: lhs, rhs
+        minus = lhs - rhs
+    end function minus
+
+    ! user-defined unary function (unary_expression)
+    integer function negate(i)
+        implicit none(type, external)
+        integer, intent(in) :: i
+        negate = -i
+    end function negate
+
+end module test_unary_following_arithmetic
+
+program main
+    use test_unary_following_arithmetic
+
+    implicit none(type, external)
+
+    integer :: i
+
+    ! All ok.
+    i = 2 + 3
+    i = 2 - 3
+    i = 2 * 3
+    i = 2 / 3
+    i = -2
+    i = +3
+    i = 2 .plus. 3
+    i = .negate.3
+    i = 3 + .negate.2  ! User-defined operators are ok.
+    i = 3 .minus. .negate.2  ! User-defined operators are ok.
+    i = 10 ** 2
+    i = 10 ** (+2)
+    i = 10 ** (-2)
+    i = 10 ** (-2) * 3
+    i = 10 ** (-+3) / 2
+    i = .negate.10 * 2 + 3
+    i = 10 ** (-2) &
+            &* 3
+    i = 10 ** (-&
+            &2) * 3
+    i = 10 ** &
+            &(-2) * 3
+    i = 10 &
+            &** (-2) * 3
+    i = 10 ** (-2) * &
+            &3
+    i = 10 ** (-2) * 3 ! some comment.
+
+    ! All fail.
+    i = 2 + +3
+    i = 2 - - 3
+    i = 2 * -3
+    i = 2 / -(3)
+    i = 10 ** +3
+    i = 10 ** -2
+    i = 10 ** -2 * 3
+    i = 10 ** -(2) / 3
+    i = 10 &
+            &** -2 * 3
+    i = 10 ** &
+            &-2
+    i = 10 ** -&
+            &2
+    i = 10 ** -2 ! some comment.
+    i = 10   **    -      2
+    i = 10   **    -      2  *   3
+    i = 10 ** -2 * 3 ** -7
+
+end program main

--- a/crates/fortitude_linter/src/rules/mod.rs
+++ b/crates/fortitude_linter/src/rules/mod.rs
@@ -166,6 +166,7 @@ pub fn code_to_rule(category: Category, code: &str) -> Option<(RuleGroup, Rule)>
         (Portability, "021") => (RuleGroup::Stable, Ast, Default, portability::star_kinds::StarKind),
         (Portability, "031") => (RuleGroup::Stable, None, Default, portability::invalid_tab::InvalidTab),
         (Portability, "041") => (RuleGroup::Preview, Ast, Optional, portability::return_in_program::ReturnInProgram),
+        (Portability, "051") => (RuleGroup::Preview, Ast, Optional, portability::unary_following_arithmetic::UnaryFollowingArithmetic),
 
         // style
         (Style, "001") => (RuleGroup::Stable, None, Default, style::line_length::LineTooLong),

--- a/crates/fortitude_linter/src/rules/portability/mod.rs
+++ b/crates/fortitude_linter/src/rules/portability/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod literal_kinds;
 pub(crate) mod non_portable_io_unit;
 pub mod return_in_program;
 pub(crate) mod star_kinds;
+pub mod unary_following_arithmetic;
 
 #[cfg(test)]
 mod tests {
@@ -25,6 +26,7 @@ mod tests {
     #[test_case(Rule::StarKind, Path::new("PORT021.f90"))]
     #[test_case(Rule::InvalidTab, Path::new("PORT031.f90"))]
     #[test_case(Rule::ReturnInProgram, Path::new("PORT041.f90"))]
+    #[test_case(Rule::UnaryFollowingArithmetic, Path::new("PORT051.f90"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/fortitude_linter/src/rules/portability/snapshots/fortitude_linter__rules__portability__tests__unary-following-arithmetic_PORT051.f90.snap
+++ b/crates/fortitude_linter/src/rules/portability/snapshots/fortitude_linter__rules__portability__tests__unary-following-arithmetic_PORT051.f90.snap
@@ -1,0 +1,326 @@
+---
+source: crates/fortitude_linter/src/rules/portability/mod.rs
+expression: diagnostics
+---
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:79:13
+   |
+78 |     ! All fail.
+79 |     i = 2 + +3
+   |             ^
+80 |     i = 2 - - 3
+81 |     i = 2 * -3
+   |
+help: Add parenthesese around the desired argument of the unary operator
+76 |     i = 10 ** (-2) * 3 ! some comment.
+77 |
+78 |     ! All fail.
+   -     i = 2 + +3
+79 +     i = 2 + (+3)
+80 |     i = 2 - - 3
+81 |     i = 2 * -3
+82 |     i = 2 / -(3)
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:80:13
+   |
+78 |     ! All fail.
+79 |     i = 2 + +3
+80 |     i = 2 - - 3
+   |             ^
+81 |     i = 2 * -3
+82 |     i = 2 / -(3)
+   |
+help: Add parenthesese around the desired argument of the unary operator
+77 |
+78 |     ! All fail.
+79 |     i = 2 + +3
+   -     i = 2 - - 3
+80 +     i = 2 - (- 3)
+81 |     i = 2 * -3
+82 |     i = 2 / -(3)
+83 |     i = 10 ** +3
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:81:13
+   |
+79 |     i = 2 + +3
+80 |     i = 2 - - 3
+81 |     i = 2 * -3
+   |             ^
+82 |     i = 2 / -(3)
+83 |     i = 10 ** +3
+   |
+help: Add parenthesese around the desired argument of the unary operator
+78 |     ! All fail.
+79 |     i = 2 + +3
+80 |     i = 2 - - 3
+   -     i = 2 * -3
+81 +     i = 2 * (-3)
+82 |     i = 2 / -(3)
+83 |     i = 10 ** +3
+84 |     i = 10 ** -2
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:82:13
+   |
+80 |     i = 2 - - 3
+81 |     i = 2 * -3
+82 |     i = 2 / -(3)
+   |             ^
+83 |     i = 10 ** +3
+84 |     i = 10 ** -2
+   |
+help: Add parenthesese around the desired argument of the unary operator
+79 |     i = 2 + +3
+80 |     i = 2 - - 3
+81 |     i = 2 * -3
+   -     i = 2 / -(3)
+82 +     i = 2 / (-(3))
+83 |     i = 10 ** +3
+84 |     i = 10 ** -2
+85 |     i = 10 ** -2 * 3
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:83:15
+   |
+81 |     i = 2 * -3
+82 |     i = 2 / -(3)
+83 |     i = 10 ** +3
+   |               ^
+84 |     i = 10 ** -2
+85 |     i = 10 ** -2 * 3
+   |
+help: Add parenthesese around the desired argument of the unary operator
+80 |     i = 2 - - 3
+81 |     i = 2 * -3
+82 |     i = 2 / -(3)
+   -     i = 10 ** +3
+83 +     i = 10 ** (+3)
+84 |     i = 10 ** -2
+85 |     i = 10 ** -2 * 3
+86 |     i = 10 ** -(2) / 3
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:84:15
+   |
+82 |     i = 2 / -(3)
+83 |     i = 10 ** +3
+84 |     i = 10 ** -2
+   |               ^
+85 |     i = 10 ** -2 * 3
+86 |     i = 10 ** -(2) / 3
+   |
+help: Add parenthesese around the desired argument of the unary operator
+81 |     i = 2 * -3
+82 |     i = 2 / -(3)
+83 |     i = 10 ** +3
+   -     i = 10 ** -2
+84 +     i = 10 ** (-2)
+85 |     i = 10 ** -2 * 3
+86 |     i = 10 ** -(2) / 3
+87 |     i = 10 &
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:85:15
+   |
+83 |     i = 10 ** +3
+84 |     i = 10 ** -2
+85 |     i = 10 ** -2 * 3
+   |               ^
+86 |     i = 10 ** -(2) / 3
+87 |     i = 10 &
+   |
+help: Add parenthesese around the desired argument of the unary operator
+82 |     i = 2 / -(3)
+83 |     i = 10 ** +3
+84 |     i = 10 ** -2
+   -     i = 10 ** -2 * 3
+85 +     i = 10 ** (-2) * 3
+86 |     i = 10 ** -(2) / 3
+87 |     i = 10 &
+88 |             &** -2 * 3
+note: This is an unsafe fix and may change runtime behavior
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:86:15
+   |
+84 |     i = 10 ** -2
+85 |     i = 10 ** -2 * 3
+86 |     i = 10 ** -(2) / 3
+   |               ^
+87 |     i = 10 &
+88 |             &** -2 * 3
+   |
+help: Add parenthesese around the desired argument of the unary operator
+83 |     i = 10 ** +3
+84 |     i = 10 ** -2
+85 |     i = 10 ** -2 * 3
+   -     i = 10 ** -(2) / 3
+86 +     i = 10 ** (-(2)) / 3
+87 |     i = 10 &
+88 |             &** -2 * 3
+89 |     i = 10 ** &
+note: This is an unsafe fix and may change runtime behavior
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:88:17
+   |
+86 |     i = 10 ** -(2) / 3
+87 |     i = 10 &
+88 |             &** -2 * 3
+   |                 ^
+89 |     i = 10 ** &
+90 |             &-2
+   |
+help: Add parenthesese around the desired argument of the unary operator
+85 |     i = 10 ** -2 * 3
+86 |     i = 10 ** -(2) / 3
+87 |     i = 10 &
+   -             &** -2 * 3
+88 +             &** (-2) * 3
+89 |     i = 10 ** &
+90 |             &-2
+91 |     i = 10 ** -&
+note: This is an unsafe fix and may change runtime behavior
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:90:14
+   |
+88 |             &** -2 * 3
+89 |     i = 10 ** &
+90 |             &-2
+   |              ^
+91 |     i = 10 ** -&
+92 |             &2
+   |
+help: Add parenthesese around the desired argument of the unary operator
+87 |     i = 10 &
+88 |             &** -2 * 3
+89 |     i = 10 ** &
+   -             &-2
+90 +             &(-2)
+91 |     i = 10 ** -&
+92 |             &2
+93 |     i = 10 ** -2 ! some comment.
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:91:15
+   |
+89 |     i = 10 ** &
+90 |             &-2
+91 |     i = 10 ** -&
+   |               ^
+92 |             &2
+93 |     i = 10 ** -2 ! some comment.
+   |
+help: Add parenthesese around the desired argument of the unary operator
+88 |             &** -2 * 3
+89 |     i = 10 ** &
+90 |             &-2
+   -     i = 10 ** -&
+   -             &2
+91 +     i = 10 ** (-&
+92 +             &2)
+93 |     i = 10 ** -2 ! some comment.
+94 |     i = 10   **    -      2
+95 |     i = 10   **    -      2  *   3
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:93:15
+   |
+91 |     i = 10 ** -&
+92 |             &2
+93 |     i = 10 ** -2 ! some comment.
+   |               ^
+94 |     i = 10   **    -      2
+95 |     i = 10   **    -      2  *   3
+   |
+help: Add parenthesese around the desired argument of the unary operator
+90 |             &-2
+91 |     i = 10 ** -&
+92 |             &2
+   -     i = 10 ** -2 ! some comment.
+93 +     i = 10 ** (-2) ! some comment.
+94 |     i = 10   **    -      2
+95 |     i = 10   **    -      2  *   3
+96 |     i = 10 ** -2 * 3 ** -7
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:94:20
+   |
+92 |             &2
+93 |     i = 10 ** -2 ! some comment.
+94 |     i = 10   **    -      2
+   |                    ^
+95 |     i = 10   **    -      2  *   3
+96 |     i = 10 ** -2 * 3 ** -7
+   |
+help: Add parenthesese around the desired argument of the unary operator
+91 |     i = 10 ** -&
+92 |             &2
+93 |     i = 10 ** -2 ! some comment.
+   -     i = 10   **    -      2
+94 +     i = 10   **    (-      2)
+95 |     i = 10   **    -      2  *   3
+96 |     i = 10 ** -2 * 3 ** -7
+97 |
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:95:20
+   |
+93 |     i = 10 ** -2 ! some comment.
+94 |     i = 10   **    -      2
+95 |     i = 10   **    -      2  *   3
+   |                    ^
+96 |     i = 10 ** -2 * 3 ** -7
+   |
+help: Add parenthesese around the desired argument of the unary operator
+92 |             &2
+93 |     i = 10 ** -2 ! some comment.
+94 |     i = 10   **    -      2
+   -     i = 10   **    -      2  *   3
+95 +     i = 10   **    (-      2)  *   3
+96 |     i = 10 ** -2 * 3 ** -7
+97 |
+98 | end program main
+note: This is an unsafe fix and may change runtime behavior
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:96:15
+   |
+94 |     i = 10   **    -      2
+95 |     i = 10   **    -      2  *   3
+96 |     i = 10 ** -2 * 3 ** -7
+   |               ^
+97 |
+98 | end program main
+   |
+help: Add parenthesese around the desired argument of the unary operator
+93 |     i = 10 ** -2 ! some comment.
+94 |     i = 10   **    -      2
+95 |     i = 10   **    -      2  *   3
+   -     i = 10 ** -2 * 3 ** -7
+96 +     i = 10 ** (-2) * 3 ** -7
+97 |
+98 | end program main
+note: This is an unsafe fix and may change runtime behavior
+
+PORT051 [*] Unary operator following an arithmetic expression
+  --> ./resources/test/fixtures/portability/PORT051.f90:96:25
+   |
+94 |     i = 10   **    -      2
+95 |     i = 10   **    -      2  *   3
+96 |     i = 10 ** -2 * 3 ** -7
+   |                         ^
+97 |
+98 | end program main
+   |
+help: Add parenthesese around the desired argument of the unary operator
+93 |     i = 10 ** -2 ! some comment.
+94 |     i = 10   **    -      2
+95 |     i = 10   **    -      2  *   3
+   -     i = 10 ** -2 * 3 ** -7
+96 +     i = 10 ** -2 * 3 ** (-7)
+97 |
+98 | end program main

--- a/crates/fortitude_linter/src/rules/portability/unary_following_arithmetic.rs
+++ b/crates/fortitude_linter/src/rules/portability/unary_following_arithmetic.rs
@@ -1,0 +1,156 @@
+use crate::diagnostics::{Diagnostic, FixAvailability, Violation};
+use crate::traits::TextRanged;
+use crate::{AstRule, CheckContext, kind_ids};
+use fortitude_macros::ViolationMetadata;
+use ruff_diagnostics::{Edit, Fix};
+use ruff_macros::derive_message_formats;
+use tree_sitter::Node;
+
+/// ## What it does
+/// Checks for use of a unary expression following an arithmetic operator.
+///
+/// ## Why is this bad?
+/// The use of a unary operator (`+`, `-` but *not* user-defined) following an arithmetic operator (
+/// `+`, `-`, `*`, `/`, `**` but *not* user-defined) is not part of the Fortran standard. In some
+/// cases, this may be ambiguous as the order of operations does not necessarily follow typical
+/// mathematical order. The computed output may therefore vary between compilers.
+///
+/// Many compilers, Intel Fortran for example, will let you do this as an extension; sometimes with
+/// a warning on compilation. Use parentheses to remove ambiguity of user expected output; the fix
+/// may change prior behaviour on some compilers.
+///
+/// ## Example
+/// ```f90
+/// x = 10 ** -2 * 2
+/// ! Would expected x = 0.02 but some compilers may give x = 0.0001.
+/// ```
+///
+/// Use instead:
+/// ```f90
+/// x = 10 ** (-2) * 2
+/// ! Result is unambiguously x = 0.02.
+/// ```
+///
+/// ## References
+/// * [Doctor Fortran in "Order! Order!"](https://stevelionel.com/drfortran/2021/04/03/doctor-fortran-in-order-order/)
+#[derive(ViolationMetadata)]
+pub(crate) struct UnaryFollowingArithmetic;
+
+impl Violation for UnaryFollowingArithmetic {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "Unary operator following an arithmetic expression".to_string()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Add parenthesese around the desired argument of the unary operator".to_string())
+    }
+}
+
+impl AstRule for UnaryFollowingArithmetic {
+    fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        // Check if we have a unary expression on the RHS of this math expression.
+        let unary_exp = node.child_by_field_name("right")?;
+
+        if unary_exp.kind() != "unary_expression" {
+            return None;
+        }
+
+        // User defined unary operators have precedence so don't cause problems.
+        let unary_op = unary_exp.child_by_field_name("operator")?;
+
+        if unary_op.kind() == "user_defined_operator" {
+            return None;
+        }
+
+        // If for some strange reason we have multiple unary operators, e.g `10 ** -+2`, then we
+        // need the right-most one so its argument can be the only thing parenthesised.
+        let unary_arg = right_most_unary(unary_exp).child_by_field_name("argument")?;
+
+        let parenthesise_end_node = if unary_arg.kind() == "math_expression" {
+            unary_arg.child_by_field_name("left")?
+        } else {
+            unary_arg
+        };
+
+        // All fixes are safe except for those of the form `a ** -b * c` where the `-` can also be a
+        // `+` and the `*` can also be a `/`.
+        let fix = if is_unsafe_fix(node, &unary_arg, &unary_op) {
+            Fix::unsafe_edits(
+                Edit::insertion("(".to_string(), unary_exp.start_textsize()),
+                [Edit::insertion(
+                    ")".to_string(),
+                    parenthesise_end_node.end_textsize(),
+                )],
+            )
+        } else {
+            Fix::safe_edits(
+                Edit::insertion("(".to_string(), unary_exp.start_textsize()),
+                [Edit::insertion(
+                    ")".to_string(),
+                    parenthesise_end_node.end_textsize(),
+                )],
+            )
+        };
+
+        some_vec![
+            context
+                .create_diagnostic(UnaryFollowingArithmetic, unary_op)
+                .with_fix(fix)
+        ]
+    }
+
+    fn entrypoints() -> Vec<u16> {
+        kind_ids!["math_expression"]
+    }
+}
+
+fn is_unsafe_fix(node: &Node, unary_arg: &Node, unary_op: &Node) -> bool {
+    // An unsafe fix is when we have something of the form `a ** -b * c` where the `-` can also be a
+    // `+` and the `*` can also be a `/`.
+
+    let Some(node_op) = node.child_by_field_name("operator") else {
+        return false;
+    };
+
+    if node_op.kind() != "**" {
+        return false;
+    }
+
+    // "-" or "+" part.
+    if unary_op.kind() != "-" && unary_op.kind() != "+" {
+        return false;
+    }
+
+    // "*" or "/" part.
+    if unary_arg.kind() != "math_expression" {
+        return false;
+    }
+
+    let Some(unary_arg_op) = unary_arg.child_by_field_name("operator") else {
+        return false;
+    };
+
+    matches!(unary_arg_op.kind(), "*" | "/")
+}
+
+fn right_most_unary(mut unary_exp: Node) -> Node {
+    // Recursively finds the right-most unary operator.
+    // E.g `-x` -> gives the `-`.
+    // E.g `-+x` -> gives the `+`.
+    // E.g `+-+-+-x` -> gives the final `-`.
+
+    loop {
+        let Some(unary_arg) = unary_exp.child_by_field_name("argument") else {
+            return unary_exp;
+        };
+
+        if unary_arg.kind() != "unary_expression" {
+            return unary_exp;
+        }
+
+        unary_exp = unary_arg;
+    }
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -133,6 +133,7 @@
 | PORT021 | [star-kind](rules/star-kind.md) | '{dtype}{size}' uses non-standard syntax | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | PORT031 | [invalid-tab](rules/invalid-tab.md) | Invalid tab character | <span title='Rule is stable' style='opacity: 0.6'>✔️</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule turned on by default'>▶️</span> |
 | PORT041 | [return-in-program](rules/return-in-program.md) | 'return' statement in program body | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
+| PORT051 | [unary-following-arithmetic](rules/unary-following-arithmetic.md) | Unary operator following an arithmetic expression | <span title='Rule is in preview'>🧪</span> <span title='Automatic fix available'>🛠️</span> <span title='Rule not on by default'>⏸️</span> |
 
 ### Fortitude (FORT)
 

--- a/docs/rules/unary-following-arithmetic.md
+++ b/docs/rules/unary-following-arithmetic.md
@@ -1,0 +1,32 @@
+# unary-following-arithmetic (PORT051)
+Fix is sometimes available.
+
+This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use.
+
+## What it does
+Checks for use of a unary expression following an arithmetic operator.
+
+## Why is this bad?
+The use of a unary operator (`+`, `-` but *not* user-defined) following an arithmetic operator (
+`+`, `-`, `*`, `/`, `**` but *not* user-defined) is not part of the Fortran standard. In some
+cases, this may be ambiguous as the order of operations does not necessarily follow typical
+mathematical order. The computed output may therefore vary between compilers.
+
+Many compilers, Intel Fortran for example, will let you do this as an extension; sometimes with
+a warning on compilation. Use parentheses to remove ambiguity of user expected output; the fix
+may change prior behaviour on some compilers.
+
+## Example
+```f90
+x = 10 ** -2 * 2
+! Would expected x = 0.02 but some compilers may give x = 0.0001.
+```
+
+Use instead:
+```f90
+x = 10 ** (-2) * 2
+! Result is unambiguously x = 0.02.
+```
+
+## References
+* [Doctor Fortran in "Order! Order!"](https://stevelionel.com/drfortran/2021/04/03/doctor-fortran-in-order-order/)


### PR DESCRIPTION
**Add new unary-following-arithmetic rule.**

- Checks if a `unary_expression` (e.g negating a number `-3`) follows a `math_expression` (or alternatively named arithmetic expression) (e.g adding two numbers `2+3`). For example, `2 + -3` should be replaced with `2 + (-3)`.
- Works with all `unary_expression` and `math_expression` operator possibilities ~including user-defined~.

Have not implemented as `AlwaysFixable` as I think(?) it can be ambigious what the user would want.
E.g do we replace `10 ** -2 * 3 - 5` with A) `10 ** (-2) * 3 - 5` or B) `10 ** (-2 * 3) - 5` or C) `10 ** (-2 * 3 - 5)`? We could default to showing some unsafe fix where we parenthesise the first expression only (option A)? Or parenthesise everything (option B)?

Closes #495.