### PR TITLE
Fix typo in attribute name

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C061.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C061.f90
@@ -9,7 +9,7 @@ contains
   integer function foo(a, b, c, p)
     use mod
     integer :: a, c(2), f
-    integer, dimension(:), intent(in) :: b
+    integer, intent(in), contiguous :: b(:)
     procedure(sub) :: p         ! must not have `intent`
   end function foo
 

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -549,7 +549,7 @@ end subroutine foo
         let code = r#"
 function foo(x)
   integer, intent(in) :: x
-  integer, allocatable, dimension(:) :: foo
+  integer, allocatable, dimension(:), contiguous, save :: foo
 end function foo
 "#;
         let tree = parser.parse(code, None).context("Failed to parse")?;
@@ -563,6 +563,8 @@ end function foo
         let foo = foo.unwrap();
         assert!(!foo.is_dummy_var());
         assert!(foo.has_attribute(AttributeKind::Allocatable));
+        assert!(foo.has_attribute(AttributeKind::Contiguous));
+        assert!(foo.has_attribute(AttributeKind::Save));
         assert!(
             foo.attributes()
                 .iter()

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -250,7 +250,7 @@ pub enum AttributeKind<'a> {
     Codimension,
     Dimension(Dimension<'a>),
     Constant,
-    Continguous,
+    Contiguous,
     Device,
     External,
     Intent(Intent),

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-intent-f95_C061.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-intent-f95_C061.f90.snap
@@ -10,7 +10,7 @@ C061 function argument 'a' missing 'intent' attribute
 10 |     use mod
 11 |     integer :: a, c(2), f
    |                ^
-12 |     integer, dimension(:), intent(in) :: b
+12 |     integer, intent(in), contiguous :: b(:)
 13 |     procedure(sub) :: p         ! must not have `intent`
    |
 
@@ -21,7 +21,7 @@ C061 function argument 'c' missing 'intent' attribute
 10 |     use mod
 11 |     integer :: a, c(2), f
    |                   ^^^^
-12 |     integer, dimension(:), intent(in) :: b
+12 |     integer, intent(in), contiguous :: b(:)
 13 |     procedure(sub) :: p         ! must not have `intent`
    |
 

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-intent_C061.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__missing-intent_C061.f90.snap
@@ -10,7 +10,7 @@ C061 function argument 'a' missing 'intent' attribute
 10 |     use mod
 11 |     integer :: a, c(2), f
    |                ^
-12 |     integer, dimension(:), intent(in) :: b
+12 |     integer, intent(in), contiguous :: b(:)
 13 |     procedure(sub) :: p         ! must not have `intent`
    |
 
@@ -21,7 +21,7 @@ C061 function argument 'c' missing 'intent' attribute
 10 |     use mod
 11 |     integer :: a, c(2), f
    |                   ^^^^
-12 |     integer, dimension(:), intent(in) :: b
+12 |     integer, intent(in), contiguous :: b(:)
 13 |     procedure(sub) :: p         ! must not have `intent`
    |
 


### PR DESCRIPTION
Fixes #695 

Typo in the attribute enum variant name meant that the variable declaration wasn't being parsed correctly, and because there was another variable with the same name in a higher scope, that was getting checked instead.