### PR TITLE
Don't raise `C072` for UDTIO routines

### DIFF
--- a/crates/fortitude_linter/resources/test/fixtures/correctness/C072.f90
+++ b/crates/fortitude_linter/resources/test/fixtures/correctness/C072.f90
@@ -17,3 +17,21 @@ contains
     character(len=*), parameter :: alt_attr = 'sample'
   end subroutine char_input
 end program cases
+
+module udtio
+  implicit none (type, external)
+  interface write(formatted)
+    module procedure :: write_formatted
+  end interface write(formatted)
+
+contains
+  ! This shouldn't raise because the standard mandates this signature for UDTIO
+  subroutine write_formatted(self, unit, iotype, v_list, iostat, iomsg)
+    class(demo_type), intent(in) :: self
+    integer, intent(in) :: unit
+    character(len=*), intent(in) :: iotype
+    integer, intent(in) :: v_list(:)
+    integer, intent(out) :: iostat
+    character(len=*), intent(inout) :: iomsg
+  end subroutine write_formatted
+end module udtio

--- a/crates/fortitude_linter/src/ast.rs
+++ b/crates/fortitude_linter/src/ast.rs
@@ -115,10 +115,6 @@ pub trait FortitudeNode<'tree> {
     /// Convert a node to text, collapsing any raised errors to None.
     fn to_text<'a>(&self, src: &'a str) -> Option<&'a str>;
 
-    /// Given a variable declaration or function statement, return its type if it's an intrinsic type,
-    /// or None otherwise.
-    fn parse_intrinsic_type(&self) -> Option<String>;
-
     /// Get the current indentation level of the node.
     fn indentation(&self, source_file: &SourceFile) -> String;
 
@@ -234,14 +230,6 @@ impl<'tree1> FortitudeNode<'tree1> for Node<'tree1> {
 
     fn to_text<'a>(&self, src: &'a str) -> Option<&'a str> {
         self.utf8_text(src.as_bytes()).ok()
-    }
-
-    fn parse_intrinsic_type(&self) -> Option<String> {
-        if let Some(child) = self.child_with_name("intrinsic_type") {
-            let grandchild = child.child(0)?;
-            return Some(grandchild.kind().to_string());
-        }
-        None
     }
 
     fn indentation(&self, source_file: &SourceFile) -> String {

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -88,7 +88,7 @@ pub struct SymbolTable<'a> {
 impl<'a> SymbolTable<'a> {
     /// Create a new [`SymbolTable`] for a node which is a scope (that is,
     /// contains variable declarations)
-    pub fn new(scope: &Node<'a>, src: &str) -> anyhow::Result<Self> {
+    pub fn new(scope: &Node<'a>, src: &'a str) -> anyhow::Result<Self> {
         let mut new_table = Self::default();
 
         // If this is a procedure, collect a list of dummy arg names

--- a/crates/fortitude_linter/src/ast/symbol_table.rs
+++ b/crates/fortitude_linter/src/ast/symbol_table.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use strum_macros::EnumIs;
 use tree_sitter::Node;
 
-use crate::traits::HasNode;
+use crate::traits::{HasNode, TextRanged};
 
 use super::{
     FortitudeNode,
@@ -239,6 +239,13 @@ impl<'a> SymbolTable<'a> {
     pub fn iter(&self) -> impl Iterator<Item = (&String, &Symbol<'_>)> {
         self.inner.iter()
     }
+
+    /// Find declaration containing the given node
+    pub fn decl_containing_node(&self, node: &Node) -> Option<&Rc<VariableDeclaration<'_>>> {
+        self.decl_lines
+            .iter()
+            .find(|decl| decl.node().textrange().contains(node.start_textsize()))
+    }
 }
 
 /// A stack of [`SymbolTable`]
@@ -257,6 +264,11 @@ impl<'a> SymbolTables<'a> {
 
     pub fn pop_table(&mut self) -> Option<SymbolTable<'a>> {
         self.inner.pop()
+    }
+
+    /// Return the current most inner symbol table
+    pub fn current(&self) -> Option<&SymbolTable<'a>> {
+        self.inner.last()
     }
 
     /// Return the symbol with the given name if it exists and is a variable

--- a/crates/fortitude_linter/src/ast/types.rs
+++ b/crates/fortitude_linter/src/ast/types.rs
@@ -313,26 +313,103 @@ impl<'a> Attribute<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, EnumIs, IntoStaticStr)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
+pub enum IntrinsicType<'a> {
+    Byte(TypeInner<'a>),
+    Integer(TypeInner<'a>),
+    Real(TypeInner<'a>),
+    #[strum(to_string = "double precision")]
+    DoublePrecision(TypeInner<'a>),
+    Complex(TypeInner<'a>),
+    #[strum(to_string = "double complex")]
+    DoubleComplex(TypeInner<'a>),
+    Logical(TypeInner<'a>),
+    Character(TypeInner<'a>),
+}
+
+impl<'a> IntrinsicType<'a> {
+    pub fn from_node(node: Node<'a>, src: &'a str) -> Self {
+        if node.kind_id() != kind!("intrinsic_type") {
+            panic!(
+                "IntrinsicType can only be created from `intrinsic_type`, got {}",
+                node.kind()
+            );
+        }
+        let type_node = node.child(0).expect("must have zeroth child");
+        let name = type_node.to_text(src).expect("must have text");
+        match type_node.kind_id() {
+            kw!("byte") => IntrinsicType::Byte(TypeInner { node, name }),
+            kw!("integer") => IntrinsicType::Integer(TypeInner { node, name }),
+            kw!("real") => IntrinsicType::Real(TypeInner { node, name }),
+            kw!("doubleprecision") => IntrinsicType::DoublePrecision(TypeInner { node, name }),
+            kw!("complex") => IntrinsicType::Complex(TypeInner { node, name }),
+            kw!("doublecomplex") => IntrinsicType::DoubleComplex(TypeInner { node, name }),
+            kw!("logical") => IntrinsicType::Logical(TypeInner { node, name }),
+            kw!("character") => IntrinsicType::Character(TypeInner { node, name }),
+            kw!("double") => {
+                let second = node
+                    .child(1)
+                    .expect("`double` must be followed by either `complex` or `precision`");
+                match second.kind_id() {
+                    kw!("complex") => IntrinsicType::DoubleComplex(TypeInner { node, name }),
+                    kw!("precision") => IntrinsicType::DoublePrecision(TypeInner { node, name }),
+                    _ => unreachable!("unexpected keyword following `double`"),
+                }
+            }
+            _ => unreachable!("Unexpected node kind for `intrinsic_type`"),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Byte(TypeInner { name, .. }) => name,
+            Self::Integer(TypeInner { name, .. }) => name,
+            Self::Real(TypeInner { name, .. }) => name,
+            Self::DoublePrecision(TypeInner { name, .. }) => name,
+            Self::Complex(TypeInner { name, .. }) => name,
+            Self::DoubleComplex(TypeInner { name, .. }) => name,
+            Self::Logical(TypeInner { name, .. }) => name,
+            Self::Character(TypeInner { name, .. }) => name,
+        }
+    }
+}
+
+impl<'a> HasNode<'a> for IntrinsicType<'a> {
+    fn node(&self) -> &Node<'a> {
+        match self {
+            Self::Byte(TypeInner { node, .. }) => node,
+            Self::Integer(TypeInner { node, .. }) => node,
+            Self::Real(TypeInner { node, .. }) => node,
+            Self::DoublePrecision(TypeInner { node, .. }) => node,
+            Self::Complex(TypeInner { node, .. }) => node,
+            Self::DoubleComplex(TypeInner { node, .. }) => node,
+            Self::Logical(TypeInner { node, .. }) => node,
+            Self::Character(TypeInner { node, .. }) => node,
+        }
+    }
+}
+
+#[derive(Clone, Debug, HasNode)]
 pub struct TypeInner<'a> {
     node: Node<'a>,
-    name: String,
+    name: &'a str,
 }
 
 #[derive(Clone, Debug, EnumIs)]
 pub enum Type<'a> {
-    Intrinsic(TypeInner<'a>),
+    Intrinsic(IntrinsicType<'a>),
     Derived(TypeInner<'a>),
     Procedure(TypeInner<'a>),
     Declared(TypeInner<'a>),
 }
 
 impl<'a> Type<'a> {
-    pub fn try_from_node(node: Node<'a>, src: &str) -> Result<Self> {
+    pub fn try_from_node(node: Node<'a>, src: &'a str) -> Result<Self> {
         let kind = node.kind_id();
-        let name = node.to_text(src).context("expected text")?.to_string();
+        let name = node.to_text(src).context("expected text")?;
         match kind {
-            kind!("intrinsic_type") => Ok(Type::Intrinsic(TypeInner { node, name })),
+            kind!("intrinsic_type") => Ok(Type::Intrinsic(IntrinsicType::from_node(node, src))),
             kind!("derived_type") => Ok(Type::Derived(TypeInner { node, name })),
             kind!("procedure") => Ok(Type::Procedure(TypeInner { node, name })),
             kind!("declared_type") => Ok(Type::Declared(TypeInner { node, name })),
@@ -342,10 +419,10 @@ impl<'a> Type<'a> {
 
     pub fn as_str(&self) -> &str {
         match self {
-            Self::Intrinsic(TypeInner { name, .. }) => name.as_str(),
-            Self::Derived(TypeInner { name, .. }) => name.as_str(),
-            Self::Procedure(TypeInner { name, .. }) => name.as_str(),
-            Self::Declared(TypeInner { name, .. }) => name.as_str(),
+            Self::Intrinsic(inner) => inner.as_str(),
+            Self::Derived(TypeInner { name, .. }) => name,
+            Self::Procedure(TypeInner { name, .. }) => name,
+            Self::Declared(TypeInner { name, .. }) => name,
         }
     }
 }
@@ -353,7 +430,7 @@ impl<'a> Type<'a> {
 impl<'a> HasNode<'a> for Type<'a> {
     fn node(&self) -> &Node<'a> {
         match self {
-            Self::Intrinsic(TypeInner { node, .. }) => node,
+            Self::Intrinsic(inner) => inner.node(),
             Self::Derived(TypeInner { node, .. }) => node,
             Self::Procedure(TypeInner { node, .. }) => node,
             Self::Declared(TypeInner { node, .. }) => node,
@@ -374,7 +451,7 @@ pub struct VariableDeclaration<'a> {
 
 impl<'a> VariableDeclaration<'a> {
     /// Create from `variable_declaration` node
-    pub fn try_from_node(node: &Node<'a>, src: &str) -> Result<Self> {
+    pub fn try_from_node(node: &Node<'a>, src: &'a str) -> Result<Self> {
         if node.kind_id() != kind!("variable_declaration") {
             return Err(anyhow!("wrong node type"));
         }
@@ -411,7 +488,7 @@ impl<'a> VariableDeclaration<'a> {
     }
 
     /// Create from `function_statement`. Will fail if the statement has no `type`
-    pub fn try_from_fn_stmt(node: &Node<'a>, src: &str) -> Result<Self> {
+    pub fn try_from_fn_stmt(node: &Node<'a>, src: &'a str) -> Result<Self> {
         if node.kind_id() != kind!("function_statement") {
             return Err(anyhow!("wrong node type"));
         }
@@ -714,7 +791,7 @@ pub struct Procedure<'a> {
 }
 
 impl<'a> Procedure<'a> {
-    pub fn try_from_node(node: &Node<'a>, src: &str) -> Result<Self> {
+    pub fn try_from_node(node: &Node<'a>, src: &'a str) -> Result<Self> {
         if !matches!(node.kind_id(), kind!("function") | kind!("subroutine")) {
             return Err(anyhow!("not a procedure"));
         }
@@ -988,5 +1065,46 @@ impl<'a> UsedItem<'a> {
 impl<'a> HasNode<'a> for UsedItem<'a> {
     fn node(&self) -> &Node<'a> {
         self.name.node()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::FortitudeNode;
+    use anyhow::Result;
+    use test_case::test_case;
+    use tree_sitter::Parser;
+
+    #[test_case("byte", |result| result.is_byte())]
+    #[test_case("integer", |result| result.is_integer())]
+    #[test_case("real", |result| result.is_real())]
+    #[test_case("doubleprecision", |result| result.is_double_precision())]
+    #[test_case("double precision", |result| result.is_double_precision())]
+    #[test_case("complex", |result| result.is_complex())]
+    #[test_case("doublecomplex", |result| result.is_double_complex())]
+    #[test_case("double complex", |result| result.is_double_complex())]
+    #[test_case("logical", |result| result.is_logical())]
+    #[test_case("character", |result| result.is_character())]
+    fn intrinsic_type(type_: &str, check: impl FnOnce(IntrinsicType) -> bool) -> Result<()> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_fortran::LANGUAGE.into())
+            .expect("Error loading Fortran grammar");
+
+        let code = format!("{type_} :: foo\nend");
+
+        let tree = parser.parse(&code, None).expect("Failed to parse");
+        let root = tree.root_node();
+        let type_ = root
+            .named_descendants()
+            .find(|child| child.kind_id() == kind!("intrinsic_type"))
+            .expect("couldn't find intrinsic_type");
+
+        let result = IntrinsicType::from_node(type_, &code);
+
+        assert!(check(result));
+
+        Ok(())
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/assumed_size.rs
+++ b/crates/fortitude_linter/src/rules/correctness/assumed_size.rs
@@ -1,4 +1,5 @@
 use crate::ast::FortitudeNode;
+use crate::ast::symbol_table::SymbolTable;
 use crate::ast::types::{AttributeKind, HasName, Intent, Type};
 use crate::diagnostics::{Annotation, Diagnostic, Span, Violation};
 use crate::settings::FortranStandard;
@@ -6,6 +7,7 @@ use crate::traits::HasNode;
 use crate::{AstRule, CheckContext, kind_ids};
 use fortitude_macros::{ViolationMetadata, kind};
 use itertools::Itertools;
+use log::debug;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
 
@@ -161,8 +163,8 @@ impl AstRule for AssumedSize {
 /// ## User derived type IO procedures
 /// The standard mandates assumed-size length with `intent(inout)` for the
 /// `iomsg` argument of user defined IO procedures for derived types, although
-/// it doesn't specify a minimum length. Unfortunately, Fortitude is currently
-/// unable to detect this use. You can use [`allow` (suppression)
+/// it doesn't specify a minimum length. Fortitude will try to detect this
+/// use. You can also use [`allow` (suppression)
 /// comments](https://fortitude.readthedocs.io/en/stable/linter/#error-suppression)
 /// to disable this rule for those uses only.
 #[derive(ViolationMetadata)]
@@ -214,6 +216,11 @@ impl AstRule for AssumedSizeCharacterIntent {
             return None;
         }
 
+        if is_user_defined_type_io_subroutine(node, current_context) {
+            debug!("Identified as user-defined-type-IO subroutine");
+            return None;
+        }
+
         // Collect all declarations on this line
         Some(
             declaration
@@ -235,4 +242,58 @@ impl AstRule for AssumedSizeCharacterIntent {
     fn entrypoints() -> Vec<u16> {
         kind_ids!["assumed_size"]
     }
+}
+
+/// This is not particularly clever, just check all the expected arguments are
+/// present and have the correct type and intent. Doesn't check there aren't
+/// more arguments than expected, and doesn't check size of `v_list`.
+fn is_user_defined_type_io_subroutine(node: &Node, table: &SymbolTable) -> bool {
+    if node
+        .ancestors()
+        .find(|ancestor| ancestor.kind_id() == kind!("subroutine"))
+        .is_none()
+    {
+        return false;
+    }
+
+    let mut has_self = false;
+    let mut has_unit = false;
+    let mut has_iotype = false;
+    let mut has_v_list = false;
+    let mut has_iostat = false;
+    let mut has_iomsg = false;
+
+    for decl in table.iter_decl_lines() {
+        let intent = decl
+            .attributes()
+            .iter()
+            .map(|attr| attr.kind())
+            .find(|attr| attr.is_intent());
+        let intent_in = intent == Some(&AttributeKind::Intent(Intent::In));
+        let intent_out = intent == Some(&AttributeKind::Intent(Intent::Out));
+        let intent_inout = intent == Some(&AttributeKind::Intent(Intent::InOut));
+
+        let names = decl
+            .names()
+            .iter()
+            .map(|name| name.name().as_str().to_ascii_lowercase())
+            .collect_vec();
+
+        let contains = |name: &str| names.contains(&name.to_string());
+
+        let (is_character, is_integer) = if let Type::Intrinsic(type_) = decl.type_() {
+            (type_.is_character(), type_.is_integer())
+        } else {
+            (false, false)
+        };
+
+        has_self = has_self || (decl.type_().is_derived() && intent_in);
+        has_unit = has_unit || (is_integer && intent_in && contains("unit"));
+        has_iotype = has_iotype || (is_character && intent_in && contains("iotype"));
+        has_v_list = has_v_list || (is_integer && intent_in && contains("v_list"));
+        has_iostat = has_iostat || (is_integer && intent_out && contains("iostat"));
+        has_iomsg = has_iomsg || (is_character && intent_inout && contains("iomsg"));
+    }
+
+    has_self && has_unit && has_iotype && has_v_list && has_iostat && has_iomsg
 }

--- a/crates/fortitude_linter/src/rules/correctness/assumed_size.rs
+++ b/crates/fortitude_linter/src/rules/correctness/assumed_size.rs
@@ -1,8 +1,10 @@
 use crate::ast::FortitudeNode;
-use crate::diagnostics::{Diagnostic, Violation};
+use crate::ast::types::{AttributeKind, HasName, Intent, Type};
+use crate::diagnostics::{Annotation, Diagnostic, Span, Violation};
 use crate::settings::FortranStandard;
+use crate::traits::HasNode;
 use crate::{AstRule, CheckContext, kind_ids};
-use fortitude_macros::{ViolationMetadata, field, kind};
+use fortitude_macros::{ViolationMetadata, kind};
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
 use tree_sitter::Node;
@@ -55,29 +57,24 @@ impl Violation for AssumedSize {
 }
 impl AstRule for AssumedSize {
     fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
-        // TODO Reimplement using SymbolTable and VariableDeclaration
         let src = context.source_text();
-        let declaration = node
-            .ancestors()
-            .find(|parent| parent.kind_id() == kind!("variable_declaration"))?;
+        let declaration = context
+            .symbol_table()
+            .current()?
+            .decl_containing_node(node)?;
 
         // Deal with `character([len=]*)` elsewhere
-        if let Some(dtype) = declaration.parse_intrinsic_type() {
-            let is_character = dtype.eq_ignore_ascii_case("character");
-            let is_kind = node
+        if let Type::Intrinsic(type_) = declaration.type_()
+            && type_.is_character()
+            && node
                 .ancestors()
-                .any(|parent| parent.kind_id() == kind!("kind"));
-            if is_character && is_kind {
-                return None;
-            }
+                .any(|parent| parent.kind_id() == kind!("kind"))
+        {
+            return None;
         }
 
         // Assumed size ok for parameters
-        if declaration
-            .children_by_field_id(field!("attribute"), &mut declaration.walk())
-            .filter_map(|attr| attr.to_text(src))
-            .any(|attr_name| attr_name.eq_ignore_ascii_case("parameter"))
-        {
+        if declaration.has_attribute(AttributeKind::Parameter) {
             return None;
         }
 
@@ -94,16 +91,9 @@ impl AstRule for AssumedSize {
         // Collect things that look like `dimension(*)` -- this
         // applies to all identifiers on this line
         let all_decls = declaration
-            .children_by_field_id(field!("declarator"), &mut declaration.walk())
-            .filter_map(|declarator| {
-                let identifier = match declarator.kind_id() {
-                    kind!("identifier") => Some(declarator),
-                    kind!("sized_declarator") => declarator.child_with_id(kind!("identifier")),
-                    _ => None,
-                }?;
-                identifier.to_text(src)
-            })
-            .map(|name| name.to_string())
+            .names()
+            .iter()
+            .map(|name| name.name().to_string())
             .map(|name| context.create_diagnostic(Self { name }, node))
             .collect_vec();
 
@@ -189,25 +179,22 @@ impl Violation for AssumedSizeCharacterIntent {
 }
 impl AstRule for AssumedSizeCharacterIntent {
     fn check(context: &CheckContext, node: &Node) -> Option<Vec<Diagnostic>> {
-        // TODO Reimplement using SymbolTable and VariableDeclaration
-
         // The recommended fix to this is only possible in Fortran 2003 and later.
         // Those still writing Fortran 95 code are on their own!
         if context.settings().target_std < FortranStandard::F2003 {
             return None;
         }
-        let src = context.source_text();
+
         // TODO: This warning will also catch:
         // - non-dummy arguments -- these are always invalid, should be a separate warning?
 
-        let declaration = node
-            .ancestors()
-            .find(|parent| parent.kind_id() == kind!("variable_declaration"))?;
+        // Find the declaration containing this node
+        let current_context = context.symbol_table().current()?;
+        let declaration = current_context.decl_containing_node(node)?;
 
         // Only applies to `character`
-        if !declaration
-            .parse_intrinsic_type()?
-            .eq_ignore_ascii_case("character")
+        if let Type::Intrinsic(type_) = declaration.type_()
+            && !type_.is_character()
         {
             return None;
         }
@@ -220,41 +207,29 @@ impl AstRule for AssumedSizeCharacterIntent {
             return None;
         }
 
-        let attrs_as_text = declaration
-            .children_by_field_id(field!("attribute"), &mut declaration.walk())
-            .filter_map(|attr| attr.to_text(src))
-            .map(|attr| attr.to_lowercase())
-            .collect_vec();
-
-        // Assumed size ok for parameters
-        if attrs_as_text.iter().any(|attr| attr == "parameter") {
+        // Assumed size ok for parameters and `intent(in)` only
+        if declaration
+            .has_any_attributes(&[AttributeKind::Parameter, AttributeKind::Intent(Intent::In)])
+        {
             return None;
         }
 
-        // Ok for `intent(in)` only
-        if let Some(intent) = attrs_as_text.iter().find(|attr| attr.starts_with("intent")) {
-            let intent = intent.split_whitespace().collect_vec().join("");
-            if intent == "intent(in)" {
-                return None;
-            }
-        }
-
         // Collect all declarations on this line
-        let all_decls = declaration
-            .children_by_field_name("declarator", &mut declaration.walk())
-            .filter_map(|declarator| {
-                let identifier = match declarator.kind_id() {
-                    kind!("identifier") => Some(declarator),
-                    kind!("sized_declarator") => declarator.child_with_id(kind!("identifier")),
-                    _ => None,
-                }?;
-                identifier.to_text(src)
-            })
-            .map(|name| name.to_string())
-            .map(|name| context.create_diagnostic(Self { name }, node))
-            .collect_vec();
-
-        Some(all_decls)
+        Some(
+            declaration
+                .names()
+                .iter()
+                .map(|name| {
+                    let annotation = Annotation::secondary(
+                        Span::from(context.source_file().clone()).with_range(name.node()),
+                    );
+                    let name = name.name().to_string();
+                    let mut diagnostic = context.create_diagnostic(Self { name }, node);
+                    diagnostic.annotate(annotation);
+                    diagnostic
+                })
+                .collect_vec(),
+        )
     }
 
     fn entrypoints() -> Vec<u16> {

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__assumed-size-character-intent_C072.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__assumed-size-character-intent_C072.f90.snap
@@ -9,7 +9,7 @@ C072 character 'autochar_glob' has assumed size but does not have `intent(in)`
 1 | program cases
 2 |   ! A char array outside a function or subroutine, no exception
 3 |   character (*) :: autochar_glob
-  |              ^
+  |              ^     -------------
 4 | contains
 5 |   subroutine char_input(autochar_in, autochar_inout, autochar_out, fixedchar)
   |
@@ -20,7 +20,7 @@ C072 character 'autochar_inout' has assumed size but does not have `intent(in)`
  7 |     character(*), intent(in)       :: autochar_in
  8 |     ! A char array with disallowed intent, exception
  9 |     character(*), intent(inout)    :: autochar_inout
-   |               ^
+   |               ^                       --------------
 10 |     ! A char array with disallowed intent, exception
 11 |     character(len=*), intent(out)  :: autochar_out
    |
@@ -31,7 +31,7 @@ C072 character 'autochar_out' has assumed size but does not have `intent(in)`
  9 |     character(*), intent(inout)    :: autochar_inout
 10 |     ! A char array with disallowed intent, exception
 11 |     character(len=*), intent(out)  :: autochar_out
-   |                   ^
+   |                   ^                   ------------
 12 |     ! A char array not passed as a parameter, no exception
 13 |     character(*)                   :: autochar_var
    |
@@ -42,7 +42,7 @@ C072 character 'autochar_var' has assumed size but does not have `intent(in)`
 11 |     character(len=*), intent(out)  :: autochar_out
 12 |     ! A char array not passed as a parameter, no exception
 13 |     character(*)                   :: autochar_var
-   |               ^
+   |               ^                       ------------
 14 |     ! A char array with fixed length, no exception
 15 |     character(len=10), intent(out) :: fixedchar
    |

--- a/docs/rules/assumed-size-character-intent.md
+++ b/docs/rules/assumed-size-character-intent.md
@@ -57,7 +57,7 @@ correct size to avoid data loss:
 ## User derived type IO procedures
 The standard mandates assumed-size length with `intent(inout)` for the
 `iomsg` argument of user defined IO procedures for derived types, although
-it doesn't specify a minimum length. Unfortunately, Fortitude is currently
-unable to detect this use. You can use [`allow` (suppression)
+it doesn't specify a minimum length. Fortitude will try to detect this
+use. You can also use [`allow` (suppression)
 comments](https://fortitude.readthedocs.io/en/stable/linter/#error-suppression)
 to disable this rule for those uses only.


### PR DESCRIPTION
Fixes #697 

Also parse tree-sitter `intrinsic_type` nodes into Rust enums. I started trying to do `kind` nodes as well, but I was getting really bogged down as they're surprisingly complicated, and it wasn't immediately obvious how to exploit them anyway.

Also some drive-by refactoring because there were some todos.