### PR TITLE
Add `name` and `count` output formats

### DIFF
--- a/crates/fortitude/tests/check.rs
+++ b/crates/fortitude/tests/check.rs
@@ -2294,6 +2294,8 @@ fn git_since() -> anyhow::Result<()> {
 #[test_case::test_case("rdjson")]
 #[test_case::test_case("azure")]
 #[test_case::test_case("sarif")]
+#[test_case::test_case("name")]
+#[test_case::test_case("count")]
 fn output_format(output_format: &str) -> Result<()> {
     const CONTENT: &str = "\
 program test

--- a/crates/fortitude/tests/snapshots/check__output_format_count.snap
+++ b/crates/fortitude/tests/snapshots/check__output_format_count.snap
@@ -1,0 +1,19 @@
+---
+source: crates/fortitude/tests/check.rs
+info:
+  program: fortitude
+  args:
+    - check
+    - "--output-format"
+    - count
+    - "--select"
+    - "S061,C001,PORT011,PORT021"
+    - test.f90
+snapshot_kind: text
+---
+success: false
+exit_code: 1
+----- stdout -----
+test.f90:4
+
+----- stderr -----

--- a/crates/fortitude/tests/snapshots/check__output_format_name.snap
+++ b/crates/fortitude/tests/snapshots/check__output_format_name.snap
@@ -1,0 +1,19 @@
+---
+source: crates/fortitude/tests/check.rs
+info:
+  program: fortitude
+  args:
+    - check
+    - "--output-format"
+    - name
+    - "--select"
+    - "S061,C001,PORT011,PORT021"
+    - test.f90
+snapshot_kind: text
+---
+success: false
+exit_code: 1
+----- stdout -----
+test.f90
+
+----- stderr -----

--- a/crates/fortitude_linter/src/diagnostics/message/grouped.rs
+++ b/crates/fortitude_linter/src/diagnostics/message/grouped.rs
@@ -17,13 +17,20 @@ use crate::fs::relativize_path;
 
 use crate::Diagnostic;
 
+pub(crate) enum GroupedMode {
+    Full,
+    Name,
+    Count,
+}
+
 pub struct GroupedRenderer<'a> {
     config: &'a DisplayDiagnosticConfig,
+    mode: GroupedMode,
 }
 
 impl<'a> GroupedRenderer<'a> {
-    pub(super) fn new(config: &'a DisplayDiagnosticConfig) -> Self {
-        Self { config }
+    pub(super) fn new(config: &'a DisplayDiagnosticConfig, mode: GroupedMode) -> Self {
+        Self { config, mode }
     }
 
     pub(super) fn render(
@@ -47,25 +54,35 @@ impl<'a> GroupedRenderer<'a> {
             let column_length = max_column_length.digits();
 
             // Print the filename.
-            writeln!(f, "{}:", relativize_path(filename).underline())?;
-
-            // Print each message.
-            for message in messages {
-                write!(
-                    f,
-                    "{}",
-                    DisplayGroupedMessage {
-                        message,
-                        show_fix_status: self.config.show_fix_status(),
-                        applicability: self.config.fix_applicability(),
-                        row_length,
-                        column_length,
+            let filename = relativize_path(filename);
+            match self.mode {
+                GroupedMode::Name => {
+                    writeln!(f, "{}", filename.red().bold())?;
+                }
+                GroupedMode::Count => {
+                    writeln!(f, "{}:{}", filename.red().bold(), messages.len())?;
+                }
+                GroupedMode::Full => {
+                    writeln!(f, "{}:", relativize_path(filename).underline())?;
+                    // Print each message.
+                    for message in messages {
+                        write!(
+                            f,
+                            "{}",
+                            DisplayGroupedMessage {
+                                message,
+                                show_fix_status: self.config.show_fix_status(),
+                                applicability: self.config.fix_applicability(),
+                                row_length,
+                                column_length,
+                            }
+                        )?;
                     }
-                )?;
-            }
 
-            // Print a blank line between files
-            writeln!(f)?;
+                    // Print a blank line between files
+                    writeln!(f)?;
+                }
+            }
         }
 
         Ok(())

--- a/crates/fortitude_linter/src/diagnostics/message/mod.rs
+++ b/crates/fortitude_linter/src/diagnostics/message/mod.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::{borrow::Cow, path::Path};
 
+use grouped::GroupedMode;
 use ruff_annotate_snippets::{
     Annotation as AnnotateAnnotation, Level as AnnotateLevel, Message as AnnotateMessage,
     Snippet as AnnotateSnippet,
@@ -125,7 +126,16 @@ impl std::fmt::Display for DisplayDiagnostics<'_> {
                 github::GithubRenderer {}.render(f, self.diagnostics)?;
             }
             OutputFormat::Grouped => {
-                grouped::GroupedRenderer::new(self.config).render(f, self.diagnostics)?;
+                grouped::GroupedRenderer::new(self.config, GroupedMode::Full)
+                    .render(f, self.diagnostics)?;
+            }
+            OutputFormat::Name => {
+                grouped::GroupedRenderer::new(self.config, GroupedMode::Name)
+                    .render(f, self.diagnostics)?;
+            }
+            OutputFormat::Count => {
+                grouped::GroupedRenderer::new(self.config, GroupedMode::Count)
+                    .render(f, self.diagnostics)?;
             }
             OutputFormat::Sarif => {
                 sarif::SarifRenderer {}.render(f, self.diagnostics)?;

--- a/crates/fortitude_linter/src/settings.rs
+++ b/crates/fortitude_linter/src/settings.rs
@@ -526,6 +526,11 @@ pub enum OutputFormat {
     Azure,
 
     Sarif,
+
+    /// Print only names of files with violations
+    Name,
+    /// Print only count violations per file
+    Count,
 }
 
 impl fmt::Display for OutputFormat {
@@ -543,6 +548,8 @@ impl fmt::Display for OutputFormat {
             Self::Rdjson => write!(f, "rdjson"),
             Self::Azure => write!(f, "azure"),
             Self::Sarif => write!(f, "sarif"),
+            Self::Name => write!(f, "name"),
+            Self::Count => write!(f, "count"),
         }
     }
 }

--- a/crates/fortitude_workspace/src/options.rs
+++ b/crates/fortitude_workspace/src/options.rs
@@ -111,10 +111,11 @@ pub struct CheckOptions {
     /// (shows source), `"concise"`, `"grouped"` (group messages by file), `"json"`
     /// (machine-readable), `"junit"` (machine-readable XML), `"github"` (GitHub
     /// Actions annotations), `"gitlab"` (GitLab CI code quality report),
-    /// `"pylint"` (Pylint text format) or `"azure"` (Azure Pipeline logging commands).
+    /// `"pylint"` (Pylint text format), `"azure"` (Azure Pipeline logging commands),
+    /// `"name"` (filenames only), or `"count"` (filename + count of violations).
     #[option(
         default = r#""full""#,
-        value_type = r#""full" | "concise" | "grouped" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azure""#,
+        value_type = r#""full" | "concise" | "grouped" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azure" | "name" | "count""#,
         example = r#"
             # Group violations by containing file.
             output-format = "grouped"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -308,7 +308,7 @@ Options:
       --ignore-allow-comments
           Ignore any `allow` comments
       --output-format <OUTPUT_FORMAT>
-          Output serialization format for violations. The default serialization format is "full" [env: FORTITUDE_OUTPUT_FORMAT=] [possible values: concise, full, json, json-lines, junit, grouped, github, gitlab, pylint, rdjson, azure, sarif]
+          Output serialization format for violations. The default serialization format is "full" [env: FORTITUDE_OUTPUT_FORMAT=] [possible values: concise, full, json, json-lines, junit, grouped, github, gitlab, pylint, rdjson, azure, sarif, name, count]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout) [env: FORTITUDE_OUTPUT_FILE=]
       --preview

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -581,11 +581,12 @@ The style in which violation messages should be formatted: `"full"` (default)
 (shows source), `"concise"`, `"grouped"` (group messages by file), `"json"`
 (machine-readable), `"junit"` (machine-readable XML), `"github"` (GitHub
 Actions annotations), `"gitlab"` (GitLab CI code quality report),
-`"pylint"` (Pylint text format) or `"azure"` (Azure Pipeline logging commands).
+`"pylint"` (Pylint text format), `"azure"` (Azure Pipeline logging commands),
+`"name"` (filenames only), or `"count"` (filename + count of violations).
 
 **Default value**: `"full"`
 
-**Type**: `"full" | "concise" | "grouped" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azure"`
+**Type**: `"full" | "concise" | "grouped" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azure" | "name" | "count"`
 
 **Example usage**:
 


### PR DESCRIPTION
Similar to `grep --files-with-matches` and `grep --count`, respectively.

Closes #698

I've styled this as bold red, to match other elements:

<img width="621" height="99" alt="image" src="https://github.com/user-attachments/assets/bc321eb5-aa64-4b1f-bfd5-986092eed229" />

but maybe it should be purple, to match `grep`/`rg` etc?

<img width="621" height="99" alt="image" src="https://github.com/user-attachments/assets/9ad59577-048c-4098-9920-c4c3a94357e3" />
