### PR TITLE
Run clippy on PR workflows

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - '**.rs'
+  pull_request:
+    paths:
+      - '**.rs'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
@ZedThree this change will make Clippy run on the PR checks and not just in the fork's push I believe. So then the results will show in the PR flow.