### PR TITLE
[dev] Add option to render Fortitude's Rust AST types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,10 +927,13 @@ dependencies = [
 name = "fortitude_dev"
 version = "0.0.0"
 dependencies = [
+ "anstyle",
  "anyhow",
  "clap",
  "fortitude",
  "fortitude_linter",
+ "fortitude_macros",
+ "fortitude_sitter",
  "fortitude_workspace",
  "itertools 0.12.1",
  "pretty_assertions",

--- a/LICENSE
+++ b/LICENSE
@@ -99,3 +99,29 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+
+and tree-sitter, licensed as follows:
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2018-2024 Max Brunsfeld
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""

--- a/crates/fortitude_dev/Cargo.toml
+++ b/crates/fortitude_dev/Cargo.toml
@@ -9,10 +9,13 @@ license = { workspace = true }
 
 [dependencies]
 fortitude = { workspace = true }
+fortitude_macros = { workspace = true }
 fortitude_linter = { workspace = true }
+fortitude_sitter = { workspace = true }
 fortitude_workspace = { workspace = true }
 
 anyhow = { workspace = true }
+anstyle = { workspace = true }
 clap = { workspace = true }
 itertools = { workspace = true }
 pretty_assertions = "1.3.0"

--- a/crates/fortitude_dev/src/parse.rs
+++ b/crates/fortitude_dev/src/parse.rs
@@ -1,7 +1,24 @@
-use std::{env, path::PathBuf};
+/// Adapted from tree-sitter
+/// Copyright 2026 Max Brunsfeld, Amaan Qureshi
+/// SPDX-License-Identifier: MIT
+use std::{
+    env,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
 
-use anyhow::Result;
-use tree_sitter::{Parser, ffi};
+use anstyle::{Color, Style};
+use anyhow::{Context, Result};
+use fortitude_linter::fs::read_to_string;
+use fortitude_macros::kind;
+use fortitude_sitter::{
+    Node, TreeCursor,
+    ast::types::{
+        Attribute, AttributeKind, HasName, NameDecl, Type, UseStatement, VariableDeclaration,
+    },
+    traits::HasNode,
+};
+use tree_sitter::{Parser, Range, ffi};
 use tree_sitter_cli::{
     parse::{ParseFileOptions, ParseOutput, ParseStats, ParseTheme, parse_file_at_path},
     util,
@@ -12,11 +29,14 @@ pub(crate) struct Args {
     /// The Fortran file to parse
     pub path: PathBuf,
     /// Output the parse data in a pretty-printed CST format
-    #[arg(long = "cst", short = 'c')]
+    #[arg(long = "cst", short = 'c', conflicts_with = "output_fortitude")]
     pub output_cst: bool,
     /// Omit ranges in the output
     #[arg(long)]
     pub no_ranges: bool,
+    /// Parse into fortitude's Rust types
+    #[arg(long = "fortitude", conflicts_with = "output_cst")]
+    pub output_fortitude: bool,
 }
 
 pub(crate) fn main(args: &Args) -> Result<()> {
@@ -58,14 +78,570 @@ pub(crate) fn main(args: &Args) -> Result<()> {
 
     let max_path_length = args.path.to_string_lossy().chars().count();
 
-    parse_file_at_path(
-        &mut parser,
-        &tree_sitter_fortran::LANGUAGE.into(),
-        &args.path,
-        &args.path.display().to_string(),
-        max_path_length,
-        &mut options,
+    if args.output_fortitude {
+        output_fortitude(&args.path, &options)?;
+    } else {
+        parse_file_at_path(
+            &mut parser,
+            &tree_sitter_fortran::LANGUAGE.into(),
+            &args.path,
+            &args.path.display().to_string(),
+            max_path_length,
+            &mut options,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn output_fortitude(path: &Path, opts: &ParseFileOptions) -> Result<()> {
+    let stdout = io::stdout();
+    let mut stdout = io::BufWriter::with_capacity(64 * 1024, stdout.lock());
+
+    let mut parser = fortitude_sitter::Parser::new(&tree_sitter_fortran::LANGUAGE.into())
+        .context("Error loading Fortran grammar")?;
+
+    let source_code = read_to_string(path)?;
+
+    let tree = parser.parse(&source_code, None)?;
+    let mut cursor = tree.walk();
+
+    let total_width = source_code
+        .lines()
+        .enumerate()
+        .map(|(row, col)| {
+            row.checked_ilog10().unwrap_or(0) as usize
+                + col.len().checked_ilog10().unwrap_or(0) as usize
+                + 1
+        })
+        .max()
+        .unwrap_or(1);
+    let mut indent_level = usize::from(!opts.no_ranges);
+    let mut did_visit_children = false;
+    let mut in_error = false;
+    loop {
+        if did_visit_children {
+            if cursor.goto_next_sibling() {
+                did_visit_children = false;
+            } else if cursor.goto_parent() {
+                did_visit_children = true;
+                indent_level -= 1;
+                if !cursor.node().has_error() {
+                    in_error = false;
+                }
+            } else {
+                break;
+            }
+        } else {
+            if fortitude_render_node(
+                opts,
+                &mut cursor,
+                &mut stdout,
+                total_width,
+                indent_level,
+                in_error,
+            )? {
+                did_visit_children = true;
+            } else if cursor.goto_first_child() {
+                did_visit_children = false;
+                indent_level += 1;
+                if cursor.node().has_error() {
+                    in_error = true;
+                }
+            } else {
+                did_visit_children = true;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn paint(color: Option<impl Into<Color>>, text: &str) -> String {
+    let style = Style::new().fg_color(color.map(Into::into));
+    format!("{style}{text}{style:#}")
+}
+
+fn render_node_range(
+    opts: &ParseFileOptions,
+    cursor: &TreeCursor,
+    is_named: bool,
+    is_multiline: bool,
+    total_width: usize,
+    range: Range,
+) -> String {
+    let has_field_name = cursor.field_name().is_some();
+    let start = range.start_point;
+    let end = range.end_point;
+    let range_color = if is_named && !is_multiline && !has_field_name {
+        opts.parse_theme.row_color_named
+    } else {
+        opts.parse_theme.row_color
+    };
+
+    let remaining_width = |row: usize, col: usize| {
+        (total_width
+            .saturating_sub(row.checked_ilog10().unwrap_or(0) as usize)
+            .saturating_sub(col.checked_ilog10().unwrap_or(0) as usize))
+        .max(1)
+    };
+    let remaining_width_start = remaining_width(start.row, start.column);
+    let remaining_width_end = remaining_width(end.row, end.column);
+    paint(
+        range_color,
+        &format!(
+            "{}:{}{:remaining_width_start$}- {}:{}{:remaining_width_end$}",
+            start.row, start.column, ' ', end.row, end.column, ' ',
+        ),
+    )
+}
+
+fn write_node_text(
+    opts: &ParseFileOptions,
+    out: &mut impl Write,
+    cursor: &TreeCursor,
+    is_named: bool,
+    source: &str,
+    color: Option<impl Into<Color> + Copy>,
+    text_info: (usize, usize),
+) -> Result<()> {
+    let (total_width, indent_level) = text_info;
+    let (quote, quote_color) = if is_named {
+        ('`', opts.parse_theme.backtick)
+    } else {
+        ('\"', color.map(|c| c.into()))
+    };
+
+    if !is_named {
+        write!(
+            out,
+            "{}{}{}",
+            paint(quote_color, &String::from(quote)),
+            paint(color, &render_node_text(source)),
+            paint(quote_color, &String::from(quote)),
+        )?;
+    } else {
+        let multiline = source.contains('\n');
+        for (i, line) in source.split_inclusive('\n').enumerate() {
+            if line.is_empty() {
+                break;
+            }
+            let mut node_range = cursor.node().range();
+            // For each line of text, adjust the row by shifting it down `i` rows,
+            // and adjust the column by setting it to the length of *this* line.
+            node_range.start_point.row += i;
+            node_range.end_point.row = node_range.start_point.row;
+            node_range.end_point.column = line.len()
+                + if i == 0 {
+                    node_range.start_point.column
+                } else {
+                    0
+                };
+            let formatted_line = render_line_feed(line, opts);
+            write!(
+                out,
+                "{}{}{}{}{}{}",
+                if multiline { "\n" } else { " " },
+                if multiline && !opts.no_ranges {
+                    render_node_range(opts, cursor, is_named, true, total_width, node_range)
+                } else {
+                    String::new()
+                },
+                if multiline {
+                    "  ".repeat(indent_level + 1)
+                } else {
+                    String::new()
+                },
+                paint(quote_color, &String::from(quote)),
+                paint(color, &render_node_text(&formatted_line)),
+                paint(quote_color, &String::from(quote)),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn render_node_text(source: &str) -> String {
+    source
+        .chars()
+        .fold(String::with_capacity(source.len()), |mut acc, c| {
+            if let Some(esc) = escape_invisible(c) {
+                acc.push_str(esc);
+            } else if let Some(esc) = escape_delimiter(c) {
+                acc.push_str(esc);
+            } else {
+                acc.push(c);
+            }
+            acc
+        })
+}
+
+fn render_line_feed(source: &str, opts: &ParseFileOptions) -> String {
+    if cfg!(windows) {
+        source.replace("\r\n", &paint(opts.parse_theme.line_feed, "\r\n"))
+    } else {
+        source.replace('\n', &paint(opts.parse_theme.line_feed, "\n"))
+    }
+}
+
+const fn escape_invisible(c: char) -> Option<&'static str> {
+    Some(match c {
+        '\n' => "\\n",
+        '\r' => "\\r",
+        '\t' => "\\t",
+        '\0' => "\\0",
+        '\\' => "\\\\",
+        '\x0b' => "\\v",
+        '\x0c' => "\\f",
+        _ => return None,
+    })
+}
+
+const fn escape_delimiter(c: char) -> Option<&'static str> {
+    Some(match c {
+        '`' => "\\`",
+        '\"' => "\\\"",
+        _ => return None,
+    })
+}
+
+/// The (optional) range and indentation
+struct Preamble<'a> {
+    opts: &'a ParseFileOptions<'a>,
+    cursor: &'a TreeCursor<'a>,
+    total_width: usize,
+    indent_level: usize,
+    in_error: bool,
+}
+
+impl<'a> Preamble<'a> {
+    fn write(&self, out: &mut impl Write, node: &Node) -> Result<()> {
+        write_preamble(
+            self.opts,
+            self.cursor,
+            out,
+            node,
+            self.total_width,
+            self.indent_level,
+            self.in_error,
+        )
+    }
+    fn writeln(&self, out: &mut impl Write, node: &Node) -> Result<()> {
+        writeln!(out)?;
+        self.write(out, node)
+    }
+
+    /// Range and indentation when we don't have a node
+    fn write_nodeless(&self, out: &mut impl Write) -> Result<()> {
+        if !self.opts.no_ranges {
+            write!(
+                out,
+                "{}",
+                paint(
+                    self.opts.parse_theme.row_color_named,
+                    &".".repeat(self.total_width * 4 + 2),
+                )
+            )?;
+        }
+        write!(out, "{}", "  ".repeat(self.indent_level),)?;
+        Ok(())
+    }
+    fn writeln_nodeless(&self, out: &mut impl Write) -> Result<()> {
+        writeln!(out)?;
+        self.write_nodeless(out)
+    }
+
+    fn with_indent(&self) -> Self {
+        Self {
+            indent_level: self.indent_level + 1,
+            ..*self
+        }
+    }
+}
+
+/// Range and indentation
+fn write_preamble(
+    opts: &ParseFileOptions,
+    cursor: &TreeCursor,
+    out: &mut impl Write,
+    node: &Node,
+    total_width: usize,
+    indent_level: usize,
+    in_error: bool,
+) -> Result<()> {
+    let is_named = node.is_named();
+    if !opts.no_ranges {
+        write!(
+            out,
+            "{}",
+            render_node_range(opts, cursor, is_named, false, total_width, node.range())
+        )?;
+    }
+    write!(
+        out,
+        "{}{}",
+        "  ".repeat(indent_level),
+        if in_error && !node.has_error() {
+            " "
+        } else {
+            ""
+        }
     )?;
+
+    Ok(())
+}
+
+/// Returns `true` if we handled a Fortitude Rust AST type
+fn fortitude_render_node(
+    opts: &ParseFileOptions,
+    cursor: &mut TreeCursor,
+    out: &mut impl Write,
+    total_width: usize,
+    indent_level: usize,
+    in_error: bool,
+) -> Result<bool> {
+    let node = cursor.node();
+    let preamble = Preamble {
+        opts,
+        cursor,
+        total_width,
+        indent_level,
+        in_error,
+    };
+    preamble.write(out, &node)?;
+    let is_named = node.is_named();
+    let handled = if is_named {
+        if let Some(field_name) = cursor.field_name() {
+            write!(
+                out,
+                "{}",
+                paint(opts.parse_theme.field, &format!("{field_name}: "))
+            )?;
+        }
+
+        if node.has_error() || node.is_error() {
+            write!(out, "{}", paint(opts.parse_theme.error, "•"))?;
+        }
+
+        let handled = write_fortitude_type(&node, &preamble, opts, out)?;
+
+        if handled {
+            writeln!(out)?;
+            preamble.with_indent().write(out, &node)?;
+            write_node_text(
+                opts,
+                out,
+                cursor,
+                false,
+                node.text(),
+                opts.parse_theme.literal,
+                (total_width, indent_level + 1),
+            )?;
+        }
+
+        if node.child_count() == 0 {
+            // Node text from a pattern or external scanner
+            write_node_text(
+                opts,
+                out,
+                cursor,
+                is_named,
+                node.text(),
+                opts.parse_theme.literal,
+                (total_width, indent_level),
+            )?;
+        }
+        handled
+    } else if node.is_missing() {
+        write!(out, "{}: ", paint(opts.parse_theme.missing, "MISSING"))?;
+        write!(out, "\"{}\"", paint(opts.parse_theme.missing, node.kind()))?;
+        false
+    } else {
+        // Terminal literals, like "fn"
+        write_node_text(
+            opts,
+            out,
+            cursor,
+            is_named,
+            node.kind(),
+            opts.parse_theme.literal,
+            (total_width, indent_level),
+        )?;
+        false
+    };
+    writeln!(out)?;
+
+    Ok(handled)
+}
+
+/// Returns `true` if we handled a Fortitude Rust AST type
+fn write_fortitude_type(
+    node: &Node,
+    preamble: &Preamble,
+    opts: &ParseFileOptions,
+    out: &mut impl Write,
+) -> Result<bool> {
+    let kind_color = if node.is_error() {
+        opts.parse_theme.error
+    } else if node.is_extra() || node.parent().is_some_and(|p| p.is_extra() && !p.is_error()) {
+        opts.parse_theme.extra
+    } else {
+        opts.parse_theme.node_kind
+    };
+
+    match node.kind_id() {
+        kind!("use_statement") => {
+            write!(out, "{}", paint(opts.parse_theme.missing, "UseStatement"))?;
+            match UseStatement::try_from_node(node) {
+                Ok(stmt) => {
+                    write_use_stmt(stmt, &preamble.with_indent(), opts, out)?;
+                }
+                Err(err) => {
+                    let msg = format!("INTERAL FORTITUDE ERROR: {err}");
+                    write!(out, " -- {}", paint(opts.parse_theme.error, &msg))?;
+                }
+            }
+
+            Ok(true)
+        }
+        kind!("variable_declaration") => {
+            write!(
+                out,
+                "{}",
+                paint(opts.parse_theme.missing, "VariableDeclaration")
+            )?;
+            match VariableDeclaration::try_from_node(node) {
+                Ok(decl) => {
+                    write_variable_declaration(decl, &preamble.with_indent(), opts, out)?;
+                }
+                Err(err) => {
+                    let msg = format!("INTERAL FORTITUDE ERROR: {err}");
+                    write!(out, " -- {}", paint(opts.parse_theme.error, &msg))?;
+                }
+            };
+            Ok(true)
+        }
+        _ => {
+            write!(out, "{}", paint(kind_color, node.kind()))?;
+            Ok(false)
+        }
+    }
+}
+
+fn write_key_value(
+    opts: &ParseFileOptions,
+    out: &mut impl Write,
+    key: &str,
+    value: &str,
+) -> Result<()> {
+    write!(
+        out,
+        "{}: {}",
+        paint(opts.parse_theme.missing, key),
+        paint(opts.parse_theme.field, value)
+    )?;
+    Ok(())
+}
+
+fn write_variable_declaration(
+    decl: VariableDeclaration,
+    preamble: &Preamble,
+    opts: &ParseFileOptions,
+    out: &mut impl Write,
+) -> Result<()> {
+    write_variable_type(decl.type_(), preamble, opts, out)?;
+
+    for attr in decl.attributes() {
+        write_variable_attribute(attr, preamble, opts, out)?;
+    }
+
+    for name in decl.names() {
+        write_variable_name(name, preamble, opts, out)?;
+    }
+
+    preamble.writeln_nodeless(out)?;
+    write_key_value(opts, out, "has_colon", &decl.has_colon().to_string())?;
+    preamble.writeln_nodeless(out)?;
+    write_key_value(opts, out, "is_function", &decl.is_function().to_string())?;
+
+    Ok(())
+}
+
+fn write_variable_type(
+    type_: &Type,
+    preamble: &Preamble,
+    opts: &ParseFileOptions,
+    out: &mut impl Write,
+) -> Result<()> {
+    let node = type_.node();
+    preamble.writeln(out, node)?;
+    write_key_value(opts, out, "Type", &type_.to_string())?;
+
+    Ok(())
+}
+
+fn write_variable_attribute(
+    attr: &Attribute,
+    preamble: &Preamble,
+    opts: &ParseFileOptions,
+    out: &mut impl Write,
+) -> Result<()> {
+    let node = attr.node();
+    preamble.writeln(out, node)?;
+    write_key_value(opts, out, "Attribute", attr.into())?;
+    match attr.kind() {
+        AttributeKind::Dimension(dim) => {
+            write!(out, "{}", paint(opts.parse_theme.field, &dim.to_string()))?
+        }
+        AttributeKind::Intent(intent) => write!(
+            out,
+            "({})",
+            paint(opts.parse_theme.field, &intent.to_string())
+        )?,
+        _ => (),
+    }
+
+    Ok(())
+}
+
+fn write_variable_name(
+    name: &NameDecl,
+    preamble: &Preamble,
+    opts: &ParseFileOptions,
+    out: &mut impl Write,
+) -> Result<()> {
+    let node = name.node();
+    preamble.writeln(out, node)?;
+    write_key_value(opts, out, "Name", name.name().as_str())?;
+
+    if let Some(size) = name.size() {
+        preamble.with_indent().writeln(out, node)?;
+        write_key_value(opts, out, "Size", size.text())?;
+    }
+    if let Some(init) = name.init() {
+        preamble.with_indent().writeln(out, node)?;
+        write_key_value(opts, out, "Initialiser", init.text())?;
+    }
+
+    Ok(())
+}
+
+fn write_use_stmt(
+    stmt: UseStatement,
+    preamble: &Preamble,
+    opts: &ParseFileOptions,
+    out: &mut impl Write,
+) -> Result<()> {
+    preamble.writeln(out, stmt.node())?;
+    write_key_value(opts, out, "Name", stmt.name().as_str())?;
+
+    preamble.writeln_nodeless(out)?;
+    write_key_value(opts, out, "intrinsic", &stmt.is_intrinsic().to_string())?;
+    preamble.writeln_nodeless(out)?;
+    write_key_value(opts, out, "has_only", &stmt.has_only().to_string())?;
+    preamble.writeln_nodeless(out)?;
+    write_key_value(opts, out, "has_colon", &stmt.has_colon().to_string())?;
 
     Ok(())
 }

--- a/crates/fortitude_linter/src/rules/modernisation/out_of_line_attribute.rs
+++ b/crates/fortitude_linter/src/rules/modernisation/out_of_line_attribute.rs
@@ -157,7 +157,7 @@ fn make_fix(var: &Variable, new_attr: &str, extra: String) -> Result<Vec<Edit>> 
         //   -> remove variable from decl statement
         edits.push(remove_variable_decl(var.node(), decl)?);
         //   -> add new decl statement with attribute
-        let type_ = decl.type_().as_str();
+        let type_ = decl.type_().name();
         let attrs = decl
             .attributes()
             .iter()

--- a/crates/fortitude_linter/src/rules/style/inconsistent_dimension.rs
+++ b/crates/fortitude_linter/src/rules/style/inconsistent_dimension.rs
@@ -102,7 +102,7 @@ fn fix_inconsistent_dimension(
     let (new_attr, var_str) =
         dimension_attribute_and_shape(var, decl, prefer_attribute.is_always())?;
 
-    let type_ = decl.type_().as_str();
+    let type_ = decl.type_().name();
     let attrs = decl
         .attributes()
         .iter()

--- a/crates/fortitude_sitter/src/ast/symbol_table.rs
+++ b/crates/fortitude_sitter/src/ast/symbol_table.rs
@@ -341,7 +341,7 @@ end program foo
             TextRange::new(TextSize::new(26), TextSize::new(27))
         );
         assert_eq!(x.name().as_str(), "x");
-        assert_eq!(x.type_().as_str(), "integer");
+        assert_eq!(x.type_().name(), "integer");
         assert_eq!(x.decl_statement().textrange(), first_decl_range);
 
         assert!(y.is_some());
@@ -369,7 +369,7 @@ end program foo
             TextRange::new(TextSize::new(60), TextSize::new(71))
         );
         assert_eq!(a.name().as_str(), "a");
-        assert_eq!(a.type_().as_str(), "real");
+        assert_eq!(a.type_().name(), "real");
         let a_attrs: Vec<&'static str> = a
             .attributes()
             .iter()

--- a/crates/fortitude_sitter/src/ast/types.rs
+++ b/crates/fortitude_sitter/src/ast/types.rs
@@ -1,5 +1,6 @@
 //! Strong types for working with the tree-sitter AST
 
+use std::fmt::Display;
 use std::{rc::Rc, str::FromStr};
 
 use anyhow::{Context, Result, anyhow};
@@ -166,7 +167,7 @@ impl<'a> Extent<'a> {
 }
 
 /// One rank of a dimension's array-spec
-#[derive(Clone, Copy, Debug, EnumIs, PartialEq)]
+#[derive(Clone, Copy, Debug, EnumIs, PartialEq, Display, IntoStaticStr)]
 pub enum DimensionArraySpec<'a> {
     Expression(Node<'a>),
     Extent(Extent<'a>),
@@ -211,6 +212,16 @@ impl<'a> Dimension<'a> {
             .collect();
 
         Ok(Self { ranks: ranks? })
+    }
+}
+
+impl<'a> Display for Dimension<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "({})",
+            self.ranks.iter().map(|rank| rank.to_string()).join(", ")
+        )
     }
 }
 
@@ -265,7 +276,8 @@ impl<'a> Bind<'a> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, EnumIs, IntoStaticStr, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, EnumIs, IntoStaticStr, PartialEq, Display)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 pub enum Intent {
     In,
     Out,
@@ -291,7 +303,7 @@ impl Intent {
     }
 }
 
-#[derive(Clone, Debug, EnumIs, EnumString, IntoStaticStr, PartialEq)]
+#[derive(Clone, Debug, EnumIs, EnumString, IntoStaticStr, PartialEq, Display)]
 #[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 pub enum AttributeKind<'a> {
     Abstract,
@@ -366,7 +378,19 @@ impl<'a> Attribute<'a> {
     }
 }
 
-#[derive(Clone, Debug, EnumIs, IntoStaticStr)]
+impl<'a> From<Attribute<'a>> for &'static str {
+    fn from(value: Attribute<'a>) -> Self {
+        value.kind.into()
+    }
+}
+
+impl<'a> From<&'a Attribute<'a>> for &'static str {
+    fn from(value: &'a Attribute<'a>) -> Self {
+        value.kind().into()
+    }
+}
+
+#[derive(Clone, Debug, EnumIs, IntoStaticStr, Display)]
 #[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 pub enum IntrinsicType<'a> {
     Byte(TypeInner<'a>),
@@ -451,8 +475,9 @@ pub struct TypeInner<'a> {
     name: &'a str,
 }
 
-#[derive(Clone, Debug, EnumIs)]
+#[derive(Clone, Debug, EnumIs, IntoStaticStr, Display)]
 pub enum Type<'a> {
+    #[strum(serialize = "Intrinsic({0})")]
     Intrinsic(IntrinsicType<'a>),
     Derived(TypeInner<'a>),
     Procedure(TypeInner<'a>),

--- a/crates/fortitude_sitter/src/ast/types.rs
+++ b/crates/fortitude_sitter/src/ast/types.rs
@@ -404,6 +404,7 @@ impl<'a> IntrinsicType<'a> {
                 let second = node
                     .child(1)
                     .expect("`double` must be followed by either `complex` or `precision`");
+                let name = node.text();
                 match second.kind_id() {
                     kw!("complex") => IntrinsicType::DoubleComplex(TypeInner { node, name }),
                     kw!("precision") => IntrinsicType::DoublePrecision(TypeInner { node, name }),
@@ -414,7 +415,8 @@ impl<'a> IntrinsicType<'a> {
         }
     }
 
-    pub fn as_str(&self) -> &str {
+    /// The type name as it appears in the source
+    pub fn name(&self) -> &str {
         match self {
             Self::Byte(TypeInner { name, .. }) => name,
             Self::Integer(TypeInner { name, .. }) => name,
@@ -470,9 +472,10 @@ impl<'a> Type<'a> {
         }
     }
 
-    pub fn as_str(&self) -> &str {
+    /// The type name as it appears in the source
+    pub fn name(&self) -> &str {
         match self {
-            Self::Intrinsic(inner) => inner.as_str(),
+            Self::Intrinsic(inner) => inner.name(),
             Self::Derived(TypeInner { name, .. }) => name,
             Self::Procedure(TypeInner { name, .. }) => name,
             Self::Declared(TypeInner { name, .. }) => name,

--- a/crates/fortitude_sitter/src/lib.rs
+++ b/crates/fortitude_sitter/src/lib.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::num::NonZeroU16;
 use std::str::Utf8Error;
-use tree_sitter::Point;
+use tree_sitter::{Point, Range};
 
 use anyhow::Result;
 use fortitude_macros::{field, kind};
@@ -306,6 +306,11 @@ impl<'tree> Node<'tree> {
     #[inline]
     pub fn byte_range(&self) -> std::ops::Range<usize> {
         self.node.byte_range()
+    }
+
+    #[inline]
+    pub fn range(&self) -> Range {
+        self.node.range()
     }
 
     /// Get the node's text.
@@ -841,7 +846,7 @@ impl<'tree> TreeCursor<'tree> {
     }
 
     /// Gets the field name of the cursor's current node
-    pub fn field_name(&mut self) -> Option<&'static str> {
+    pub fn field_name(&self) -> Option<&'static str> {
         self.cursor.field_name()
     }
 


### PR DESCRIPTION
Running:

```console
$ cargo dev print-ast --fortitude /path/to/file.f90
```

prints the AST like `--cst`, except that (some) nodes where we have a corresponding Rust type are highlighted and rendered instead. The intention of this mode is to help developers find errors and deficiencies in our Rust types.

With `--cst`:

```
15:2  - 15:56       variable_declaration
15:2  - 15:18         type: intrinsic_type
15:2  - 15:8            "double"
15:9  - 15:18           "precision"
15:18 - 15:19         ","
15:20 - 15:31         attribute: type_qualifier
15:20 - 15:31           "allocatable"
15:31 - 15:32         ","
15:33 - 15:48         attribute: type_qualifier
15:33 - 15:42           "dimension"
15:42 - 15:48           argument_list
15:42 - 15:43             "("
15:43 - 15:44             extent_specifier
15:43 - 15:44               ":"
15:44 - 15:45             ","
15:46 - 15:47             extent_specifier
15:46 - 15:47               ":"
15:47 - 15:48             ")"
15:49 - 15:51         "::"
15:52 - 15:56         declarator: identifier `zing`
```

with `--fortitude`:

```
15:2  - 15:56       VariableDeclaration
15:2  - 15:18         Type: Intrinsic(double precision)
15:20 - 15:31         Attribute: allocatable
15:33 - 15:48         Attribute: dimension(Extent, Extent)
15:52 - 15:56         Name: zing
..............        has_colon: true
..............        is_function: false
15:2  - 15:56         "double precision, allocatable, dimension(:, :) :: zing"
```

The colours in the terminal are also different to help our nodes stand out.

This also makes it easier to spot where we currently don't handle something correctly:

```
4:2   - 4:70        VariableDeclaration -- INTERAL FORTITUDE ERROR: unknown attribute 'bind'
4:2   - 4:70          "integer(c_int), public, bind(C, name=\"enzyme_const\") :: enzyme_const"
```