### PR TITLE
Don't trigger `trailing-backslash` if the next node is a comment 

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C051.F90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C051.F90
@@ -8,4 +8,6 @@ program t
     A = 2.0
     print *, A
 
+    ! this is fine \
+    ! if this is a comment
 end program t

--- a/crates/fortitude_linter/src/rules/correctness/trailing_backslash.rs
+++ b/crates/fortitude_linter/src/rules/correctness/trailing_backslash.rs
@@ -1,7 +1,7 @@
 use crate::ast::FortitudeNode;
 use crate::diagnostics::{Diagnostic, Violation};
 use crate::{AstRule, CheckContext, kind_ids};
-use fortitude_macros::ViolationMetadata;
+use fortitude_macros::{ViolationMetadata, kind};
 use lazy_regex::regex;
 use ruff_macros::derive_message_formats;
 use ruff_text_size::{TextRange, TextSize};
@@ -52,6 +52,10 @@ impl Violation for TrailingBackslash {
 
 impl AstRule for TrailingBackslash {
     fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
+        if node.next_sibling()?.kind_id() == kind!("comment") {
+            return None;
+        }
+
         // Preprocessor might ignore trailing whitespace
         let trailing_backslash_re = regex!(r#".*(\\)\s*$"#);
 


### PR DESCRIPTION
Fixes #694

Includes #701 to keep clippy happy