### PR TITLE
Enable passing arbitrary config settings on the command line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,7 +298,7 @@ take into account:
 - Configuration file settings from various sources:
   - Project level, such as `/path/to/project/fortitude.toml`
   - User level, such as `$HOME/.config/fortitude/fortitude.toml`
-  - Passed directly: `fortitude --config-file=myconfig.toml check`
+  - Passed directly: `fortitude --config=myconfig.toml check`
 - Command line settings (which may override config file settings)
 
 Config files within a project can also be hierarchical, so those nested deeper in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,12 +819,14 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "shellexpand",
  "strum",
  "tempfile",
  "termimad",
  "terminal-light",
  "test-case",
  "textwrap",
+ "toml",
 ]
 
 [[package]]
@@ -2337,11 +2339,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2692,44 +2694,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "topological-sort"
@@ -3596,12 +3596,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
-dependencies = [
- "memchr",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
 tree-sitter = "~0.25.0"
 tree-sitter-cli = "~0.25.0"
 tree-sitter-fortran = { git = "https://github.com/stadelmanma/tree-sitter-fortran.git", rev = "32a3e63" }
-toml = "0.8.19"
+toml = "1.0.0"
 unicode-width = "0.2.0"
 url = { version = "2.5.0" }
 

--- a/crates/fortitude/Cargo.toml
+++ b/crates/fortitude/Cargo.toml
@@ -38,10 +38,12 @@ ruff_text_size = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+shellexpand = { workspace = true }
 strum = { workspace = true }
 termimad = { workspace = true }
 terminal-light = { workspace = true }
 textwrap = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/fortitude/src/cli.rs
+++ b/crates/fortitude/src/cli.rs
@@ -1,10 +1,21 @@
-use clap::{ArgAction::SetTrue, Parser, Subcommand};
-use fortitude_workspace::configuration::{
-    convert_file_and_extensions_to_include, resolve_bool_arg,
+use anyhow::bail;
+use clap::{
+    ArgAction::SetTrue,
+    Parser, Subcommand,
+    builder::{TypedValueParser, ValueParserFactory},
 };
+use fortitude_workspace::{
+    configuration::{convert_file_and_extensions_to_include, resolve_bool_arg},
+    options::Options,
+};
+use itertools::Itertools;
 use path_absolutize::path_dedot;
+use ruff_options_metadata::{OptionEntry, OptionsMetadata};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::{fmt::Write as _, ops::Deref};
 
 use fortitude_linter::{
     fs::{FilePattern, GlobPath},
@@ -15,6 +26,7 @@ use fortitude_linter::{
         FortranStandard, IgnoreAllowComments, OutputFormat, PatternPrefixPair, PreviewMode,
         ProgressBar, UnsafeFixes,
     },
+    warn_user_once_by_message,
 };
 use fortitude_workspace::configuration::{Configuration, ConfigurationTransformer};
 
@@ -43,9 +55,26 @@ pub struct GlobalConfigArgs {
     #[clap(flatten)]
     log_level_args: LogLevelArgs,
 
-    /// Path to a TOML configuration file
-    #[arg(long, global = true, help_heading = "Global options")]
+    /// Either a path to a TOML configuration file
+    /// (`[fpm,fortitude,pyproject].toml`), or a TOML `<KEY> = <VALUE>` pair
+    /// (such as you might find in a `fortitude.toml` configuration file)
+    /// overriding a specific configuration option.  Overrides of individual
+    /// settings using this option always take precedence over all configuration
+    /// files, including configuration files that were also specified using
+    /// `--config`.
+    #[arg(
+        long,
+        action = clap::ArgAction::Append,
+        value_name = "CONFIG_OPTION",
+        value_parser = ConfigArgumentParser,
+        global = true,
+        help_heading = "Global options",
+    )]
+    pub config: Vec<SingleConfigArgument>,
+    /// Path to a TOML configuration file. (Deprecated: Use `--config=<filename>` instead.)
+    #[arg(long, global = true, help_heading = "Global options", hide = true)]
     pub config_file: Option<PathBuf>,
+
     /// Ignore all configuration files.
     #[arg(
         long,
@@ -452,7 +481,6 @@ pub struct CheckArguments {
 /// Configuration-related arguments passed via the CLI.
 #[derive(Default)]
 pub struct ConfigArguments {
-    // TODO: add other ruff bits like `isolated` and `overrides`
     /// Whether the user specified --isolated on the command line
     pub(crate) isolated: bool,
     /// The logging level to be used, derived from command-line arguments passed
@@ -460,6 +488,11 @@ pub struct ConfigArguments {
     /// Path to a fpm.toml or fortitude.toml configuration file (etc.).
     /// Either 0 or 1 configuration file paths may be provided on the command line.
     config_file: Option<PathBuf>,
+    /// Overrides provided via the `--config "KEY=VALUE"` option.
+    /// An arbitrary number of these overrides may be provided on the command line.
+    /// These overrides take precedence over all configuration files,
+    /// even configuration files that were also specified using `--config`.
+    overrides: Configuration,
     /// Overrides provided via dedicated flags such as `--line-length` etc.
     /// These overrides take precedence over all configuration files,
     /// and also over all overrides specified using any `--config "KEY=VALUE"` flags.
@@ -476,12 +509,63 @@ impl ConfigArguments {
         per_flag_overrides: ExplicitConfigOverrides,
     ) -> anyhow::Result<Self> {
         let log_level = global_options.log_level();
-        let config_file = global_options.config_file;
+        let deprecated_config_file = global_options.config_file;
+        let config_options = global_options.config;
         let isolated = global_options.isolated;
+
+        if deprecated_config_file.is_some() {
+            warn_user_once_by_message!(
+                "The `--config-file` option is now deprecated in favour of `--config`"
+            );
+        }
+
+        let mut config_file: Option<PathBuf> = deprecated_config_file;
+        let mut overrides = Configuration::default();
+
+        for option in config_options {
+            match option {
+                SingleConfigArgument::SettingsOverride(overridden_option) => {
+                    let overridden_option = Arc::try_unwrap(overridden_option)
+                        .unwrap_or_else(|option| option.deref().clone());
+                    overrides = overrides.combine(Configuration::from_options(
+                        overridden_option,
+                        &path_dedot::CWD,
+                    ));
+                }
+                SingleConfigArgument::FilePath(path) => {
+                    if isolated {
+                        bail!(
+                            "\
+The argument `--config={}` cannot be used with `--isolated`
+
+  tip: You cannot specify a configuration file and also specify `--isolated`,
+       as `--isolated` causes fortitude to ignore all configuration files.
+       For more information, try `--help`.
+",
+                            path.display()
+                        );
+                    }
+                    if let Some(ref config_file) = config_file {
+                        let (first, second) = (config_file.display(), path.display());
+                        bail!(
+                            "\
+You cannot specify more than one configuration file on the command line.
+
+  tip: remove either `--config={first}` or `--config={second}`.
+       For more information, try `--help`.
+"
+                        );
+                    }
+                    config_file = Some(path);
+                }
+            }
+        }
+
         Ok(Self {
             isolated,
             log_level,
             config_file,
+            overrides,
             per_flag_overrides,
         })
     }
@@ -489,7 +573,8 @@ impl ConfigArguments {
 
 impl ConfigurationTransformer for ConfigArguments {
     fn transform(&self, config: Configuration) -> Configuration {
-        self.per_flag_overrides.transform(config)
+        let with_config_overrides = self.overrides.clone().combine(config);
+        self.per_flag_overrides.transform(with_config_overrides)
     }
 }
 
@@ -700,5 +785,205 @@ pub struct ServerCommand {
 impl ServerCommand {
     pub(crate) fn resolve_preview(self) -> Option<bool> {
         resolve_bool_arg(Some(self.preview), Some(self.no_preview))
+    }
+}
+
+/// Enumeration of various ways in which a --config CLI flag
+/// could be invalid
+#[derive(Debug)]
+enum InvalidConfigFlagReason {
+    InvalidToml(toml::de::Error),
+    /// It was valid TOML, but not a valid fortitude config file.
+    /// E.g. the user tried to select a rule that doesn't exist,
+    /// or tried to enable a setting that doesn't exist
+    ValidTomlButInvalidFortitudeSchema(toml::de::Error),
+    /// It was a valid fortitude config file, but the user tried to pass a
+    /// value for `extend` as part of the config override.
+    /// `extend` is special, because it affects which config files we look at
+    /// in the first place. We currently only parse --config overrides *after*
+    /// we've combined them with all the arguments from the various config files
+    /// that we found, so trying to override `extend` as part of a --config
+    /// override is forbidden.
+    // TODO(peter): use this when we get `extend`
+    #[allow(dead_code)]
+    ExtendPassedViaConfigFlag,
+}
+
+impl InvalidConfigFlagReason {
+    const fn description(&self) -> &'static str {
+        match self {
+            Self::InvalidToml(_) => "The supplied argument is not valid TOML",
+            Self::ValidTomlButInvalidFortitudeSchema(_) => {
+                "Could not parse the supplied argument as a `fortitude.toml` configuration option"
+            }
+            Self::ExtendPassedViaConfigFlag => "Cannot include `extend` in a --config flag value",
+        }
+    }
+}
+
+/// Enumeration to represent a single `--config` argument
+/// passed via the CLI.
+///
+/// Using the `--config` flag, users may pass 0 or 1 paths
+/// to configuration files and an arbitrary number of
+/// "inline TOML" overrides for specific settings.
+///
+/// For example:
+///
+/// ```sh
+/// fortitude check --config "path/to/fortitude.toml" --config "extend-select=['E501', 'F841']" --config "lint.per-file-ignores = {'some_file.py' = ['F841']}"
+/// ```
+#[derive(Clone, Debug)]
+pub enum SingleConfigArgument {
+    FilePath(PathBuf),
+    SettingsOverride(Arc<Options>),
+}
+
+#[derive(Clone)]
+pub struct ConfigArgumentParser;
+
+impl ValueParserFactory for SingleConfigArgument {
+    type Parser = ConfigArgumentParser;
+
+    fn value_parser() -> Self::Parser {
+        ConfigArgumentParser
+    }
+}
+
+impl TypedValueParser for ConfigArgumentParser {
+    type Value = SingleConfigArgument;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        // Convert to UTF-8.
+        let Some(value) = value.to_str() else {
+            // But respect non-UTF-8 paths.
+            let path_to_config_file = PathBuf::from(value);
+            if path_to_config_file.is_file() {
+                return Ok(SingleConfigArgument::FilePath(path_to_config_file));
+            }
+            return Err(clap::Error::new(clap::error::ErrorKind::InvalidUtf8));
+        };
+
+        // Expand environment variables and tildes.
+        if let Ok(path_to_config_file) =
+            shellexpand::full(value).map(|config| PathBuf::from(&*config))
+            && path_to_config_file.is_file()
+        {
+            return Ok(SingleConfigArgument::FilePath(path_to_config_file));
+        }
+
+        let config_parse_error = match toml::Table::from_str(value) {
+            Ok(table) => match table.try_into::<Options>() {
+                Ok(option) => {
+                    return Ok(SingleConfigArgument::SettingsOverride(Arc::new(option)));
+                }
+                Err(underlying_error) => {
+                    InvalidConfigFlagReason::ValidTomlButInvalidFortitudeSchema(underlying_error)
+                }
+            },
+            Err(underlying_error) => InvalidConfigFlagReason::InvalidToml(underlying_error),
+        };
+
+        let mut new_error = clap::Error::new(clap::error::ErrorKind::ValueValidation).with_cmd(cmd);
+        if let Some(arg) = arg {
+            new_error.insert(
+                clap::error::ContextKind::InvalidArg,
+                clap::error::ContextValue::String(arg.to_string()),
+            );
+        }
+        new_error.insert(
+            clap::error::ContextKind::InvalidValue,
+            clap::error::ContextValue::String(value.to_string()),
+        );
+
+        let underlying_error = match &config_parse_error {
+            InvalidConfigFlagReason::ExtendPassedViaConfigFlag => {
+                let tip = config_parse_error.description().into();
+                new_error.insert(
+                    clap::error::ContextKind::Suggested,
+                    clap::error::ContextValue::StyledStrs(vec![tip]),
+                );
+                return Err(new_error);
+            }
+            InvalidConfigFlagReason::InvalidToml(underlying_error)
+            | InvalidConfigFlagReason::ValidTomlButInvalidFortitudeSchema(underlying_error) => {
+                underlying_error
+            }
+        };
+
+        // small hack so that multiline tips
+        // have the same indent on the left-hand side:
+        let tip_indent = " ".repeat("  tip: ".len());
+
+        let mut tip = format!(
+            "\
+A `--config` flag must either be a path to a `.toml` configuration file
+{tip_indent}or a TOML `<KEY> = <VALUE>` pair overriding a specific configuration
+{tip_indent}option"
+        );
+
+        // Here we do some heuristics to try to figure out whether
+        // the user was trying to pass in a path to a configuration file
+        // or some inline TOML.
+        // We want to display the most helpful error to the user as possible.
+        if Path::new(value)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
+        {
+            if !value.contains('=') {
+                let _ = write!(
+                    &mut tip,
+                    "
+
+It looks like you were trying to pass a path to a configuration file.
+The path `{value}` does not point to a configuration file"
+                );
+            }
+        } else if let Some((key, value)) = value.split_once('=') {
+            let key = key.trim_ascii();
+            let value = value.trim_ascii_start();
+
+            match Options::metadata().find(key) {
+                Some(OptionEntry::Set(set)) if !value.starts_with('{') => {
+                    let prefixed_subfields = set
+                        .collect_fields()
+                        .iter()
+                        .map(|(name, _)| format!("- `{key}.{name}`"))
+                        .join("\n");
+
+                    let _ = write!(
+                        &mut tip,
+                        "
+
+`{key}` is a table of configuration options.
+Did you want to override one of the table's subkeys?
+
+Possible choices:
+
+{prefixed_subfields}"
+                    );
+                }
+                _ => {
+                    let _ = write!(
+                        &mut tip,
+                        "\n\n{}:\n\n{underlying_error}",
+                        config_parse_error.description()
+                    );
+                }
+            }
+        }
+        let tip = tip.trim_end().to_owned().into();
+
+        new_error.insert(
+            clap::error::ContextKind::Suggested,
+            clap::error::ContextValue::StyledStrs(vec![tip]),
+        );
+
+        Err(new_error)
     }
 }

--- a/crates/fortitude/tests/check.rs
+++ b/crates/fortitude/tests/check.rs
@@ -280,7 +280,7 @@ unknown-key = 1
 
     assert_cmd_snapshot!(cmd
                          .check_command()
-                         .args(["--config-file", "fpm.toml"])
+                         .args(["--config", "fpm.toml"])
                          .arg("no_file.f90"),
                          @r"
     success: false
@@ -359,7 +359,7 @@ select = ["C001", "style"]
 
     assert_cmd_snapshot!(cmd
                          .check_command()
-                         .args(["--config-file", "fortitude.toml"])
+                         .args(["--config", "fortitude.toml"])
                          .arg("test.f90"),
                          @r"
     success: false
@@ -403,7 +403,7 @@ select = ["C001"]
 
     assert_cmd_snapshot!(cmd
                          .check_command()
-                         .args(["--config-file", "fortitude.toml"])
+                         .args(["--config", "fortitude.toml"])
                          .arg("test.f90")
                          .args(["--extend-select", "style"]),
                          @r"
@@ -783,7 +783,7 @@ fixable = ["C003"]
                          .arg("--unsafe-fixes")
                          .arg("--fix")
                          .arg("--extend-fixable=S061")
-                         .args(["--config-file", "fortitude.toml"])
+                         .args(["--config", "fortitude.toml"])
                          .arg("test.f90"),
                          @r"
     success: true
@@ -827,7 +827,7 @@ fixable = ["C003"]
                          .arg("--unsafe-fixes")
                          .arg("--fix")
                          .arg("--fixable=S061")
-                         .args(["--config-file", "fortitude.toml"])
+                         .args(["--config", "fortitude.toml"])
                          .arg("test.f90"),
                          @r"
     success: false
@@ -873,7 +873,7 @@ fixable = ["S061"]
                          .arg("--fix")
                          .arg("--unfixable=S061")
                          .arg("--extend-fixable=C003")
-                         .args(["--config-file", "fortitude.toml"])
+                         .args(["--config", "fortitude.toml"])
                          .arg("test.f90"),
                          @r"
     success: false
@@ -1592,7 +1592,7 @@ end program myprogram
     ])?;
     assert_cmd_snapshot!(cmd
                          .check_command()
-                         .args(["--config-file", "fortitude.toml"])
+                         .args(["--config", "fortitude.toml"])
                          .arg("myfile.ff")
                          .args(["--select=S001,S091,C001"]),
                          @r"
@@ -2347,5 +2347,282 @@ fn output_format_show_fixes(output_format: &str) -> Result<()> {
         ])
     );
 
+    Ok(())
+}
+
+#[test]
+fn config_override_rejected_if_invalid_toml() {
+    assert_cmd_snapshot!(fortitude_cmd().arg("check")
+        .args(STDIN_BASE_OPTIONS)
+        .args(["--config", "foo = bar", "."]), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: invalid value 'foo = bar' for '--config <CONFIG_OPTION>'
+
+      tip: A `--config` flag must either be a path to a `.toml` configuration file
+           or a TOML `<KEY> = <VALUE>` pair overriding a specific configuration
+           option
+
+    The supplied argument is not valid TOML:
+
+    TOML parse error at line 1, column 7
+      |
+    1 | foo = bar
+      |       ^^^
+    string values must be quoted, expected literal string
+
+    For more information, try '--help'.
+    ");
+}
+
+#[test]
+fn too_many_config_files() -> Result<()> {
+    let fixture = FortitudeCheck::new()?;
+    fixture.write_file("fortitude.toml", "")?;
+    fixture.write_file("fortitude2.toml", "")?;
+
+    assert_cmd_snapshot!(fixture
+        .check_command()
+        .arg("--config")
+        .arg("fortitude.toml")
+        .arg("--config")
+        .arg("fortitude2.toml")
+        .arg("."), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    fortitude failed
+    Error: You cannot specify more than one configuration file on the command line.
+
+      tip: remove either `--config=fortitude.toml` or `--config=fortitude2.toml`.
+           For more information, try `--help`.
+    ");
+    Ok(())
+}
+
+#[test]
+fn config_file_and_isolated() -> Result<()> {
+    let fixture = FortitudeCheck::new()?;
+    fixture.write_file("fortitude.toml", "")?;
+
+    assert_cmd_snapshot!(fixture
+        .check_command()
+        .arg("--config")
+        .arg("fortitude.toml")
+        .arg("--isolated")
+        .arg("."), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    fortitude failed
+    Error: The argument `--config=fortitude.toml` cannot be used with `--isolated`
+
+      tip: You cannot specify a configuration file and also specify `--isolated`,
+           as `--isolated` causes fortitude to ignore all configuration files.
+           For more information, try `--help`.
+    ");
+    Ok(())
+}
+
+#[test]
+fn config_override_via_cli() -> Result<()> {
+    let fixture = FortitudeCheck::with_file(
+        "fortitude.toml",
+        r#"
+[check]
+line-length = 100
+select = ["E"]
+        "#,
+    )?;
+    let test_code = r#"
+program test
+integer, dimension(3) :: foo
+
+x = "longer_than_90_charactersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss"
+end
+"#;
+    assert_cmd_snapshot!(fixture
+        .check_command()
+        .arg("--config")
+        .arg("fortitude.toml")
+        .args(["--config", "check.line-length=90"])
+        .args(["--config", "check.extend-select=['S001', 'S263']"])
+        .args(["--config", "check.inconsistent-dimensions.prefer-attribute = \"never\""])
+        .arg("-")
+        .pass_stdin(test_code), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:3:26: S263 Bad declaration of array
+    -:5:91: S001 line length of 97, exceeds maximum 90
+    fortitude: 1 files scanned.
+    Number of errors: 2
+
+    For more information about specific rules, run:
+
+        fortitude explain X001,Y002,...
+
+    No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
+#[test]
+fn valid_toml_but_nonexistent_option_provided_via_config_argument() {
+    assert_cmd_snapshot!(fortitude_cmd().arg("check")
+        .args(STDIN_BASE_OPTIONS)
+        .args([".", "--config", "check.extend-select=['NOTACODE']"]),
+        @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: invalid value 'check.extend-select=['NOTACODE']' for '--config <CONFIG_OPTION>'
+
+      tip: A `--config` flag must either be a path to a `.toml` configuration file
+           or a TOML `<KEY> = <VALUE>` pair overriding a specific configuration
+           option
+
+    Could not parse the supplied argument as a `fortitude.toml` configuration option:
+
+    Unknown rule selector: `NOTACODE`
+    in `check.extend-select`
+
+    For more information, try '--help'.
+    ");
+}
+
+#[test]
+fn each_toml_option_requires_a_new_flag_1() {
+    assert_cmd_snapshot!(fortitude_cmd().arg("check")
+        .args(STDIN_BASE_OPTIONS)
+        // commas can't be used to delimit different config overrides;
+        // you need a new --config flag for each override
+        .args([".", "--config", "check.extend-select=['S001'], check.line-length=90"]),
+        @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: invalid value 'check.extend-select=['S001'], check.line-length=90' for '--config <CONFIG_OPTION>'
+
+      tip: A `--config` flag must either be a path to a `.toml` configuration file
+           or a TOML `<KEY> = <VALUE>` pair overriding a specific configuration
+           option
+
+    The supplied argument is not valid TOML:
+
+    TOML parse error at line 1, column 29
+      |
+    1 | check.extend-select=['S001'], check.line-length=90
+      |                             ^
+    unexpected key or value, expected newline, `#`
+
+    For more information, try '--help'.
+    ");
+}
+
+#[test]
+fn each_toml_option_requires_a_new_flag_2() {
+    assert_cmd_snapshot!(fortitude_cmd().arg("check")
+        .args(STDIN_BASE_OPTIONS)
+        // spaces *also* can't be used to delimit different config overrides;
+        // you need a new --config flag for each override
+        .args([".", "--config", "check.extend-select=['S001'] check.line-length=90"]),
+        @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: invalid value 'check.extend-select=['S001'] check.line-length=90' for '--config <CONFIG_OPTION>'
+
+      tip: A `--config` flag must either be a path to a `.toml` configuration file
+           or a TOML `<KEY> = <VALUE>` pair overriding a specific configuration
+           option
+
+    The supplied argument is not valid TOML:
+
+    TOML parse error at line 1, column 30
+      |
+    1 | check.extend-select=['S001'] check.line-length=90
+      |                              ^
+    unexpected key or value, expected newline, `#`
+
+    For more information, try '--help'.
+    ");
+}
+
+#[test]
+fn config_doubly_overridden_via_cli() -> Result<()> {
+    let fixture = FortitudeCheck::with_file(
+        "fortitude.toml",
+        r#"
+[check]
+line-length = 100
+select=["S001"]
+"#,
+    )?;
+    let test_code = "program test\nx = 'longer_than_90_charactersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss'\nend";
+    assert_cmd_snapshot!(fixture
+        .check_command()
+        // The --line-length flag takes priority over both the config file
+        // and the `--config="check.line-length=110"` flag,
+        // despite them both being specified after this flag on the command line:
+        .args(["--line-length", "90"])
+        .arg("--config")
+        .arg("fortitude.toml")
+        .args(["--config", "check.line-length=110"])
+        .arg("-")
+        .pass_stdin(test_code), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:2:91: S001 line length of 97, exceeds maximum 90
+    fortitude: 1 files scanned.
+    Number of errors: 1
+
+    For more information about specific rules, run:
+
+        fortitude explain X001,Y002,...
+
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
+#[test]
+fn complex_config_setting_overridden_via_cli() -> Result<()> {
+    let fixture = FortitudeCheck::with_file("fortitude.toml", "check.select = ['C001']")?;
+    let test_code = "program violates_c001; end";
+    assert_cmd_snapshot!(fixture
+        .check_command()
+        .arg("--config")
+        .arg("fortitude.toml")
+        .args(["--config", "check.per-file-ignores = {'generated.f90' = ['C001']}"])
+        .args(["--stdin-filename", "generated.f90"])
+        .arg("-")
+        .pass_stdin(test_code), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    fortitude: 1 files scanned.
+    All checks passed!
+
+
+    ----- stderr -----
+    ");
     Ok(())
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,10 +56,9 @@ to a source file than the root `fortitude.toml`, then rule selection
 settings such as `select` and `ignore` are taken from the nested file,
 not from the root file.
 
-If a config file is passed on the command line using `--config-file`,
-those settings are used for _all_ files, and any relative paths in
-that config file are resolved relative to the directory where
-`fortitude` is run.
+If a config file is passed on the command line using `--config`, those settings
+are used for _all_ files, and any relative paths in that config file are
+resolved relative to the directory where `fortitude` is run.
 
 Similarly, any other options set on the command line (for example,
 `--select`) override those in all found config files.
@@ -196,6 +195,54 @@ $ fortitude check --select S001 --select implicit-typing --quiet
 Settings on the command line always take precedence over those given in the configuration
 file.
 
+### The `--config` CLI flag
+
+The `--config` flag has two uses. It is most often used to point to the
+configuration file that you would like Fortitude to use, for example:
+
+```console
+$ fortitude check path/to/directory --config path/to/fortitude.toml
+```
+
+However, the `--config` flag can also be used to provide arbitrary
+overrides of configuration settings using TOML `<KEY> = <VALUE>` pairs.
+This is mostly useful in situations where you wish to override a configuration setting
+that does not have a dedicated command-line flag.
+
+In the below example, the `--config` flag is the only way of overriding the
+`use-statements.allow-bare-use` configuration setting from the command line,
+since this setting has no dedicated CLI flag. The `per-file-ignores` setting
+could also have been overridden via the `--per-file-ignores` dedicated flag,
+but using `--config` to override the setting is also fine:
+
+```console
+$ fortitude check path/to/file --config path/to/fortitude.toml --config
+"lint.use-statements.allow-bare-use = ['netcdf']" --config "lint.per-file-ignores = {'some_file.f90' = ['C001']}"
+```
+
+Configuration options passed to `--config` are parsed in the same way as
+configuration options in a `fortitude.toml` file.  As such, options specific to
+the Fortitude linter need to be prefixed with `check.`  (`--config
+"check.use-statements.allow-bare-use = ['netcdf']"` rather than simply `--config
+"use-statements.allow-bare-use = ['netcdf']"`).
+
+If a specific configuration option is simultaneously overridden by
+a dedicated flag and by the `--config` flag, the dedicated flag
+takes priority. In this example, the maximum permitted line length
+will be set to 90, not 100:
+
+```console
+$ fortitude check path/to/file --line-length=90 --config "check.line-length=100"
+```
+
+Specifying `--config "check.line-length=90"` will override the
+`check.line-length` setting from *all* configuration files detected by
+Fortitude, including configuration files discovered in subdirectories.  In this
+respect, specifying `--config "check.line-length=90"` has the same effect as
+specifying `--line-length=90`, which will similarly override the
+`check.line-length` setting from all configuration files detected by Fortitude,
+regardless of where a specific configuration file is located.
+
 ### Full command-line interface
 
 See `fortitude help` for the full list of Fortitude's top-level commands:
@@ -225,8 +272,10 @@ Log levels:
   -s, --silent   Disable all logging (but still exit with status code "1" upon detecting diagnostics)
 
 Global options:
-      --config-file <CONFIG_FILE>  Path to a TOML configuration file
-      --isolated                   Ignore all configuration files
+      --config <CONFIG_OPTION>
+          Either a path to a TOML configuration file (`[fpm,fortitude,pyproject].toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might find in a `fortitude.toml` configuration file) overriding a specific configuration option.  Overrides of individual settings using this option always take precedence over all configuration files, including configuration files that were also specified using `--config`
+      --isolated
+          Ignore all configuration files
 
 For help with a specific command, see: `fortitude help <command>`.
 ```
@@ -330,8 +379,10 @@ Log levels:
   -s, --silent   Disable all logging (but still exit with status code "1" upon detecting diagnostics)
 
 Global options:
-      --config-file <CONFIG_FILE>  Path to a TOML configuration file
-      --isolated                   Ignore all configuration files
+      --config <CONFIG_OPTION>
+          Either a path to a TOML configuration file (`[fpm,fortitude,pyproject].toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might find in a `fortitude.toml` configuration file) overriding a specific configuration option.  Overrides of individual settings using this option always take precedence over all configuration files, including configuration files that were also specified using `--config`
+      --isolated
+          Ignore all configuration files
 ```
 
 <!-- End auto-generated check help. -->


### PR DESCRIPTION
Deprecates `--config-file` in favour of `--config`

Feature and docs completely taken from Ruff and adapted