### PR TITLE
Fix performance regression in `line-too-long`

### DIFF
--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -59,6 +59,7 @@ use ruff_source_file::{SourceFile, SourceFileBuilder};
 use rustc_hash::FxHashMap;
 use source_kind::SourceKindDiff;
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{self, Write};
 use std::iter::once;
@@ -304,9 +305,14 @@ pub(crate) fn check_path(
 
     // Perform AST analysis
     let root = tree.root_node();
+    let mut comment_positions = HashSet::new();
     for node in once(root).chain(root.descendants()) {
         if context.is_rule_enabled(Rule::SyntaxError) && node.is_missing() {
             violations.push(context.create_diagnostic(SyntaxError {}, node));
+        }
+
+        if node.kind_id() == kind!("comment") {
+            comment_positions.insert(node.start_position());
         }
 
         if node.is_named() && BEGIN_SCOPE_NODES.contains(&node.kind()) {
@@ -369,7 +375,7 @@ pub(crate) fn check_path(
 
     // ignore line length in comments requires AST
     if context.is_rule_enabled(Rule::LineTooLong) {
-        violations.extend(LineTooLong::check(&context, &root));
+        violations.extend(LineTooLong::check(&context, &comment_positions));
     }
 
     if context.is_rule_enabled(Rule::InvalidTab) {

--- a/crates/fortitude_linter/src/rules/style/line_length.rs
+++ b/crates/fortitude_linter/src/rules/style/line_length.rs
@@ -6,7 +6,6 @@ use ruff_macros::derive_message_formats;
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use std::collections::HashSet;
-use tree_sitter::Node;
 use tree_sitter::Point;
 
 /// ## What does it do?
@@ -78,7 +77,7 @@ impl Violation for LineTooLong {
 }
 
 impl LineTooLong {
-    pub fn check(context: &CheckContext, root: &Node) -> Vec<Diagnostic> {
+    pub fn check(context: &CheckContext, comment_positions: &HashSet<Point>) -> Vec<Diagnostic> {
         let source = context.source_file().to_source_code();
         let settings = context.settings();
         let limit = settings.line_length;
@@ -86,21 +85,6 @@ impl LineTooLong {
         let mut violations = Vec::new();
 
         let tab_size = settings.invalid_tab.indent_width.as_usize();
-
-        let comment_positions: HashSet<Point> = context
-            .source_text()
-            .char_indices()
-            .filter(|(index, _)| {
-                if let Some(node) = root.named_descendant_for_byte_range(*index, *index) {
-                    matches!(node.kind(), "comment")
-                } else {
-                    false
-                }
-            })
-            .map(|(index, _)| root.named_descendant_for_byte_range(index, index))
-            .filter(|node| node.is_some())
-            .map(|node| node.unwrap().start_position())
-            .collect();
 
         for line in source.text().universal_newlines() {
             // The maximum width of the line is the number of bytes multiplied by the tab size (the


### PR DESCRIPTION
Collecting the comment positions while walking the AST gives a ~30% speed up (with concise output) over using `named_descendant_for_byte_range` inside the check. The latter method has to walk the entire AST for each character, and caused the rule to take 5x as long as all of the AST rules combined.