### PR TITLE
Propagate some errors better 

### DIFF
--- a/crates/fortitude/src/check.rs
+++ b/crates/fortitude/src/check.rs
@@ -4,15 +4,17 @@ use crate::resolve;
 use crate::show_files::show_files;
 use crate::show_settings::show_settings;
 use crate::stdin::read_from_stdin;
-use fortitude_linter::diagnostics::{Diagnostics, FixMap, Violation};
+use fortitude_linter::diagnostics::{
+    Diagnostics, FixMap, Violation, create_panic_diagnostic, panic::catch_unwind,
+};
 use fortitude_linter::fs::{self, read_to_string};
-use fortitude_linter::line_filter::{FilterMap, git_since, git_staged_files};
+use fortitude_linter::line_filter::{FilterMap, FilterSet, git_since, git_staged_files};
 use fortitude_linter::rules::Rule;
 use fortitude_linter::rules::error::ioerror::IoError;
 use fortitude_linter::settings::{self, CheckSettings, FixMode, ProgressBar, Settings};
 use fortitude_linter::source_kind::SourceKindDiff;
 use fortitude_linter::warn_user_once;
-use fortitude_linter::{FixerResult, check_and_fix_file, check_file, check_only_file};
+use fortitude_linter::{FixerResult, check_and_fix_file, check_only_file};
 
 use anyhow::Result;
 use colored::Colorize;
@@ -21,7 +23,7 @@ use ignore::Error;
 use indicatif::{ParallelProgressIterator, ProgressStyle};
 use log::{debug, warn};
 use rayon::prelude::*;
-use ruff_source_file::SourceFileBuilder;
+use ruff_source_file::{SourceFile, SourceFileBuilder};
 use ruff_text_size::TextRange;
 use rustc_hash::FxHashMap;
 use std::fmt::Write;
@@ -454,6 +456,34 @@ fn check_files(
     );
 
     Ok(results)
+}
+
+pub fn check_file(
+    path: &Path,
+    file: &SourceFile,
+    line_filter: &Option<FilterSet>,
+    settings: &CheckSettings,
+    fix_mode: FixMode,
+    ignore_allow_comments: settings::IgnoreAllowComments,
+) -> anyhow::Result<Diagnostics> {
+    let result = catch_unwind(|| {
+        fortitude_linter::check_file(
+            path,
+            file,
+            line_filter,
+            settings,
+            fix_mode,
+            ignore_allow_comments,
+        )
+    });
+
+    match result {
+        Ok(inner) => inner,
+        Err(error) => {
+            let diagnostic = create_panic_diagnostic(&error, Some(path));
+            Ok(Diagnostics::new(vec![diagnostic]))
+        }
+    }
 }
 
 fn check_stdin(

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use strum_macros::EnumIs;
 use tree_sitter::Node;
 
-use crate::{ast::types::ProcedureKind, traits::HasNode};
+use crate::traits::HasNode;
 
 use super::{
     FortitudeNode,
@@ -88,7 +88,7 @@ pub struct SymbolTable<'a> {
 impl<'a> SymbolTable<'a> {
     /// Create a new [`SymbolTable`] for a node which is a scope (that is,
     /// contains variable declarations)
-    pub fn new(scope: &Node<'a>, src: &str) -> Self {
+    pub fn new(scope: &Node<'a>, src: &str) -> anyhow::Result<Self> {
         let mut new_table = Self::default();
 
         // If this is a procedure, collect a list of dummy arg names
@@ -113,17 +113,45 @@ impl<'a> SymbolTable<'a> {
             vec![]
         };
 
-        scope
-            .named_children(&mut scope.walk())
-            .filter(|child| child.kind() == "use_statement")
-            .filter_map(|stmt| UseStatement::try_from_node(&stmt, src).ok())
-            .for_each(|stmt| new_table.insert_from_use_statement(stmt, src));
-
-        scope
-            .named_children(&mut scope.walk())
-            .filter(|child| child.kind() == "variable_declaration")
-            .filter_map(|decl| VariableDeclaration::try_from_node(&decl, src).ok())
-            .for_each(|line| new_table.insert_from_decl_line(line, &dummy_vars));
+        for child in scope.named_children(&mut scope.walk()) {
+            match child.kind_id() {
+                kind!("use_statement") => {
+                    let use_statement = UseStatement::try_from_node(&child, src)?;
+                    new_table.insert_from_use_statement(use_statement, src);
+                }
+                kind!("variable_declaration") => {
+                    let decl = VariableDeclaration::try_from_node(&child, src)?;
+                    new_table.insert_from_decl_line(decl, &dummy_vars);
+                }
+                kind!("internal_procedures") => {
+                    for proc in child.named_children(&mut child.walk()) {
+                        let procedure = match proc.kind_id() {
+                            kind!("function") => {
+                                Symbol::Function(Procedure::try_from_node(&proc, src)?)
+                            }
+                            kind!("subroutine") => {
+                                Symbol::Subroutine(Procedure::try_from_node(&proc, src)?)
+                            }
+                            _ => continue,
+                        };
+                        new_table.insert_symbol(procedure);
+                    }
+                }
+                _ => {
+                    let symbol = match child.kind_id() {
+                        kind!("derived_type_definition") => {
+                            Symbol::Type(TypeDefinition::try_from_node(&child, src)?)
+                        }
+                        kind!("module") => Symbol::Module(Module::try_from_node(&child, src)?),
+                        kind!("program") => Symbol::Program(Program::try_from_node(&child, src)?),
+                        _ => {
+                            continue;
+                        }
+                    };
+                    new_table.insert_symbol(symbol);
+                }
+            }
+        }
 
         // The `function` statement itself _may_ also be the declaration line if
         // it has a type as a procedure attribute. If it doesn't, then it will
@@ -145,48 +173,7 @@ impl<'a> SymbolTable<'a> {
             }
         }
 
-        // Add procedure definitions
-        if let Some(procs) = scope.child_with_name("internal_procedures") {
-            procs
-                .named_children(&mut procs.walk())
-                .filter_map(|proc| match proc.kind_id() {
-                    kind!("function") | kind!("subroutine") => {
-                        Procedure::try_from_node(&proc, src).ok()
-                    }
-                    _ => None,
-                })
-                .for_each(|proc| {
-                    let name = proc.name();
-                    match proc.kind() {
-                        ProcedureKind::Function => new_table
-                            .inner
-                            .insert(name.to_string(), Symbol::Function(proc)),
-                        ProcedureKind::Subroutine => new_table
-                            .inner
-                            .insert(name.to_string(), Symbol::Subroutine(proc)),
-                    };
-                })
-        }
-
-        // Add modules, programs, and derived type definitions
-        scope
-            .named_children(&mut scope.walk())
-            .filter_map(|child| match child.kind() {
-                "derived_type_definition" => TypeDefinition::try_from_node(&child, src)
-                    .ok()
-                    .map(Symbol::Type),
-                "module" => Module::try_from_node(&child, src).ok().map(Symbol::Module),
-                "program" => Program::try_from_node(&child, src)
-                    .ok()
-                    .map(Symbol::Program),
-                _ => None,
-            })
-            .for_each(|symbol| {
-                let name = symbol.name();
-                new_table.inner.insert(name.to_string(), symbol);
-            });
-
-        new_table
+        Ok(new_table)
     }
 
     /// Insert all symbols found in a single variable declaration statement
@@ -217,6 +204,10 @@ impl<'a> SymbolTable<'a> {
             }
         }
         self.use_statements.push(stmt);
+    }
+
+    pub fn insert_symbol(&mut self, symbol: Symbol<'a>) {
+        self.inner.insert(symbol.name().to_string(), symbol);
     }
 
     /// Return the symbol with the given name if it exists
@@ -340,7 +331,7 @@ end program foo
         let second_decl_range = TextRange::new(TextSize::new(43), TextSize::new(71));
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let x = symbol_table.get_var("x");
         let y = symbol_table.get_var("y");
@@ -411,7 +402,7 @@ end program foo
         let tree = parser.parse(code, None).context("Failed to parse")?;
         let root = tree.root_node().child(0).context("Missing child")?;
 
-        let symbol_table = SymbolTable::new(&root, code);
+        let symbol_table = SymbolTable::new(&root, code)?;
 
         assert!(symbol_table.get("x").is_some());
         assert!(symbol_table.get("a").is_none());
@@ -436,7 +427,7 @@ end program foo
         let root = tree.root_node().child(0).context("Missing child")?;
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let x = symbol_table.get_var("X");
         assert!(x.is_some());
@@ -467,12 +458,12 @@ end program foo
         let root = tree.root_node().child(0).context("Missing child")?;
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let block = root
             .child_with_name("block_construct")
             .context("Missing block")?;
-        symbol_table.push_table(SymbolTable::new(&block, code));
+        symbol_table.push_table(SymbolTable::new(&block, code)?);
 
         let x = symbol_table.get_var("X");
         assert!(x.is_some());
@@ -511,7 +502,7 @@ end subroutine foo
         let root = tree.root_node().child(0).context("Missing child")?;
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let x = symbol_table.get_var("x");
         assert!(x.is_some());
@@ -556,7 +547,7 @@ end function foo
         let root = tree.root_node().child(0).context("Missing child")?;
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let foo = symbol_table.get_var("foo");
         assert!(foo.is_some());
@@ -588,7 +579,7 @@ end function foo
         let root = tree.root_node().child(0).context("Missing child")?;
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let foo = symbol_table.get_var("foo");
         assert!(foo.is_some());
@@ -615,7 +606,7 @@ end function foo
         let root = tree.root_node().child(0).context("Missing child")?;
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let y = symbol_table.get_var("y");
         assert!(y.is_some());
@@ -648,7 +639,7 @@ end program foo
         let root = tree.root_node().child(0).context("Missing child")?;
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let bar = symbol_table.get("bar");
         assert!(bar.is_some());
@@ -681,7 +672,7 @@ end program foo
         let root = tree.root_node().child(0).context("Missing child")?;
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let i8 = symbol_table.get("i8");
         assert!(i8.is_some());
@@ -765,7 +756,7 @@ end program foo
         let tree = parser.parse(code, None).context("Failed to parse")?;
         let root = tree.root_node().child(0).context("Missing child")?;
 
-        let symbol_table = SymbolTable::new(&root, code);
+        let symbol_table = SymbolTable::new(&root, code)?;
 
         let count = symbol_table.iter_symbols().count();
         assert_eq!(count, 6);

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -278,7 +278,8 @@ impl<'a> AttributeKind<'a> {
     pub fn try_from_node(value: &Node<'a>) -> Result<Self> {
         let first_child = value.child(0).unwrap().kind();
         // TODO: handle codimension properly
-        let attr = AttributeKind::from_str(first_child)?;
+        let attr = AttributeKind::from_str(first_child)
+            .context(format!("unknown attribute '{first_child}'"))?;
 
         match attr {
             AttributeKind::Intent(_) => Ok(AttributeKind::Intent(Intent::from_node(value))),
@@ -685,7 +686,8 @@ pub struct ProcedureAttribute<'a> {
 
 impl<'a> ProcedureAttribute<'a> {
     pub fn try_from_node(node: Node<'a>) -> Result<Self> {
-        let kind = ProcedureAttributeKind::from_str(node.kind())?;
+        let kind = ProcedureAttributeKind::from_str(node.kind())
+            .context(format!("unknown procedure attribute '{}'", node.kind()))?;
         Ok(Self { kind, node })
     }
 
@@ -717,7 +719,8 @@ impl<'a> Procedure<'a> {
             return Err(anyhow!("not a procedure"));
         }
 
-        let kind = ProcedureKind::from_str(node.kind()).unwrap();
+        let kind = ProcedureKind::from_str(node.kind())
+            .context(format!("unknown procedure kind '{}'", node.kind()))?;
 
         let stmt = node.child(0).context("expected child")?;
 
@@ -730,6 +733,7 @@ impl<'a> Procedure<'a> {
         let attributes: Result<Vec<_>> = stmt
             .named_children(&mut stmt.walk())
             .filter(|attr| attr.kind_id() == kind!("procedure_qualifier"))
+            .map(|attr| attr.child(0).expect("procedure_qualifier must have child"))
             .map(ProcedureAttribute::try_from_node)
             .collect();
         let attributes = attributes?;

--- a/crates/fortitude_linter/src/diagnostics/mod.rs
+++ b/crates/fortitude_linter/src/diagnostics/mod.rs
@@ -3,17 +3,20 @@
 // SPDX-License-Identifier: MIT
 
 mod message;
+pub mod panic;
 mod stylesheet;
 pub mod violation;
 
 use std::{
+    backtrace::BacktraceStatus,
     borrow::Cow,
     fmt::{Display, Formatter},
     ops::{Add, AddAssign},
+    path::Path,
     sync::Arc,
 };
 
-use ruff_source_file::{LineColumn, SourceFile};
+use ruff_source_file::{LineColumn, SourceFile, SourceFileBuilder};
 use rustc_hash::FxHashMap;
 
 use anyhow::Result;
@@ -21,7 +24,10 @@ use ruff_annotate_snippets::Level as AnnotateLevel;
 use ruff_text_size::{Ranged, TextRange};
 use serde::Serialize;
 
-use crate::{fix::FixTable, rules::Rule, settings::OutputFormat, traits::TextRanged};
+use crate::{
+    diagnostics::panic::PanicError, fix::FixTable, rules::Rule, settings::OutputFormat,
+    traits::TextRanged,
+};
 
 pub use message::{DisplayDiagnostic, DisplayDiagnostics, render_diagnostics};
 pub use violation::{AlwaysFixableViolation, FixAvailability, Violation, ViolationMetadata};
@@ -1600,6 +1606,55 @@ where
         env!("CARGO_PKG_HOMEPAGE"),
         rule.name()
     )));
+
+    diagnostic
+}
+
+/// Create a `Diagnostic` from a panic.
+pub fn create_panic_diagnostic(error: &PanicError, path: Option<&Path>) -> Diagnostic {
+    let mut diagnostic = Diagnostic::new(
+        DiagnosticId::Panic,
+        Severity::Fatal,
+        error.to_diagnostic_message(path.as_ref().map(|path| path.display())),
+    );
+
+    diagnostic.sub(SubDiagnostic::new(
+        SubDiagnosticSeverity::Info,
+        "This indicates a bug in Fortitude.",
+    ));
+    let report_message = "If you could open an issue at \
+                            https://github.com/PlasmaFAIR/fortitude/issues/new?title=%5Bpanic%5D, \
+                            we'd be very appreciative!";
+    diagnostic.sub(SubDiagnostic::new(
+        SubDiagnosticSeverity::Info,
+        report_message,
+    ));
+
+    if let Some(backtrace) = &error.backtrace {
+        match backtrace.status() {
+            BacktraceStatus::Disabled => {
+                diagnostic.sub(SubDiagnostic::new(
+                            SubDiagnosticSeverity::Info,
+                            "run with `RUST_BACKTRACE=1` environment variable to show the full backtrace information",
+                        ));
+            }
+            BacktraceStatus::Captured => {
+                diagnostic.sub(SubDiagnostic::new(
+                    SubDiagnosticSeverity::Info,
+                    format!("Backtrace:\n{backtrace}"),
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(path) = path {
+        let file = SourceFileBuilder::new(path.to_string_lossy(), "").finish();
+        let span = Span::from(file);
+        let mut annotation = Annotation::primary(span);
+        annotation.hide_snippet(true);
+        diagnostic.annotate(annotation);
+    }
 
     diagnostic
 }

--- a/crates/fortitude_linter/src/diagnostics/panic.rs
+++ b/crates/fortitude_linter/src/diagnostics/panic.rs
@@ -1,0 +1,167 @@
+// Adapted from ruff
+// Copyright 2022-2026 Charles Marsh
+// SPDX-License-Identifier: MIT
+
+use std::any::Any;
+use std::backtrace::BacktraceStatus;
+use std::cell::Cell;
+use std::panic::Location;
+use std::sync::OnceLock;
+
+#[derive(Debug)]
+pub struct PanicError {
+    pub location: Option<String>,
+    pub payload: Payload,
+    pub backtrace: Option<std::backtrace::Backtrace>,
+}
+
+#[derive(Debug)]
+pub struct Payload(Box<dyn std::any::Any + Send>);
+
+impl Payload {
+    pub fn downcast_ref<R: Any>(&self) -> Option<&R> {
+        self.0.downcast_ref::<R>()
+    }
+}
+
+impl std::fmt::Display for Payload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(s) = self.0.downcast_ref::<String>() {
+            f.write_str(s)
+        } else if let Some(s) = self.0.downcast_ref::<&str>() {
+            f.write_str(s)
+        } else {
+            f.write_str("Box<dyn Any>")
+        }
+    }
+}
+
+impl PanicError {
+    pub fn resume_unwind(self) -> ! {
+        std::panic::resume_unwind(self.payload.0)
+    }
+
+    pub fn to_diagnostic_message(&self, path: Option<impl std::fmt::Display>) -> String {
+        use std::fmt::Write;
+
+        let mut message = String::new();
+        message.push_str("Panicked");
+
+        if let Some(location) = &self.location {
+            let _ = write!(&mut message, " at {location}");
+        }
+
+        if let Some(path) = path {
+            let _ = write!(&mut message, " when checking `{path}`");
+        }
+
+        let _ = write!(&mut message, ": `{payload}`", payload = self.payload);
+
+        message
+    }
+}
+
+impl std::fmt::Display for PanicError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "panicked at")?;
+        if let Some(location) = &self.location {
+            write!(f, " {location}")?;
+        }
+
+        write!(f, ":\n{payload}", payload = self.payload)?;
+
+        if let Some(backtrace) = &self.backtrace {
+            match backtrace.status() {
+                BacktraceStatus::Disabled => {
+                    writeln!(
+                        f,
+                        "\nrun with `RUST_BACKTRACE=1` environment variable to display a backtrace"
+                    )?;
+                }
+                BacktraceStatus::Captured => {
+                    writeln!(f, "\nBacktrace: {backtrace}")?;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct CapturedPanicInfo {
+    backtrace: Option<std::backtrace::Backtrace>,
+    location: Option<String>,
+}
+
+thread_local! {
+    static CAPTURE_PANIC_INFO: Cell<bool> = const { Cell::new(false) };
+    static LAST_BACKTRACE: Cell<CapturedPanicInfo> = const {
+        Cell::new(CapturedPanicInfo { backtrace: None, location: None })
+    };
+}
+
+fn install_hook() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let should_capture = CAPTURE_PANIC_INFO.with(Cell::get);
+            if !should_capture {
+                return (*prev)(info);
+            }
+
+            let location = info.location().map(Location::to_string);
+            let backtrace = Some(std::backtrace::Backtrace::capture());
+
+            LAST_BACKTRACE.set(CapturedPanicInfo {
+                backtrace,
+                location,
+            });
+        }));
+    });
+}
+
+/// Invokes a closure, capturing and returning the cause of an unwinding panic if one occurs.
+///
+/// ### Thread safety
+///
+/// This is implemented by installing a custom [panic hook](std::panic::set_hook).  This panic hook
+/// is a global resource.  The hook that we install captures panic info in a thread-safe manner,
+/// and also ensures that any threads that are _not_ currently using this `catch_unwind` wrapper
+/// still use the previous hook (typically the default hook, which prints out panic information to
+/// stderr).
+///
+/// We assume that there is nothing else running in this process that needs to install a competing
+/// panic hook. We are careful to install our custom hook only once, and we do not ever restore
+/// the previous hook (since you can always retain the previous hook's behavior by not calling this
+/// wrapper).
+pub fn catch_unwind<F, R>(f: F) -> Result<R, PanicError>
+where
+    F: FnOnce() -> R + std::panic::UnwindSafe,
+{
+    install_hook();
+    let prev_should_capture = CAPTURE_PANIC_INFO.replace(true);
+    let result = std::panic::catch_unwind(f).map_err(|payload| {
+        // Try to get the backtrace and location from our custom panic hook.
+        // The custom panic hook only runs once when `panic!` is called (or similar). It doesn't
+        // run when the panic is propagated with `std::panic::resume_unwind`. The panic hook
+        // is also not called when the panic is raised with `std::panic::resume_unwind`.
+        // Because of that, always take the payload from `catch_unwind` because it may have been transformed
+        // by an inner `std::panic::catch_unwind` handlers and only use the information
+        // from the custom handler to enrich the error with the backtrace and location.
+        let CapturedPanicInfo {
+            location,
+            backtrace,
+        } = LAST_BACKTRACE.with(Cell::take);
+
+        PanicError {
+            location,
+            payload: Payload(payload),
+            backtrace,
+        }
+    });
+    CAPTURE_PANIC_INFO.set(prev_should_capture);
+    result
+}

--- a/crates/fortitude_linter/src/fix/edits.rs
+++ b/crates/fortitude_linter/src/fix/edits.rs
@@ -299,7 +299,7 @@ end program foo
         let root = tree.root_node().child(0).context("Missing child")?;
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let test_source = SourceFileBuilder::new("test.f90", code).finish();
 
@@ -360,7 +360,7 @@ end program foo
         let root = tree.root_node().child(0).context("Missing child")?;
 
         let mut symbol_table = SymbolTables::default();
-        symbol_table.push_table(SymbolTable::new(&root, code));
+        symbol_table.push_table(SymbolTable::new(&root, code)?);
 
         let x = symbol_table.get_var("x").unwrap();
         let y = symbol_table.get_var("y").unwrap();

--- a/crates/fortitude_linter/src/lib.rs
+++ b/crates/fortitude_linter/src/lib.rs
@@ -256,13 +256,7 @@ pub fn check_only_file(
         .parse(file.source_text(), None)
         .context("Failed to parse")?;
 
-    Ok(check_path(
-        path,
-        file,
-        settings,
-        &tree,
-        ignore_allow_comments,
-    ))
+    check_path(path, file, settings, &tree, ignore_allow_comments)
 }
 
 /// Check an already parsed file. This actually does all the checking,
@@ -274,7 +268,7 @@ pub(crate) fn check_path(
     settings: &CheckSettings,
     tree: &Tree,
     ignore_allow_comments: settings::IgnoreAllowComments,
-) -> Vec<Diagnostic> {
+) -> anyhow::Result<Vec<Diagnostic>> {
     let mut violations = Vec::new();
     let mut allow_comments = Vec::new();
 
@@ -316,7 +310,7 @@ pub(crate) fn check_path(
         }
 
         if node.is_named() && BEGIN_SCOPE_NODES.contains(&node.kind()) {
-            let new_table = SymbolTable::new(&node, file.source_text());
+            let new_table = SymbolTable::new(&node, file.source_text())?;
 
             // Check for keyword reuse in this scope
             if context.rules.enabled(Rule::KeywordReuse) {
@@ -501,7 +495,7 @@ pub(crate) fn check_path(
         }
     }
 
-    violations
+    Ok(violations)
 }
 
 const MAX_ITERATIONS: usize = 100;
@@ -549,7 +543,7 @@ pub fn check_and_fix_file<'a>(
         // Map row and column locations to byte slices (lazily).
         let locator = Locator::new(transformed.source_text());
 
-        let violations = check_path(path, &transformed, settings, &tree, ignore_allow_comments);
+        let violations = check_path(path, &transformed, settings, &tree, ignore_allow_comments)?;
 
         if iterations == 0 {
             is_valid_syntax = !tree.root_node().has_error();


### PR DESCRIPTION
A couple of things to help improve catching/detecting errors.

I'm in two minds about the ast/types enum parsing. Currently we mostly have methods like `Meow::try_from_node() -> Result<Self>`, but `Err`s that get bubbled up just get turned into warnings without much context:

```
warning: Error opening file /tmp/foo.f90: unknown attribute 'contiguous'
  Cause: unknown attribute 'contiguous'
  Cause: Matching variant not found
```

If we instead used `.expect` or something to convert these into panics, the first commit here gives us something a bit more actionable:

```
error[panic]: Panicked at crates/fortitude_linter/src/ast/types.rs:281:57 when checking `/tmp/foo.f90`: `unknown attribute 'contiguous': VariantNotFound`
--> /tmp/foo.f90:1:1
info: This indicates a bug in Fortitude.
info: If you could open an issue at https://github.com/PlasmaFAIR/fortitude/issues/new?title=%5Bpanic%5D, we'd be very appreciative!
info: run with `RUST_BACKTRACE=1` environment variable to show the full backtrace information
```

We can use get a backtrace, which helps with pinpointing the error.

Also, given that we handle syntax errors separately, we should really be able to always convert into our internal enums, and failure to do so means we're not handling something correctly and is therefore a bug that we want to know about ASAP.