### PR TITLE
Fix links to relevant settings from rule docstrings

### DIFF
--- a/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
+++ b/crates/fortitude_linter/src/rules/correctness/exit_labels.rs
@@ -108,8 +108,8 @@ impl AstRule for MissingExitOrCycleLabel {
 /// end do
 /// ```
 ///
-/// ## Settings
-/// See [check.exit-unlabelled-loops](../settings.md#checkexit-unlabelled-loops)
+/// ## Options
+/// - `check.exit-unlabelled-loops.allow-unnested-loops`
 #[derive(ViolationMetadata)]
 pub(crate) struct ExitOrCycleInUnlabelledLoop {
     name: String,

--- a/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
+++ b/crates/fortitude_linter/src/rules/correctness/shadowed_variable.rs
@@ -81,8 +81,9 @@ use ruff_macros::derive_message_formats;
 /// end module my_mod
 /// ```
 ///
-/// ## Settings
-/// See [check.shadowed-variables](../settings.md#checkshadowed-variables)
+/// ## Options
+/// - `check.shadowed-variables.allow`
+/// - `check.shadowed-variables.strict`
 #[derive(ViolationMetadata)]
 pub struct ShadowedVariable {
     name: String,

--- a/crates/fortitude_linter/src/rules/correctness/use_statements.rs
+++ b/crates/fortitude_linter/src/rules/correctness/use_statements.rs
@@ -29,8 +29,8 @@ use tree_sitter::Node;
 /// code have come from, and avoids introducing many unneeded components to your
 /// local scope.
 ///
-/// ## Settings
-/// See [check.use-statements](../settings.md#checkuse-statements)
+/// ## Options
+/// - `check.use-statements.allow-bare-use`
 #[derive(ViolationMetadata)]
 pub(crate) struct UseAll {}
 

--- a/crates/fortitude_linter/src/rules/style/keywords.rs
+++ b/crates/fortitude_linter/src/rules/style/keywords.rs
@@ -101,7 +101,7 @@ impl DoubleKeyword {
 /// - `check.keyword-whitespace.inout-with-space`
 /// - `check.keyword-whitespace.goto-with-space`
 #[derive(ViolationMetadata)]
-pub struct KeywordsMissingSpace {
+pub(crate) struct KeywordsMissingSpace {
     keywords: DoubleKeyword,
 }
 
@@ -194,7 +194,7 @@ impl AstRule for KeywordsMissingSpace {
 /// - `check.keyword-whitespace.inout-with-space`
 /// - `check.keyword-whitespace.goto-with-space`
 #[derive(ViolationMetadata)]
-pub struct KeywordHasWhitespace {
+pub(crate) struct KeywordHasWhitespace {
     keywords: DoubleKeyword,
 }
 
@@ -358,7 +358,7 @@ pub mod settings {
 /// ## Options
 /// - `check.incorrect-keyword-case.keyword-case`
 #[derive(ViolationMetadata)]
-pub struct IncorrectKeywordCase {
+pub(crate) struct IncorrectKeywordCase {
     actual: String,
     expected: String,
 }

--- a/crates/fortitude_linter/src/rules/style/keywords.rs
+++ b/crates/fortitude_linter/src/rules/style/keywords.rs
@@ -90,12 +90,16 @@ impl DoubleKeyword {
 /// omitted, such as `elseif` instead of `else if` and `endmodule` instead of
 /// `endmodule`. The keywords `inout` and `goto` are exempt from this rule by
 /// default, but may be included by setting the options
-/// [`inout-with-space`](../settings.md#inout-with-space) and
-/// [`goto-with-space`](../settings.md#goto-with-space).
+/// [`check.keyword-whitespace.inout-with-space`] and
+/// [`check.keyword-whitespace.goto-with-space`].
 ///
 /// ## Why is this bad?
 /// Contracting two keywords into one can make code less readable. Enforcing
 /// this rule can help maintain a consistent style.
+///
+/// ## Options
+/// - `check.keyword-whitespace.inout-with-space`
+/// - `check.keyword-whitespace.goto-with-space`
 #[derive(ViolationMetadata)]
 pub struct KeywordsMissingSpace {
     keywords: DoubleKeyword,
@@ -175,15 +179,20 @@ impl AstRule for KeywordsMissingSpace {
 
 /// ## What it does
 /// Checks for the use of `in out` instead of `inout` and `go to` instead of `goto`.
-/// Either may be exempted from this rule by setting the options
-/// [`inout-with-space`](../settings.md#inout-with-space) and
-/// [`goto-with-space`](../settings.md#goto-with-space).
 ///
 /// ## Why is this bad?
 /// By convention, `inout` is normally preferred to `in out`. Both `go to` and
 /// `goto` are valid, but Fortitude prefers the latter as `goto` is most common
 /// in other languages, and neither `go` nor `to` have secondary purposes in
 /// other keywords. Enforcing this rule can help maintain a consistent style.
+///
+/// Either keyword may be exempted from this rule by setting the options
+/// [`check.keyword-whitespace.inout-with-space`] and
+/// [`check.keyword-whitespace.goto-with-space`].
+///
+/// ## Options
+/// - `check.keyword-whitespace.inout-with-space`
+/// - `check.keyword-whitespace.goto-with-space`
 #[derive(ViolationMetadata)]
 pub struct KeywordHasWhitespace {
     keywords: DoubleKeyword,
@@ -298,9 +307,7 @@ pub mod settings {
 }
 
 /// ## What it does
-/// Checks that Fortran keywords use a consistent casing style. Flags any keyword
-/// whose casing does not match the configured style (see
-/// [`keyword-case`](../settings.md#keyword-case)).
+/// Checks that Fortran keywords use a consistent casing style.
 ///
 /// ## Why is this bad?
 /// Fortran is case-insensitive, so keyword casing is purely a stylistic choice.
@@ -309,8 +316,10 @@ pub mod settings {
 /// harder to scan. Enforcing a consistent style helps maintain a uniform
 /// appearance across the codebase.
 ///
-/// Modern Fortran style guides generally favour lowercase keywords. Older
-/// codebases often use uppercase, inherited from fixed-form Fortran conventions.
+/// Modern Fortran style guides generally favour lowercase keywords, while older
+/// codebases often use uppercase, inherited from fixed-form Fortran
+/// conventions; the used case can be configured with
+/// [`check.incorrect-keyword-case.keyword-case`]
 ///
 /// ## Examples
 ///
@@ -345,6 +354,9 @@ pub mod settings {
 /// INTEGER, INTENT(IN) :: x
 /// END SUBROUTINE foo
 /// ```
+///
+/// ## Options
+/// - `check.incorrect-keyword-case.keyword-case`
 #[derive(ViolationMetadata)]
 pub struct IncorrectKeywordCase {
     actual: String,

--- a/crates/fortitude_macros/src/violation_metadata.rs
+++ b/crates/fortitude_macros/src/violation_metadata.rs
@@ -37,6 +37,13 @@ fn get_docs(attrs: &[Attribute]) -> syn::Result<String> {
                 let line = value.strip_prefix(' ').unwrap_or(&value);
                 explanation.push_str(line);
                 explanation.push('\n');
+
+                if explanation.contains("## Settings") {
+                    return Err(Error::new_spanned(
+                        attr,
+                        "use '## Options' instead of '## Settings'",
+                    ));
+                }
             } else {
                 return Err(Error::new_spanned(attr, "unimplemented doc comment style"));
             }

--- a/docs/rules/exit-or-cycle-in-unlabelled-loop.md
+++ b/docs/rules/exit-or-cycle-in-unlabelled-loop.md
@@ -25,5 +25,9 @@ do i = 1, 10
 end do
 ```
 
-## Settings
-See [check.exit-unlabelled-loops](../settings.md#checkexit-unlabelled-loops)
+## Options
+- [`check.exit-unlabelled-loops.allow-unnested-loops`][check.exit-unlabelled-loops.allow-unnested-loops]
+
+
+[check.exit-unlabelled-loops.allow-unnested-loops]: ../settings.md#check_exit-unlabelled-loops_allow-unnested-loops
+

--- a/docs/rules/incorrect-keyword-case.md
+++ b/docs/rules/incorrect-keyword-case.md
@@ -6,9 +6,7 @@ This rule is unstable and in [preview](../preview.md). The `--preview` flag is r
 This rule is turned on by default.
 
 ## What it does
-Checks that Fortran keywords use a consistent casing style. Flags any keyword
-whose casing does not match the configured style (see
-[`keyword-case`](../settings.md#keyword-case)).
+Checks that Fortran keywords use a consistent casing style.
 
 ## Why is this bad?
 Fortran is case-insensitive, so keyword casing is purely a stylistic choice.
@@ -17,8 +15,10 @@ However, inconsistent casing — mixing `IMPLICIT NONE`, `implicit none`, and
 harder to scan. Enforcing a consistent style helps maintain a uniform
 appearance across the codebase.
 
-Modern Fortran style guides generally favour lowercase keywords. Older
-codebases often use uppercase, inherited from fixed-form Fortran conventions.
+Modern Fortran style guides generally favour lowercase keywords, while older
+codebases often use uppercase, inherited from fixed-form Fortran
+conventions; the used case can be configured with
+[`check.incorrect-keyword-case.keyword-case`][check.incorrect-keyword-case.keyword-case]
 
 ## Examples
 
@@ -53,3 +53,10 @@ IMPLICIT NONE
 INTEGER, INTENT(IN) :: x
 END SUBROUTINE foo
 ```
+
+## Options
+- [`check.incorrect-keyword-case.keyword-case`][check.incorrect-keyword-case.keyword-case]
+
+
+[check.incorrect-keyword-case.keyword-case]: ../settings.md#check_incorrect-keyword-case_keyword-case
+

--- a/docs/rules/keyword-has-whitespace.md
+++ b/docs/rules/keyword-has-whitespace.md
@@ -5,12 +5,22 @@ This rule is turned on by default.
 
 ## What it does
 Checks for the use of `in out` instead of `inout` and `go to` instead of `goto`.
-Either may be exempted from this rule by setting the options
-[`inout-with-space`](../settings.md#inout-with-space) and
-[`goto-with-space`](../settings.md#goto-with-space).
 
 ## Why is this bad?
 By convention, `inout` is normally preferred to `in out`. Both `go to` and
 `goto` are valid, but Fortitude prefers the latter as `goto` is most common
 in other languages, and neither `go` nor `to` have secondary purposes in
 other keywords. Enforcing this rule can help maintain a consistent style.
+
+Either keyword may be exempted from this rule by setting the options
+[`check.keyword-whitespace.inout-with-space`][check.keyword-whitespace.inout-with-space] and
+[`check.keyword-whitespace.goto-with-space`][check.keyword-whitespace.goto-with-space].
+
+## Options
+- [`check.keyword-whitespace.inout-with-space`][check.keyword-whitespace.inout-with-space]
+- [`check.keyword-whitespace.goto-with-space`][check.keyword-whitespace.goto-with-space]
+
+
+[check.keyword-whitespace.inout-with-space]: ../settings.md#check_keyword-whitespace_inout-with-space
+[check.keyword-whitespace.goto-with-space]: ../settings.md#check_keyword-whitespace_goto-with-space
+

--- a/docs/rules/keywords-missing-space.md
+++ b/docs/rules/keywords-missing-space.md
@@ -8,9 +8,18 @@ Checks for the use of keywords comprised of two words where the space is
 omitted, such as `elseif` instead of `else if` and `endmodule` instead of
 `endmodule`. The keywords `inout` and `goto` are exempt from this rule by
 default, but may be included by setting the options
-[`inout-with-space`](../settings.md#inout-with-space) and
-[`goto-with-space`](../settings.md#goto-with-space).
+[`check.keyword-whitespace.inout-with-space`][check.keyword-whitespace.inout-with-space] and
+[`check.keyword-whitespace.goto-with-space`][check.keyword-whitespace.goto-with-space].
 
 ## Why is this bad?
 Contracting two keywords into one can make code less readable. Enforcing
 this rule can help maintain a consistent style.
+
+## Options
+- [`check.keyword-whitespace.inout-with-space`][check.keyword-whitespace.inout-with-space]
+- [`check.keyword-whitespace.goto-with-space`][check.keyword-whitespace.goto-with-space]
+
+
+[check.keyword-whitespace.inout-with-space]: ../settings.md#check_keyword-whitespace_inout-with-space
+[check.keyword-whitespace.goto-with-space]: ../settings.md#check_keyword-whitespace_goto-with-space
+

--- a/docs/rules/shadowed-variable.md
+++ b/docs/rules/shadowed-variable.md
@@ -77,5 +77,11 @@ contains
 end module my_mod
 ```
 
-## Settings
-See [check.shadowed-variables](../settings.md#checkshadowed-variables)
+## Options
+- [`check.shadowed-variables.allow`][check.shadowed-variables.allow]
+- [`check.shadowed-variables.strict`][check.shadowed-variables.strict]
+
+
+[check.shadowed-variables.allow]: ../settings.md#check_shadowed-variables_allow
+[check.shadowed-variables.strict]: ../settings.md#check_shadowed-variables_strict
+

--- a/docs/rules/use-all.md
+++ b/docs/rules/use-all.md
@@ -21,5 +21,9 @@ This makes it easier for programmers to understand where the symbols in your
 code have come from, and avoids introducing many unneeded components to your
 local scope.
 
-## Settings
-See [check.use-statements](../settings.md#checkuse-statements)
+## Options
+- [`check.use-statements.allow-bare-use`][check.use-statements.allow-bare-use]
+
+
+[check.use-statements.allow-bare-use]: ../settings.md#check_use-statements_allow-bare-use
+

--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -97,6 +97,17 @@ use tree_sitter::Node;
 /// Use instead:
 /// ```f90
 /// ```
+///
+/// <!---
+/// Delete this section if you don't have any options
+/// ## Options
+/// - `check.options-group.option-name`
+/// --->
+///
+/// <---
+/// ## References
+/// - Include any references here
+/// --->
 #[derive(ViolationMetadata)]
 pub(crate) struct {name};
 


### PR DESCRIPTION
Closes #682

Try to be more consistent in how we link to rule-specific settings from the
docstrings, make it a compile-time error if the wrong section title is used, and
add something to the template for making new rules.