### PR TITLE
Bump `ruff_annotate_snippets`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,8 +2453,8 @@ dependencies = [
 
 [[package]]
 name = "ruff_annotate_snippets"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.6#e4c7f357777a2fdd34dbe6a98b1b7d3e7488f675"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.16.2#5b48a040974781ba90b47c8df628f8fd9b6c95dd"
 dependencies = [
  "anstyle",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ path-slash = { version = "0.2.1" }
 predicates = "3.1.2"
 pretty_assertions = "1.4.1"
 regex = { version = "1.10.2" }
-ruff_annotate_snippets = { git = "https://github.com/astral-sh/ruff.git", tag = "0.15.6", version = "0.1.0" }
+ruff_annotate_snippets = { git = "https://github.com/astral-sh/ruff.git", tag = "0.16.2" }
 ruff_cache = { git = "https://github.com/astral-sh/ruff.git", tag = "0.15.6", version = "0.0.0" }
 ruff_diagnostics = { git = "https://github.com/astral-sh/ruff.git", tag = "0.15.6", version = "0.0.0" }
 ruff_macros = { git = "https://github.com/astral-sh/ruff.git", tag = "0.15.6", version = "0.0.0" }

--- a/crates/fortitude/tests/snapshots/check__output_format_full.snap
+++ b/crates/fortitude/tests/snapshots/check__output_format_full.snap
@@ -51,7 +51,6 @@ S061 [*] end statement should be named.
 2 |   logical*4, parameter :: true = .true.
 3 | end program
   | ^^^^^^^^^^^
-  |
 help: Write as 'end program test'.
 
 fortitude: 1 files scanned.

--- a/crates/fortitude_linter/src/diagnostics/message/full.rs
+++ b/crates/fortitude_linter/src/diagnostics/message/full.rs
@@ -2,7 +2,7 @@
 // Copyright 2022 Charles Marsh
 // SPDX-License-Identifier: MIT
 
-use ruff_annotate_snippets::Renderer as AnnotateRenderer;
+use annotate_snippets::Renderer as AnnotateRenderer;
 
 use super::Resolved;
 use super::{Diagnostic, DisplayDiagnosticConfig};
@@ -41,7 +41,7 @@ impl<'a> FullRenderer<'a> {
             .info(stylesheet.info)
             .note(stylesheet.note)
             .help(stylesheet.help)
-            .line_no(stylesheet.line_no)
+            .line_num(stylesheet.line_no)
             .emphasis(stylesheet.emphasis)
             .none(stylesheet.none)
             .hyperlink(stylesheet.hyperlink);
@@ -50,7 +50,7 @@ impl<'a> FullRenderer<'a> {
             let resolved = Resolved::new(diag, self.config);
             let renderable = resolved.to_renderable(self.config);
             for diag in renderable.diagnostics.iter() {
-                writeln!(f, "{}", renderer.render(diag.to_annotate()))?;
+                writeln!(f, "{}", renderer.render(&[diag.to_annotate()]))?;
             }
 
             if self.config.show_fix_diff
@@ -125,7 +125,6 @@ mod tests {
           |
         1 | integer*4 foo; end
           |        ^
-          |
         ");
     }
 
@@ -202,7 +201,6 @@ mod tests {
           |
         1 | integer*4 foo; end
           |        ^
-          |
         ");
     }
 
@@ -277,7 +275,6 @@ print()
         2 | if False:
         3 | print()
           | ^
-          |
         ");
     }
 
@@ -315,9 +312,8 @@ print()
         error[stable-test-rule]: Invalid unescaped character SUB, use "\x1a" instead
          --> example.py:1:25
           |
-        1 | nested_fstrings = f'␈{f'{f'␛'}'}'
+        1 | nested_fstrings = f'␈{f'␚{f'␛'}'}'
           |                         ^
-          |
         "#);
     }
 
@@ -340,9 +336,8 @@ print()
         error[stable-test-rule]: Invalid unescaped character SUB, use "\x1a" instead
          --> example.py:1:2
           |
-        1 | ␈␛
+        1 | ␈␚␛
           |  ^
-          |
         "#);
 
         Ok(())
@@ -365,7 +360,6 @@ print()
         1 | def foo():
         2 |     return 1
           |     ^^^^^^^^
-          |
         ");
     }
 
@@ -440,7 +434,6 @@ print()
           |
         1 | import foo
           | ^
-          |
         ");
     }
 
@@ -461,7 +454,6 @@ print()
           |
         1 | import foo
           | ^
-          |
         ");
     }
 
@@ -484,11 +476,10 @@ print()
 
         insta::assert_snapshot!(env.render(&diagnostic), @r"
         error[stable-test-rule]: main diagnostic message
-         --> example.py:2:1
+         --> example.py:1:16
           |
         1 | unexpected eof
           |               ^
-          |
         ");
     }
 

--- a/crates/fortitude_linter/src/diagnostics/message/mod.rs
+++ b/crates/fortitude_linter/src/diagnostics/message/mod.rs
@@ -16,11 +16,11 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::{borrow::Cow, path::Path};
 
-use grouped::GroupedMode;
-use ruff_annotate_snippets::{
-    Annotation as AnnotateAnnotation, Level as AnnotateLevel, Message as AnnotateMessage,
-    Snippet as AnnotateSnippet,
+use annotate_snippets::{
+    Annotation as AnnotateAnnotation, AnnotationKind, Group as AnnotateGroup,
+    Level as AnnotateLevel, Snippet as AnnotateSnippet,
 };
+use grouped::GroupedMode;
 use ruff_source_file::{OneIndexed, SourceCode, SourceFile};
 use ruff_text_size::{TextLen, TextRange, TextSize};
 
@@ -185,7 +185,7 @@ impl<'a> Resolved<'a> {
 /// A single resolved diagnostic.
 #[derive(Debug)]
 struct ResolvedDiagnostic<'a> {
-    level: AnnotateLevel,
+    level: AnnotateLevel<'static>,
     id: Option<String>,
     documentation_url: Option<String>,
     message: String,
@@ -234,10 +234,11 @@ impl<'a> ResolvedDiagnostic<'a> {
             diag.secondary_code_or_id().to_string()
         };
 
+        let level = diag.inner.severity.to_annotate();
         let level = if config.hide_severity {
-            AnnotateLevel::None
+            level.no_name()
         } else {
-            diag.inner.severity.to_annotate()
+            level
         };
 
         ResolvedDiagnostic {
@@ -340,7 +341,7 @@ impl<'a> ResolvedDiagnostic<'a> {
         snippets_by_input
             .sort_by(|snips1, snips2| snips1.has_primary.cmp(&snips2.has_primary).reverse());
         RenderableDiagnostic {
-            level: self.level,
+            level: self.level.clone(),
             id: self.id.as_deref(),
             documentation_url: self.documentation_url.as_deref(),
             message: &self.message,
@@ -433,7 +434,7 @@ struct Renderable<'r> {
 #[derive(Debug)]
 struct RenderableDiagnostic<'r> {
     /// The severity of the diagnostic.
-    level: AnnotateLevel,
+    level: AnnotateLevel<'static>,
     /// The ID of the diagnostic. The ID can usually be used on the CLI or in a
     /// config file to change the severity of a lint.
     ///
@@ -461,7 +462,7 @@ struct RenderableDiagnostic<'r> {
 
 impl RenderableDiagnostic<'_> {
     /// Convert this to an "annotate" snippet.
-    fn to_annotate(&self) -> AnnotateMessage<'_> {
+    fn to_annotate(&self) -> AnnotateGroup<'_> {
         let snippets = self.snippets_by_input.iter().flat_map(|snippets| {
             let path = snippets.path;
             snippets
@@ -469,15 +470,18 @@ impl RenderableDiagnostic<'_> {
                 .iter()
                 .map(|snippet| snippet.to_annotate(path))
         });
-        let mut message = self
+        let mut title = self
             .level
-            .title(self.message)
-            .is_fixable(self.is_fixable)
-            .lineno_offset(self.header_offset);
+            .clone()
+            .primary_title(self.message)
+            .is_fixable(self.is_fixable);
         if let Some(id) = self.id {
-            message = message.id_with_url(id, self.documentation_url);
+            title = title.id(id);
+            if let Some(url) = self.documentation_url {
+                title = title.id_url(url);
+            }
         }
-        message.snippets(snippets)
+        title.elements(snippets).lineno_offset(self.header_offset)
     }
 }
 
@@ -632,10 +636,11 @@ impl<'r> RenderableSnippet<'r> {
     }
 
     /// Convert this to an "annotate" snippet.
-    fn to_annotate<'a>(&'a self, path: &'a str) -> AnnotateSnippet<'a> {
-        AnnotateSnippet::source(&self.snippet)
-            .origin(path)
+    fn to_annotate<'a>(&'a self, path: &'a str) -> AnnotateSnippet<'a, AnnotateAnnotation<'a>> {
+        AnnotateSnippet::source(self.snippet.as_ref())
+            .path(path)
             .line_start(self.line_start.get())
+            .fold(false)
             .annotations(
                 self.annotations
                     .iter()
@@ -684,23 +689,12 @@ impl<'r> RenderableAnnotation<'r> {
 
     /// Convert this to an "annotate" annotation.
     fn to_annotate(&self) -> AnnotateAnnotation<'_> {
-        // This is not really semantically meaningful, but
-        // it does currently result in roughly the message
-        // we want to convey.
-        //
-        // TODO: While this means primary annotations use `^` and
-        // secondary annotations use `-` (which is fine), this does
-        // result in coloring for primary annotations that looks like
-        // an error (red) and coloring for secondary annotations that
-        // looks like a warning (yellow). This is perhaps not quite in
-        // line with what we want, but fixing this probably requires
-        // changes to `ruff_annotate_snippets`, so we punt for now.
-        let level = if self.is_primary {
-            AnnotateLevel::Error
+        let kind = if self.is_primary {
+            AnnotationKind::Primary
         } else {
-            AnnotateLevel::Warning
+            AnnotationKind::Context
         };
-        let mut ann = level.span(self.range.into());
+        let mut ann = kind.span(self.range.into());
         if let Some(message) = self.message {
             ann = ann.label(message);
         }
@@ -1120,13 +1114,12 @@ watermelon
         env.context(0);
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:5:1
           |
         5 | elephant
           | ^^^^^^^^
-          |
         ",
         );
 
@@ -1152,7 +1145,7 @@ watermelon
         env.context(2);
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
           --> animals:11:1
            |
@@ -1160,7 +1153,6 @@ watermelon
         10 | jackrabbit
         11 | kangaroo
            | ^^^^^^^^
-           |
         ",
         );
 
@@ -1202,7 +1194,7 @@ watermelon
             .build();
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
           --> animals:1:1
            |
@@ -1217,7 +1209,6 @@ watermelon
         10 | jackrabbit
         11 | kangaroo
            | ^^^^^^^^
-           |
         ",
         );
     }
@@ -1496,7 +1487,7 @@ watermelon
         // instead of special casing the snippet assembly.
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> spacey-animals:3:1
           |
@@ -1507,7 +1498,6 @@ watermelon
           |
         5 | canary
           | ^^^^^^
-          |
         ",
         );
     }
@@ -1663,7 +1653,7 @@ watermelon
         diag.sub(env.sub_warn().primary("animals", "11", "11", "").build());
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:3:1
           |
@@ -1691,7 +1681,6 @@ watermelon
         10 | jackrabbit
         11 | kangaroo
            | ^^^^^^^^
-           |
         ",
         );
 
@@ -1702,7 +1691,7 @@ watermelon
         diag.sub(env.sub_warn().primary("fruits", "3", "3", "").build());
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:3:1
           |
@@ -1720,7 +1709,6 @@ watermelon
         10 | jackrabbit
         11 | kangaroo
            | ^^^^^^^^
-           |
         warning: sub-diagnostic message
          --> fruits:3:1
           |
@@ -1809,7 +1797,7 @@ watermelon
         let diag = env.err().primary("animals", "5", "7:0", "").build();
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:5:1
           |
@@ -1817,7 +1805,7 @@ watermelon
         4 |   dog
         5 | / elephant
         6 | | finch
-          | |______^
+          | |_____^
         7 |   gorilla
         8 |   hippopotamus
           |
@@ -1903,16 +1891,14 @@ watermelon
             .build();
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:4:1
           |
         2 |    beetle
         3 |    canary
-        4 |    dog
-          |  __^
-        5 | |  elephant
-          | | _^
+        4 | /  dog
+        5 | |/ elephant
         6 | || finch
           | ||_____^
         7 | |  gorilla
@@ -1932,16 +1918,14 @@ watermelon
             .build();
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:4:1
           |
         2 |    beetle
         3 |    canary
-        4 |    dog
-          |  __^
-        5 | |  elephant
-          | | _^
+        4 | /  dog
+        5 | |/ elephant
         6 | || finch
           | ||_____^
         7 | |  gorilla
@@ -1963,16 +1947,14 @@ watermelon
             .build();
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:5:1
           |
         3 |    canary
         4 |    dog
-        5 |    elephant
-          |  __^
-        6 | |  finch
-          | | _^
+        5 | /  elephant
+        6 | |/ finch
         7 | || gorilla
           | ||_______^
           |  |_______|
@@ -1998,19 +1980,17 @@ watermelon
         // better using only ASCII art.
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:5:1
           |
         3 |    canary
         4 |    dog
-        5 |    elephant
-          |   _^
-          |  |_|
+        5 | // elephant
         6 | || finch
           | ||_____^
-        7 |  | gorilla
-          |  |_______^
+        7 | |  gorilla
+          | |________^
         8 |    hippopotamus
         9 |    inchworm
           |
@@ -2026,14 +2006,13 @@ watermelon
             .build();
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:5:1
           |
         3 |    canary
         4 |    dog
-        5 |    elephant
-          |  __^
+        5 | /  elephant
         6 | |  finch
           | |__^___^
           |   _|
@@ -2080,14 +2059,14 @@ watermelon
             .build();
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:5:3
           |
         3 | canary
         4 | dog
         5 | elephant
-          |   ----
+          |   ^^^^
           |   |
           |   giant land mammal
           |   but afraid of mice
@@ -2153,7 +2132,7 @@ watermelon
             .build();
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
          --> animals:5:1
           |
@@ -2179,7 +2158,6 @@ watermelon
           |
         7 | gorilla
           | ------- secondary 7
-          |
         ",
         );
     }
@@ -2232,7 +2210,7 @@ watermelon
             .build();
         insta::assert_snapshot!(
             env.render(&diag),
-            @"
+            @r"
         error[stable-test-rule]: main diagnostic message
           --> animals:11:1
            |
@@ -2263,7 +2241,6 @@ watermelon
            |
          2 | banana
            | ------ secondary fruits 2
-           |
         ",
         );
     }

--- a/crates/fortitude_linter/src/diagnostics/mod.rs
+++ b/crates/fortitude_linter/src/diagnostics/mod.rs
@@ -19,8 +19,8 @@ use std::{
 use ruff_source_file::{LineColumn, SourceFile, SourceFileBuilder};
 use rustc_hash::FxHashMap;
 
+use annotate_snippets::Level as AnnotateLevel;
 use anyhow::Result;
-use ruff_annotate_snippets::Level as AnnotateLevel;
 use ruff_text_size::{Ranged, TextRange};
 use serde::Serialize;
 
@@ -1191,11 +1191,11 @@ pub enum Severity {
 }
 
 impl Severity {
-    fn to_annotate(self) -> AnnotateLevel {
+    fn to_annotate(self) -> AnnotateLevel<'static> {
         match self {
-            Severity::Info => AnnotateLevel::Info,
-            Severity::Warning => AnnotateLevel::Warning,
-            Severity::Error => AnnotateLevel::Error,
+            Severity::Info => AnnotateLevel::INFO,
+            Severity::Warning => AnnotateLevel::WARNING,
+            Severity::Error => AnnotateLevel::ERROR,
             // NOTE: Should we really collapse this to "error"?
             //
             // After collapsing this, the snapshot tests seem to reveal that we
@@ -1203,7 +1203,7 @@ impl Severity {
             // And maybe *rendering* this as just an `error` is fine. If we
             // really do need different rendering, then I think we can add a
             // `Level::Fatal`. ---AG
-            Severity::Fatal => AnnotateLevel::Error,
+            Severity::Fatal => AnnotateLevel::ERROR,
         }
     }
 
@@ -1227,13 +1227,13 @@ pub enum SubDiagnosticSeverity {
 }
 
 impl SubDiagnosticSeverity {
-    fn to_annotate(self) -> AnnotateLevel {
+    fn to_annotate(self) -> AnnotateLevel<'static> {
         match self {
-            SubDiagnosticSeverity::Help => AnnotateLevel::Help,
-            SubDiagnosticSeverity::Info => AnnotateLevel::Info,
-            SubDiagnosticSeverity::Warning => AnnotateLevel::Warning,
-            SubDiagnosticSeverity::Error => AnnotateLevel::Error,
-            SubDiagnosticSeverity::Fatal => AnnotateLevel::Error,
+            SubDiagnosticSeverity::Help => AnnotateLevel::HELP,
+            SubDiagnosticSeverity::Info => AnnotateLevel::INFO,
+            SubDiagnosticSeverity::Warning => AnnotateLevel::WARNING,
+            SubDiagnosticSeverity::Error => AnnotateLevel::ERROR,
+            SubDiagnosticSeverity::Fatal => AnnotateLevel::ERROR,
         }
     }
 }

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__exit-or-cycle-in-unlabelled-loop_C142.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__exit-or-cycle-in-unlabelled-loop_C142.f90.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 C142 'cycle' statement in unlabelled 'do' loop
-  --> ./resources/test/fixtures/correctness/C142.f90:26:5
+  --> ./resources/test/fixtures/correctness/C142.f90:27:7
    |
 24 |   label5: do i = 1, 2
 25 |     ! should warn
@@ -16,7 +17,7 @@ C142 'cycle' statement in unlabelled 'do' loop
    |
 
 C142 'exit' statement in unlabelled 'do' loop
-  --> ./resources/test/fixtures/correctness/C142.f90:48:3
+  --> ./resources/test/fixtures/correctness/C142.f90:50:5
    |
 46 |   end do label8
 47 |
@@ -29,7 +30,7 @@ C142 'exit' statement in unlabelled 'do' loop
    |
 
 C142 'exit' statement in unlabelled 'do' loop
-  --> ./resources/test/fixtures/correctness/C142.f90:54:5
+  --> ./resources/test/fixtures/correctness/C142.f90:56:7
    |
 53 |   do
 54 |     do

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__exit-or-cycle-in-unlabelled-loop_C142.f90_nested_loops_only.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__exit-or-cycle-in-unlabelled-loop_C142.f90_nested_loops_only.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 C142 'cycle' statement in unlabelled 'do' loop
-  --> ./resources/test/fixtures/correctness/C142.f90:26:5
+  --> ./resources/test/fixtures/correctness/C142.f90:27:7
    |
 24 |   label5: do i = 1, 2
 25 |     ! should warn
@@ -16,7 +17,7 @@ C142 'cycle' statement in unlabelled 'do' loop
    |
 
 C142 'exit' statement in unlabelled 'do' loop
-  --> ./resources/test/fixtures/correctness/C142.f90:54:5
+  --> ./resources/test/fixtures/correctness/C142.f90:56:7
    |
 53 |   do
 54 |     do

--- a/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__nonportable-shortcircuit-inquiry_C161.f90.snap
+++ b/crates/fortitude_linter/src/rules/correctness/snapshots/fortitude_linter__rules__correctness__tests__nonportable-shortcircuit-inquiry_C161.f90.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/fortitude_linter/src/rules/correctness/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 C161 variable inquiry `present(arg1)` and use in same logical expression
-  --> ./resources/test/fixtures/correctness/C161.f90:13:9
+  --> ./resources/test/fixtures/correctness/C161.f90:13:29
    |
 11 |     end if
 12 |
@@ -16,7 +17,7 @@ C161 variable inquiry `present(arg1)` and use in same logical expression
    |
 
 C161 variable inquiry `present(arg2)` and use in same logical expression
-  --> ./resources/test/fixtures/correctness/C161.f90:21:9
+  --> ./resources/test/fixtures/correctness/C161.f90:21:35
    |
 19 |     end if
 20 |
@@ -29,7 +30,7 @@ C161 variable inquiry `present(arg2)` and use in same logical expression
    |
 
 C161 variable inquiry `present(arg1)` and use in same logical expression
-  --> ./resources/test/fixtures/correctness/C161.f90:33:9
+  --> ./resources/test/fixtures/correctness/C161.f90:33:40
    |
 31 |     end if
 32 |
@@ -55,7 +56,7 @@ C161 variable inquiry `associated(arg1)` and use in same logical expression
    |
 
 C161 variable inquiry `associated(arg1)` and use in same logical expression
-  --> ./resources/test/fixtures/correctness/C161.f90:42:9
+  --> ./resources/test/fixtures/correctness/C161.f90:42:32
    |
 40 |     end if
 41 |
@@ -81,7 +82,7 @@ C161 variable inquiry `present(arg2)` and use in same logical expression
    |
 
 C161 variable inquiry `allocated(arg2)` and use in same logical expression
-  --> ./resources/test/fixtures/correctness/C161.f90:46:16
+  --> ./resources/test/fixtures/correctness/C161.f90:46:53
    |
 44 |     end if
 45 |
@@ -94,7 +95,7 @@ C161 variable inquiry `allocated(arg2)` and use in same logical expression
    |
 
 C161 variable inquiry `allocated(arg2)` and use in same logical expression
-  --> ./resources/test/fixtures/correctness/C161.f90:50:9
+  --> ./resources/test/fixtures/correctness/C161.f90:50:36
    |
 48 |     end if
 49 |

--- a/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__forall-statement_OB071.f90.snap
+++ b/crates/fortitude_linter/src/rules/obsolescent/snapshots/fortitude_linter__rules__obsolescent__tests__forall-statement_OB071.f90.snap
@@ -22,7 +22,6 @@ OB071 `forall` statements are obsolescent in F2018, prefer `do concurrent` inste
 8 |
 9 | FORALL(J=1:8)  PATTERN(J)%P => OBJECT(1+IEOR(J-1,2))
   | ^^^^^^
-  |
 help: Use `do concurrent` instead
 
 OB071 `forall` statements are obsolescent in F2018, prefer `do concurrent` instead

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-indentation_S105.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-indentation_S105.f90.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 S105 [*] Incorrect indentation
  --> ./resources/test/fixtures/style/S105.f90:1:1
@@ -2197,7 +2198,6 @@ S105 [*] Incorrect indentation
 164 | end subroutine labels
 165 |   end program mprog
     | ^^
-    |
 help: Replace with the correct number of spaces, 0
 162 | 20        x = 3
 163 | x = 1;20   x = 4

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-indentation_S105.f90_include_semicolons.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-indentation_S105.f90_include_semicolons.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 S105 [*] Incorrect indentation
  --> ./resources/test/fixtures/style/S105.f90:1:1
@@ -2259,7 +2260,6 @@ S105 [*] Incorrect indentation
 164 | end subroutine labels
 165 |   end program mprog
     | ^^
-    |
 help: Replace with the correct number of spaces, 0
 162 | 20        x = 3
 163 | x = 1;20   x = 4

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-indentation_S105.f90_indent_width_2.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-indentation_S105.f90_indent_width_2.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 S105 [*] Incorrect indentation
  --> ./resources/test/fixtures/style/S105.f90:1:1
@@ -1885,7 +1886,6 @@ S105 [*] Incorrect indentation
 164 | end subroutine labels
 165 |   end program mprog
     | ^^
-    |
 help: Replace with the correct number of spaces, 0
 162 | 20        x = 3
 163 | x = 1;20   x = 4

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-indentation_S105.f90_non_default_settings.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-indentation_S105.f90_non_default_settings.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/fortitude_linter/src/rules/style/mod.rs
 expression: diagnostics
+snapshot_kind: text
 ---
 S105 [*] Incorrect indentation
  --> ./resources/test/fixtures/style/S105.f90:1:1
@@ -2198,7 +2199,6 @@ S105 [*] Incorrect indentation
 164 | end subroutine labels
 165 |   end program mprog
     | ^^
-    |
 help: Replace with the correct number of spaces, 0
 162 | 20        x = 3
 163 | x = 1;20   x = 4

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-keyword-case_S233.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__incorrect-keyword-case_S233.f90.snap
@@ -1294,7 +1294,6 @@ S233 [*] Keyword 'END' should be 'end'
 50 |
 51 | END MODULE MY_MODULE
    | ^^^
-   |
 help: Change to 'end'
 48 |     END IF
 49 | END FUNCTION FACT
@@ -1312,7 +1311,6 @@ S233 [*] Keyword 'MODULE' should be 'module'
 50 |
 51 | END MODULE MY_MODULE
    |     ^^^^^^
-   |
 help: Change to 'module'
 48 |     END IF
 49 | END FUNCTION FACT
@@ -3487,7 +3485,6 @@ S233 [*] Keyword 'END' should be 'end'
 165 | STOP
 166 | END PROGRAM KEYWORD_ZOO
     | ^^^
-    |
 help: Change to 'end'
 163 | DEALLOCATE(ARR)
 164 |
@@ -3501,7 +3498,6 @@ S233 [*] Keyword 'PROGRAM' should be 'program'
 165 | STOP
 166 | END PROGRAM KEYWORD_ZOO
     |     ^^^^^^^
-    |
 help: Change to 'program'
 163 | DEALLOCATE(ARR)
 164 |

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__keywords-missing-space_S231.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__keywords-missing-space_S231.f90.snap
@@ -508,7 +508,6 @@ S231 [*] Missing space in 'endprogram'
 228 |   end function fff
 229 | endprogram p
     | ^^^^^^^^^^
-    |
 help: Replace with 'end program'
 226 |       out) :: x
 227 |     fff = x

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__keywords-missing-space_S231.f90_include_inout_goto.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__keywords-missing-space_S231.f90_include_inout_goto.snap
@@ -548,7 +548,6 @@ S231 [*] Missing space in 'endprogram'
 228 |   end function fff
 229 | endprogram p
     | ^^^^^^^^^^
-    |
 help: Replace with 'end program'
 226 |       out) :: x
 227 |     fff = x

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__missing-newline-at-end-of-file_S002.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__missing-newline-at-end-of-file_S002.f90.snap
@@ -9,7 +9,6 @@ S002 [*] missing newline at end of file
 1 | program p
 2 | end program p ! Missing newline, be careful with tools that might add one!
   |                                                                           ^
-  |
 help: Add newline at end of file
 1 | program p
   - end program p ! Missing newline, be careful with tools that might add one!

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-semicolon_S081.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__superfluous-semicolon_S081.f90.snap
@@ -176,7 +176,6 @@ S081 [*] unnecessary semicolon
 12 |   i = i + j; write (*, *) i;;
 13 | end program p;
    |              ^
-   |
 help: Remove this character
 10 |   integer :: j;
 11 |   i = 1;; j = 2;

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__too-complex_S901.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__too-complex_S901.f90.snap
@@ -117,7 +117,7 @@ S901 cyclomatic complexity of 14, exceeds maximum 5
 231 |     !! Full test example, should trigger
 232 | /   subroutine classify_orbit(semi_major, eccentricity, inclination, &
 233 | |                             period, body_mass, orbit_type, stability)
-    | |______________________________________________________________________^
+    | |_____________________________________________________________________^
 234 |       real, intent(in)               :: semi_major, eccentricity
 235 |       real, intent(in)               :: inclination, period, body_mass
     |

--- a/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unnamed-end-statement_S061.f90.snap
+++ b/crates/fortitude_linter/src/rules/style/snapshots/fortitude_linter__rules__style__tests__unnamed-end-statement_S061.f90.snap
@@ -270,7 +270,6 @@ S061 [*] end statement should be named.
 114 |   ! CATCH THIS
 115 | END MODULE
     | ^^^^^^^^^^
-    |
 help: Write as 'END MODULE MYMOD2_UPPER'.
 112 |     ! IGNORE THIS
 113 |   END FUNCTION MYFUNC2


### PR DESCRIPTION
Has a bunch of fixes and performance improvements. Very minimal impact on our diagnostic output, mostly dropping extraneous empty lines